### PR TITLE
feat(mcp): expose PubSub group in default composite scopes

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -45,6 +45,7 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   @default_package_groups ~w(
     sessions organizations projects tickets chat artifacts wiki
     personas instructions memory review assets github notifications
+    pubsub
   )
 
   @doc "The typed-confirmation phrase for disabling required core groups."


### PR DESCRIPTION
## Summary
- Adds `pubsub` to `@default_package_groups` in `backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex` so `/custom/<slug>/mcp` composite scopes expose the PubSub domain tools.

## Why
PubSub.* tools (PubSub.Publish/Follow/Unfollow/Ack/FetchChannel/FetchAll/Overview, server `tobor_pubsub`) have been deployed since 06-27 (af6f1ac5e, Stream C) and are routed at `pubsub.tobor.locker/mcp`, but were never added to the default package groups — so no composite scope exposed them; they were live-only at the subdomain endpoint.

## Self-heal, no migration
`heal_default_package/1` + `maybe_put_groups_refresh/2` union-merge the missing group into the global `tobor` template and any scope cloned from it on the next `get_default_package`/`ensure_org_default`/`ensure_account_default` call — existing org scopes self-heal on deploy with no migration.

## Verification
- `mix compile` green; no warnings in the edited file (`--warnings-as-errors` fails only on pre-existing warnings in unrelated github/projects tool files).
- Live subdomain smoke green: `initialize`/`tools/list`/`Overview` against `pubsub.tobor.locker/mcp`; `watch.sh --once` exit 0.

Co-Authored-By: Loom <loom@therobotlives.com>