### PR TITLE
feat(backend): ACL/group library — ERP-ref permission primitives (F1 acl-core)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ backend/_build/
 backend/deps/
 frontend/node_modules/
 frontend/.next/
+*_crash.dump

--- a/backend/db/changelog/081-acl-core.yaml
+++ b/backend/db/changelog/081-acl-core.yaml
@@ -1,0 +1,80 @@
+databaseChangeLog:
+  # ── ACL / group library (tobor.locker overhaul F1) ───────────────────────
+  # Reusable permission primitives on Noizu ERP references ({:ref, Type, id}
+  # records stored as {"type": ..., "id": ...} jsonb) so grants bind to ANY
+  # arbitrary entity. Deny-wins resolution in NoizuPromptLingua.Acl.
+
+  - changeSet:
+      id: 081-create-table-acl-groups
+      author: loom
+      changes:
+        - sql:
+            sql: |
+              CREATE TABLE acl_groups (
+                id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                name varchar(255) NOT NULL,
+                description text,
+                ref jsonb,
+                status varchar(16) NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'archived')),
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                inserted_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now()
+              );
+              CREATE UNIQUE INDEX idx_acl_groups_name ON acl_groups (name);
+              CREATE INDEX idx_acl_groups_ref ON acl_groups ((ref->>'type'), (ref->>'id'));
+      rollback:
+        - sql:
+            sql: DROP TABLE IF EXISTS acl_groups;
+
+  - changeSet:
+      id: 081-create-table-acl-group-members
+      author: loom
+      changes:
+        - sql:
+            sql: |
+              CREATE TABLE acl_group_members (
+                id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                group_id uuid NOT NULL REFERENCES acl_groups(id) ON DELETE CASCADE,
+                member_ref jsonb NOT NULL,
+                expires_at timestamptz,
+                inserted_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT uq_acl_group_members_group_member UNIQUE (group_id, member_ref)
+              );
+              CREATE INDEX idx_acl_group_members_group ON acl_group_members (group_id);
+              CREATE INDEX idx_acl_group_members_member
+                ON acl_group_members ((member_ref->>'type'), (member_ref->>'id'));
+      rollback:
+        - sql:
+            sql: DROP TABLE IF EXISTS acl_group_members;
+
+  - changeSet:
+      id: 081-create-table-acl-rules
+      author: loom
+      changes:
+        - sql:
+            sql: |
+              CREATE TABLE acl_rules (
+                id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                subject_ref jsonb NOT NULL,
+                resource_ref jsonb NOT NULL,
+                action varchar(255) NOT NULL,
+                effect varchar(16) NOT NULL
+                  CHECK (effect IN ('allow', 'deny')),
+                scope varchar(255),
+                priority integer NOT NULL DEFAULT 0,
+                status varchar(16) NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'archived')),
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                inserted_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now()
+              );
+              CREATE INDEX idx_acl_rules_subject
+                ON acl_rules ((subject_ref->>'type'), (subject_ref->>'id'));
+              CREATE INDEX idx_acl_rules_resource
+                ON acl_rules ((resource_ref->>'type'), (resource_ref->>'id'));
+              CREATE INDEX idx_acl_rules_action ON acl_rules (action);
+      rollback:
+        - sql:
+            sql: DROP TABLE IF EXISTS acl_rules;

--- a/backend/db/changelog/db.changelog-master.yaml
+++ b/backend/db/changelog/db.changelog-master.yaml
@@ -244,3 +244,6 @@ databaseChangeLog:
   - include:
       file: 080-mcp-key-toolsets.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 081-acl-core.yaml
+      relativeToChangelogFile: true

--- a/backend/lib/noizu_prompt_lingua/acl.ex
+++ b/backend/lib/noizu_prompt_lingua/acl.ex
@@ -1,0 +1,299 @@
+defmodule NoizuPromptLingua.Acl do
+  @moduledoc """
+  ACL/group library (Liquibase 081) — reusable permission primitives built on
+  Noizu ERP references (`{:ref, Type, id}` records, JSONB persisted via
+  `NoizuPromptLingua.Acl.ERPRef`), so grants attach to ANY arbitrary entity
+  (users, personas, api keys, orgs, projects, wikis…) without schema changes.
+
+  Layout:
+
+    * `acl_groups` — named groups, optionally bound to an entity via `ref`.
+    * `acl_group_members` — entity refs in groups (incl. nested groups).
+    * `acl_rules` — subject_ref grant/deny `action` on resource_ref, optional
+      `scope` tag + `priority`.
+
+  Resolution: `resolve/4` expands the subject's groups transitively
+  (cycle-guarded), fetches applicable rules, and delegates the decision to the
+  pure `NoizuPromptLingua.Acl.Resolver` (deny-wins, no-match default deny).
+
+      Acl.allowed?({:ref, User, uid}, "wiki.read", {:ref, Wiki, wid})
+  """
+
+  # Scoped import: a bare `import Ecto.Query` would pull in `Ecto.Query.update/3`,
+  # whose macro expansion shadows this module's `update/3` (see MCPCustomScopes).
+  import Ecto.Query, only: [from: 2, dynamic: 1, dynamic: 2]
+
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.Acl.Group
+  alias NoizuPromptLingua.Schema.Acl.GroupMember
+  alias NoizuPromptLingua.Schema.Acl.Rule
+  alias NoizuPromptLingua.Acl.Resolver
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  @action_wildcard Rule.action_wildcard()
+  @max_group_depth 16
+
+  # ──────────────────────────────────────────────────────────────────
+  # Resolution
+  # ──────────────────────────────────────────────────────────────────
+
+  @doc """
+  Effective permission verdict for `subject_ref` performing `action` on
+  `resource_ref`.
+
+  Options: `scope` (nil = global rules only apply… see Resolver), `at`
+  (DateTime for membership expiry, default now), `default` (`:deny`/`:allow`,
+  default `:deny`).
+
+  Returns `{:allow, rule | :default}` / `{:deny, rule | :default}`.
+  """
+  def resolve(subject_ref, action, resource_ref, opts \\ []) do
+    subjects = subject_candidates(subject_ref, opts)
+    rules = applicable_rules(subjects, action, resource_ref, Keyword.get(opts, :scope))
+    Resolver.evaluate(rules, subjects, action, resource_ref, opts)
+  end
+
+  @doc "Boolean convenience over `resolve/4`."
+  def allowed?(subject_ref, action, resource_ref, opts \\ []) do
+    case resolve(subject_ref, action, resource_ref, opts) do
+      {:allow, _} -> true
+      {:deny, _} -> false
+    end
+  end
+
+  @doc "Detailed verdict — see `NoizuPromptLingua.Acl.Resolver.explain/5`."
+  def explain(subject_ref, action, resource_ref, opts \\ []) do
+    subjects = subject_candidates(subject_ref, opts)
+    rules = applicable_rules(subjects, action, resource_ref, Keyword.get(opts, :scope))
+    Resolver.explain(rules, subjects, action, resource_ref, opts)
+  end
+
+  @doc """
+  The subject itself plus every group ref it reaches through
+  `acl_group_members` — nested groups expanded transitively (BFS, cycle
+  guard, depth-capped). Non-expired memberships of active groups only.
+  """
+  def subject_candidates(subject_ref, opts \\ []) do
+    at = Keyword.get(opts, :at, DateTime.utc_now())
+
+    frontier = [subject_ref]
+    visited = MapSet.new([normalize_ref(subject_ref)])
+
+    do_expand(frontier, visited, at, [subject_ref])
+  end
+
+  defp do_expand([], _visited, _at, acc), do: acc
+
+  defp do_expand(frontier, visited, at, acc) do
+    next =
+      frontier
+      |> Enum.flat_map(&direct_group_refs(&1, at))
+      |> Enum.uniq()
+      |> Enum.reject(&MapSet.member?(visited, normalize_ref(&1)))
+
+    visited = MapSet.union(visited, MapSet.new(Enum.map(next, &normalize_ref/1)))
+
+    if map_size(visited) > @max_group_depth do
+      # Cycle / runaway graph guard — stop expanding, return what we have.
+      acc
+    else
+      do_expand(next, visited, at, acc ++ next)
+    end
+  end
+
+  defp direct_group_refs(candidate_ref, at) do
+    from(g in Group,
+      join: m in GroupMember,
+      on: m.group_id == g.id,
+      where: g.status == "active",
+      where: m.member_ref == ^candidate_ref,
+      where: is_nil(m.expires_at) or m.expires_at > ^at,
+      select: g.ref
+    )
+    |> Repo.all()
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp applicable_rules(subjects, action, resource_ref, scope) do
+    subject_dyn = subject_dyn(subjects)
+
+    resource_dyn =
+      dynamic(
+        [r],
+        r.resource_ref == ^(normalize_ref(resource_ref) || resource_ref) or
+          fragment("?->>'type' = ? and ?->>'id' = 'any'", r.resource_ref, ^kind_str(resource_ref), r.resource_ref) or
+          fragment("?->>'type' = 'any' and ?->>'id' = 'any'", r.resource_ref, r.resource_ref)
+      )
+
+    scope_dyn =
+      if scope do
+        dynamic([r], is_nil(r.scope) or r.scope == ^scope)
+      else
+        dynamic([r], is_nil(r.scope))
+      end
+
+    from(r in Rule,
+      where: r.status == "active",
+      where: r.action in ^[action, @action_wildcard],
+      where: ^subject_dyn,
+      where: ^resource_dyn,
+      where: ^scope_dyn
+    )
+    |> Repo.all()
+  end
+
+  defp subject_dyn([]), do: dynamic(false)
+
+  defp subject_dyn(subjects) do
+    Enum.reduce(subjects, dynamic(false), fn subject, acc ->
+      dynamic([r], ^acc or r.subject_ref == ^subject)
+    end)
+  end
+
+  defp kind_str(ref) do
+    case normalize_ref(ref) do
+      R.ref(module: :any) -> "any"
+      R.ref(module: m, id: _) -> NoizuPromptLingua.Acl.ERPRef.kind_to_string(m)
+      _ -> "any"
+    end
+  end
+
+  defp normalize_ref(ref) do
+    case NoizuPromptLingua.Acl.ERPRef.cast(ref) do
+      {:ok, R.ref() = canonical} -> canonical
+      _ -> nil
+    end
+  end
+
+  # ──────────────────────────────────────────────────────────────────
+  # Groups
+  # ──────────────────────────────────────────────────────────────────
+
+  @doc "Create an ACL group. `:ref` binds it to an arbitrary entity (optional)."
+  def create_group(attrs), do: %Group{} |> Group.changeset(attrs) |> Repo.insert()
+
+  def update_group(%Group{} = group, attrs),
+    do: group |> Group.changeset(attrs) |> Repo.update()
+
+  def update_group(id, attrs) when is_binary(id) do
+    case get_group(id) do
+      nil -> {:error, :not_found}
+      group -> update_group(group, attrs)
+    end
+  end
+
+  @doc "Archive (soft-disable) a group — archived groups stop resolving."
+  def archive_group(%Group{} = group), do: update_group(group, %{status: "archived"})
+  def archive_group(id) when is_binary(id), do: update_group(id, %{status: "archived"})
+
+  def get_group(id) when is_binary(id), do: Repo.get(Group, id)
+  def get_group(_), do: nil
+
+  def get_group_by_name(name) when is_binary(name),
+    do: Repo.one(from(g in Group, where: g.name == ^name))
+
+  # ──────────────────────────────────────────────────────────────────
+  # Membership
+  # ──────────────────────────────────────────────────────────────────
+
+  @doc """
+  Add a member (any ERP ref) to a group. Opts: `:expires_at` (DateTime —
+  membership stops resolving after it).
+
+  Groups may be identified by struct, uuid, or name.
+  """
+  def add_member(group, member_ref, opts \\ []) do
+    case resolve_group(group) do
+      nil ->
+        {:error, :not_found}
+
+      group ->
+        attrs =
+          %{group_id: group.id, member_ref: member_ref}
+          |> maybe_put(:expires_at, Keyword.get(opts, :expires_at))
+
+        %GroupMember{} |> GroupMember.changeset(attrs) |> Repo.insert()
+    end
+  end
+
+  @doc "Remove a member from a group."
+  def remove_member(group, member_ref) do
+    case resolve_group(group) do
+      nil ->
+        {:error, :not_found}
+
+      group ->
+        {count, _} =
+          from(m in GroupMember, where: m.group_id == ^group.id and m.member_ref == ^member_ref)
+          |> Repo.delete_all()
+
+        {:ok, count}
+    end
+  end
+
+  @doc "All membership rows of a group."
+  def members(group) do
+    case resolve_group(group) do
+      nil ->
+        []
+
+      group ->
+        from(m in GroupMember, where: m.group_id == ^group.id, order_by: m.inserted_at)
+        |> Repo.all()
+    end
+  end
+
+  @doc "Active groups a member (any ERP ref) belongs to directly."
+  def groups_for(member_ref, opts \\ []) do
+    at = Keyword.get(opts, :at, DateTime.utc_now())
+
+    from(g in Group,
+      join: m in GroupMember,
+      on: m.group_id == g.id,
+      where: g.status == "active",
+      where: m.member_ref == ^member_ref,
+      where: is_nil(m.expires_at) or m.expires_at > ^at
+    )
+    |> Repo.all()
+  end
+
+  defp resolve_group(%Group{} = group), do: group
+  defp resolve_group(id_or_name) when is_binary(id_or_name),
+    do: get_group(id_or_name) || get_group_by_name(id_or_name)
+
+  defp resolve_group(_), do: nil
+
+  # ──────────────────────────────────────────────────────────────────
+  # Rules
+  # ──────────────────────────────────────────────────────────────────
+
+  @doc """
+  Create a rule. Required: `subject_ref`, `resource_ref`, `action`, `effect`
+  (`allow`/`deny`). Optional: `scope`, `priority`, `metadata`.
+  """
+  def create_rule(attrs), do: %Rule{} |> Rule.changeset(attrs) |> Repo.insert()
+
+  def update_rule(%Rule{} = rule, attrs),
+    do: rule |> Rule.changeset(attrs) |> Repo.update()
+
+  def update_rule(id, attrs) when is_binary(id) do
+    case get_rule(id) do
+      nil -> {:error, :not_found}
+      rule -> update_rule(rule, attrs)
+    end
+  end
+
+  @doc "Archive (soft-disable) a rule."
+  def archive_rule(%Rule{} = rule), do: update_rule(rule, %{status: "archived"})
+  def archive_rule(id) when is_binary(id), do: update_rule(id, %{status: "archived"})
+
+  def get_rule(id) when is_binary(id), do: Repo.get(Rule, id)
+  def get_rule(_), do: nil
+
+  # ──────────────────────────────────────────────────────────────────
+
+  defp maybe_put(attrs, _key, nil), do: attrs
+  defp maybe_put(attrs, key, value), do: Map.put(attrs, key, value)
+end

--- a/backend/lib/noizu_prompt_lingua/acl/erp_ref.ex
+++ b/backend/lib/noizu_prompt_lingua/acl/erp_ref.ex
@@ -1,0 +1,129 @@
+defmodule NoizuPromptLingua.Acl.ERPRef do
+  @moduledoc """
+  Ecto custom type for polymorphic Noizu ERP references — the
+  `{:ref, Type, id}` record from `Noizu.EntityReference.Records` — persisted as
+  a JSONB object `{"type": "<Type>", "id": "<id>"}`.
+
+  Used for the ACL subject/resource bindings (`acl_rules.subject_ref`,
+  `acl_rules.resource_ref`, `acl_groups.ref`, `acl_group_members.member_ref`)
+  so a permission can attach to ANY arbitrary entity (user, persona, api key,
+  organization, project, another group…) without schema changes.
+
+  Conventions:
+
+    * `Type` is an entity module atom (`NoizuPromptLingua.Users.User`), stored
+      without the `Elixir.` prefix. On load it round-trips via
+      `String.to_existing_atom/1`, so only modules actually present in the
+      running node can be restored (which is the only interesting case).
+    * The kind atom `:any` is a wildcard (`{"type": "any"}`) — used by rules to
+      grant/deny an entire entity kind or, as `{:ref, :any, :any}`, globally.
+    * ids are stored as strings and loaded back as strings; `:any` ids load
+      back as the `:any` atom wildcard.
+  """
+
+  use Ecto.Type
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  @wildcard :any
+
+  @doc "Underlying database column type (jsonb)."
+  def type, do: :map
+
+  # ──────────────────────────────────────────────────────────────────
+  # cast — in-memory values into a canonical ref record
+  # ──────────────────────────────────────────────────────────────────
+
+  def cast(nil), do: {:ok, nil}
+
+  # Already a ref record (bare tuple form included).
+  def cast(R.ref(module: m, id: i)) when (is_atom(m) or is_binary(m)) and not is_nil(i) do
+    {:ok, R.ref(module: normalize_kind(m), id: i)}
+  end
+
+  # Entity structs / wrapped refs — normalize through the ERP protocol.
+  def cast(value) when is_struct(value) do
+    case Noizu.EntityReference.Protocol.ref(value) do
+      {:ok, R.ref() = ref} -> cast(ref)
+      _ -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  # ──────────────────────────────────────────────────────────────────
+  # dump — ref record → jsonb map
+  # ──────────────────────────────────────────────────────────────────
+
+  def dump(nil), do: {:ok, nil}
+
+  def dump(R.ref(module: m, id: i)) do
+    {:ok, %{"type" => kind_to_string(m), "id" => to_string(i)}}
+  end
+
+  def dump(_), do: :error
+
+  # ──────────────────────────────────────────────────────────────────
+  # load — jsonb map → ref record
+  # ──────────────────────────────────────────────────────────────────
+
+  def load(nil), do: {:ok, nil}
+
+  def load(%{"type" => t, "id" => i}) do
+    with {:ok, kind} <- string_to_kind(t) do
+      {:ok, R.ref(module: kind, id: string_to_id(i))}
+    end
+  end
+
+  def load(_), do: :error
+
+  # ──────────────────────────────────────────────────────────────────
+  # Public helpers (SQL fragments + pure comparisons)
+  # ──────────────────────────────────────────────────────────────────
+
+  @doc "Canonical jsonb map for a ref — used for equality comparisons in queries."
+  def dump_map(ref) do
+    case cast(ref) do
+      {:ok, R.ref() = canonical} ->
+        {:ok, canonical} = dump(canonical)
+        canonical
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc "The stored type string for a kind/module (wildcard aware)."
+  def kind_to_string(@wildcard), do: "any"
+  def kind_to_string(m) when is_atom(m), do: m |> Atom.to_string() |> String.trim_leading("Elixir.")
+  def kind_to_string(m) when is_binary(m), do: m
+
+  @doc """
+  Restore a kind/module from its stored type string. Module strings must map
+  to an already-loaded module atom (to_existing_atom keeps the atom table safe);
+  `\"any\"` restores the `:any` wildcard.
+  """
+  def string_to_kind("any"), do: {:ok, @wildcard}
+
+  def string_to_kind(t) when is_binary(t) do
+    try do
+      {:ok, String.to_existing_atom("Elixir." <> t)}
+    rescue
+      ArgumentError ->
+        try do
+          {:ok, String.to_existing_atom(t)}
+        rescue
+          ArgumentError -> :error
+        end
+    end
+  end
+
+  def string_to_kind(_), do: :error
+
+  defp string_to_id("any"), do: @wildcard
+  defp string_to_id(i), do: i
+
+  defp normalize_kind(@wildcard), do: @wildcard
+  defp normalize_kind(m) when is_atom(m), do: m
+  defp normalize_kind(m) when is_binary(m), do: m
+end

--- a/backend/lib/noizu_prompt_lingua/acl/resolver.ex
+++ b/backend/lib/noizu_prompt_lingua/acl/resolver.ex
@@ -1,0 +1,183 @@
+defmodule NoizuPromptLingua.Acl.Resolver do
+  @moduledoc """
+  Pure effective-permission resolver for the ACL library — no Repo, no HTTP,
+  no process state, fully unit-testable.
+
+  Given the applicable rules (already fetched), the subject candidate refs
+  (subject + expanded group refs), the action and the resource ref, decide
+  allow/deny:
+
+  1. Keep `active` rules only.
+  2. Scope: a rule with a `scope` applies only when the requested scope equals
+     it; `nil`-scoped rules apply everywhere.
+  3. Subject: rule `subject_ref` must equal one of the candidate refs.
+  4. Action: rule action must equal the requested action or be the `"*"`
+     wildcard.
+  5. Resource: exact ref equality, kind wildcard (`{:ref, Type, :any}`), or
+     global wildcard (`{:ref, :any, :any}`).
+  6. Precedence: **deny wins** — any matching deny beats every matching allow,
+     regardless of priority. Priority only ranks the reported decision among
+     the winning effect's matches.
+  7. No match → the configured default (`:deny` unless `default: :allow`).
+  """
+
+  alias NoizuPromptLingua.Acl.ERPRef
+  alias NoizuPromptLingua.Schema.Acl.Rule
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  @wildcard :any
+  @action_wildcard Rule.action_wildcard()
+
+  @doc """
+  Resolve to `{:allow, rule | :default}` / `{:deny, rule | :default}`.
+  `rules` may be `Rule` structs or plain maps with the rule fields.
+  """
+  def evaluate(rules, subjects, action, resource_ref, opts \\ []) do
+    default = Keyword.get(opts, :default, :deny)
+    scope = Keyword.get(opts, :scope)
+
+    subjects_n = normalize_all(subjects)
+    resource = normalize(resource_ref)
+
+    matched =
+      rules
+      |> Enum.filter(&active?/1)
+      |> Enum.filter(&scope_match?(&1, scope))
+      |> Enum.filter(&subject_match?(&1, subjects_n))
+      |> Enum.filter(&action_match?(&1, action))
+      |> Enum.filter(&(&1 |> resource_match?(resource) == :ok))
+      |> Enum.map(&normalize_rule/1)
+
+    denies = Enum.filter(matched, &(&1.effect == "deny"))
+    allows = Enum.filter(matched, &(&1.effect == "allow"))
+
+    cond do
+      denies != [] -> {:deny, top(denies)}
+      allows != [] -> {:allow, top(allows)}
+      default == :allow -> {:allow, :default}
+      true -> {:deny, :default}
+    end
+  end
+
+  @doc "Boolean convenience over `evaluate/5`."
+  def allowed?(rules, subjects, action, resource_ref, opts \\ []) do
+    case evaluate(rules, subjects, action, resource_ref, opts) do
+      {:allow, _} -> true
+      {:deny, _} -> false
+    end
+  end
+
+  @doc """
+  Full explanation:
+  `%{verdict: :allow | :deny, reason: rule | :default,
+     matched: %{allow: [...], deny: [...], default: :deny | :allow}}`.
+  """
+  def explain(rules, subjects, action, resource_ref, opts \\ []) do
+    matched = match_detail(rules, subjects, action, resource_ref, opts)
+
+    verdict =
+      cond do
+        matched.deny != [] -> :deny
+        matched.allow != [] -> :allow
+        matched.default == :allow -> :allow
+        true -> :deny
+      end
+
+    reason =
+      cond do
+        verdict == :deny and matched.deny != [] -> top(matched.deny)
+        verdict == :allow and matched.allow != [] -> top(matched.allow)
+        true -> :default
+      end
+
+    %{verdict: verdict, reason: reason, matched: matched}
+  end
+
+  # ── filters ────────────────────────────────────────────────────────
+
+  defp active?(rule), do: Map.get(rule, :status, "active") in [nil, "active"]
+
+  # A nil-scope rule applies everywhere; a scoped rule only when the request
+  # names that scope. A nil-scope REQUEST therefore sees global rules only.
+  defp scope_match?(%{scope: nil}, _requested), do: true
+  defp scope_match?(%{scope: s}, requested), do: not is_nil(requested) and s == requested
+
+  defp subject_match?(_rule, [] = _subjects), do: false
+
+  defp subject_match?(%{subject_ref: sr}, subjects) do
+    case normalize(sr) do
+      nil -> false
+      s -> s in subjects
+    end
+  end
+
+  defp action_match?(%{action: a}, action) when is_binary(a), do: a == action or a == @action_wildcard
+  defp action_match?(_, _), do: false
+
+  @doc """
+  Resource match verdict for one rule: `:ok` (rule applies) or `:skip`.
+  Wildcards: `{:ref, :any, :any}` global; `{:ref, Type, :any}` kind-wide.
+  """
+  def resource_match?(%{resource_ref: rr}, resource) do
+    case normalize(rr) do
+      R.ref(module: @wildcard, id: @wildcard) ->
+        :ok
+
+      R.ref(module: kind, id: @wildcard) ->
+        case resource do
+          R.ref(module: ^kind, id: _) -> :ok
+          _ -> :skip
+        end
+
+      exact ->
+        if exact == resource, do: :ok, else: :skip
+    end
+  end
+
+  def resource_match?(_, _), do: :skip
+
+  # ── helpers ────────────────────────────────────────────────────────
+
+  defp match_detail(rules, subjects, action, resource_ref, opts) do
+    default = Keyword.get(opts, :default, :deny)
+    scope = Keyword.get(opts, :scope)
+    subjects_n = normalize_all(subjects)
+    resource = normalize(resource_ref)
+
+    matched =
+      rules
+      |> Enum.filter(&active?/1)
+      |> Enum.filter(&scope_match?(&1, scope))
+      |> Enum.filter(&subject_match?(&1, subjects_n))
+      |> Enum.filter(&action_match?(&1, action))
+      |> Enum.filter(&(&1 |> resource_match?(resource) == :ok))
+      |> Enum.map(&normalize_rule/1)
+
+    %{
+      allow: Enum.filter(matched, &(&1.effect == "allow")),
+      deny: Enum.filter(matched, &(&1.effect == "deny")),
+      default: default
+    }
+  end
+
+  defp top(rules), do: Enum.max_by(rules, &Map.get(&1, :priority, 0))
+
+  defp normalize_rule(%{} = rule) do
+    rule
+    |> Map.put(:subject_ref, normalize(Map.get(rule, :subject_ref)))
+    |> Map.put(:resource_ref, normalize(Map.get(rule, :resource_ref)))
+  end
+
+  defp normalize_all(refs), do: Enum.reject(Enum.map(refs, &normalize/1), &is_nil/1)
+
+  defp normalize(nil), do: nil
+
+  defp normalize(ref) do
+    case ERPRef.cast(ref) do
+      {:ok, R.ref() = canonical} -> canonical
+      _ -> nil
+    end
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/schema/acl/group.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/acl/group.ex
@@ -1,0 +1,37 @@
+defmodule NoizuPromptLingua.Schema.Acl.Group do
+  @moduledoc """
+  An ACL permission group (Liquibase 081). A group MAY be bound to any
+  arbitrary entity via its `ref` (an ERP `{:ref, Type, id}` record, JSONB) —
+  org groups bound to an Organization ref, project groups, ad-hoc global
+  groups (`ref: nil`). Members of any shape attach via
+  `NoizuPromptLingua.Schema.Acl.GroupMember`; rules target groups by their ref
+  via `NoizuPromptLingua.Schema.Acl.Rule`.
+
+  Resolution lives in `NoizuPromptLingua.Acl` / `NoizuPromptLingua.Acl.Resolver`.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias NoizuPromptLingua.Acl.ERPRef
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+  schema "acl_groups" do
+    field :name, :string
+    field :description, :string
+    field :ref, ERPRef
+    field :status, :string, default: "active"
+    field :metadata, :map, default: %{}
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @statuses ~w(active archived)
+
+  def changeset(group, attrs) do
+    group
+    |> cast(attrs, [:name, :description, :ref, :status, :metadata])
+    |> validate_required([:name])
+    |> validate_inclusion(:status, @statuses)
+    |> unique_constraint(:name, name: :idx_acl_groups_name)
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/schema/acl/group_member.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/acl/group_member.ex
@@ -1,0 +1,30 @@
+defmodule NoizuPromptLingua.Schema.Acl.GroupMember do
+  @moduledoc """
+  Membership of an arbitrary entity (ERP `{:ref, Type, id}` record, JSONB) in
+  an ACL group (Liquibase 081). Members may be users, personas, api keys — or
+  the ref of another ACL group, which is how nested groups are expressed (the
+  resolver expands them transitively with a cycle guard).
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias NoizuPromptLingua.Acl.ERPRef
+  alias NoizuPromptLingua.Schema.Acl.Group
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+  schema "acl_group_members" do
+    belongs_to :group, Group, type: Ecto.UUID
+    field :member_ref, ERPRef
+    field :expires_at, :utc_datetime_usec
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(member, attrs) do
+    member
+    |> cast(attrs, [:group_id, :member_ref, :expires_at])
+    |> validate_required([:group_id, :member_ref])
+    |> foreign_key_constraint(:group_id)
+    |> unique_constraint(:member_ref, name: :uq_acl_group_members_group_member)
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/schema/acl/rule.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/acl/rule.ex
@@ -1,0 +1,54 @@
+defmodule NoizuPromptLingua.Schema.Acl.Rule do
+  @moduledoc """
+  An ACL rule (Liquibase 081): `subject_ref` (a user, persona, api key, or a
+  group's ref) grants or denies `action` on `resource_ref`. Subject and
+  resource are ERP `{:ref, Type, id}` records (JSONB via
+  `NoizuPromptLingua.Acl.ERPRef`) so rules attach to any arbitrary entity.
+
+  Wildcards:
+
+    * `action: "*"` — matches every action.
+    * `resource_ref: {:ref, Type, :any}` — matches every resource of that kind.
+    * `resource_ref: {:ref, :any, :any}` — global rule, matches all resources.
+
+  `scope` is an opaque tag (e.g. `\"mcp\"`, `\"wiki\"`); a rule with a scope only
+  applies to resolution requests for that scope, `nil` applies everywhere.
+
+  Evaluation semantics (deny-wins) live in `NoizuPromptLingua.Acl.Resolver`.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias NoizuPromptLingua.Acl.ERPRef
+
+  @primary_key {:id, Ecto.UUID, autogenerate: true}
+  schema "acl_rules" do
+    field :subject_ref, ERPRef
+    field :resource_ref, ERPRef
+    field :action, :string
+    field :effect, :string
+    field :scope, :string
+    field :priority, :integer, default: 0
+    field :status, :string, default: "active"
+    field :metadata, :map, default: %{}
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @effects ~w(allow deny)
+  @statuses ~w(active archived)
+  @action_wildcard "*"
+
+  def changeset(rule, attrs) do
+    rule
+    |> cast(attrs, [:subject_ref, :resource_ref, :action, :effect, :scope, :priority, :status, :metadata])
+    |> validate_required([:subject_ref, :resource_ref, :action, :effect])
+    |> validate_inclusion(:effect, @effects)
+    |> validate_inclusion(:status, @statuses)
+    |> validate_length(:action, min: 1, max: 255)
+    |> validate_length(:scope, max: 255)
+  end
+
+  @doc "The action wildcard value."
+  def action_wildcard, do: @action_wildcard
+end

--- a/backend/priv/repo/migrations/20260901000000_acl_core.exs
+++ b/backend/priv/repo/migrations/20260901000000_acl_core.exs
@@ -1,0 +1,83 @@
+defmodule NoizuPromptLingua.Repo.Migrations.AclCore do
+  use Ecto.Migration
+
+  @moduledoc """
+  ACL/group library tables (Liquibase 081-acl-core twin). Prod Helm has
+  Liquibase gated off, so Ecto.Migrator applies these. IF NOT EXISTS keeps this
+  safe if Liquibase later runs 081 on the same database.
+  """
+
+  def up do
+    execute("""
+    CREATE TABLE IF NOT EXISTS acl_groups (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      name varchar(255) NOT NULL,
+      description text,
+      ref jsonb,
+      status varchar(16) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'archived')),
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      inserted_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+    """)
+
+    execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_acl_groups_name ON acl_groups (name)")
+    execute("CREATE INDEX IF NOT EXISTS idx_acl_groups_ref ON acl_groups ((ref->>'type'), (ref->>'id'))")
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS acl_group_members (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      group_id uuid NOT NULL REFERENCES acl_groups(id) ON DELETE CASCADE,
+      member_ref jsonb NOT NULL,
+      expires_at timestamptz,
+      inserted_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT uq_acl_group_members_group_member UNIQUE (group_id, member_ref)
+    )
+    """)
+
+    execute("CREATE INDEX IF NOT EXISTS idx_acl_group_members_group ON acl_group_members (group_id)")
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_acl_group_members_member
+      ON acl_group_members ((member_ref->>'type'), (member_ref->>'id'))
+    """)
+
+    execute("""
+    CREATE TABLE IF NOT EXISTS acl_rules (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      subject_ref jsonb NOT NULL,
+      resource_ref jsonb NOT NULL,
+      action varchar(255) NOT NULL,
+      effect varchar(16) NOT NULL
+        CHECK (effect IN ('allow', 'deny')),
+      scope varchar(255),
+      priority integer NOT NULL DEFAULT 0,
+      status varchar(16) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'archived')),
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      inserted_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_acl_rules_subject
+      ON acl_rules ((subject_ref->>'type'), (subject_ref->>'id'))
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_acl_rules_resource
+      ON acl_rules ((resource_ref->>'type'), (resource_ref->>'id'))
+    """)
+
+    execute("CREATE INDEX IF NOT EXISTS idx_acl_rules_action ON acl_rules (action)")
+  end
+
+  def down do
+    execute("DROP TABLE IF EXISTS acl_rules")
+    execute("DROP TABLE IF EXISTS acl_group_members")
+    execute("DROP TABLE IF EXISTS acl_groups")
+  end
+end

--- a/backend/test/noizu_prompt_lingua/acl/resolver_test.exs
+++ b/backend/test/noizu_prompt_lingua/acl/resolver_test.exs
@@ -1,0 +1,214 @@
+defmodule NoizuPromptLingua.Acl.ResolverTest do
+  @moduledoc """
+  Pure (no-DB) tests for the ACL resolver semantics and the ERPRef Ecto type.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias NoizuPromptLingua.Acl.ERPRef
+  alias NoizuPromptLingua.Acl.Resolver
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  @uid Ecto.UUID.generate()
+  @wid Ecto.UUID.generate()
+  @other_wid Ecto.UUID.generate()
+
+  @user R.ref(module: NoizuPromptLingua.Users.User, id: @uid)
+  @wiki R.ref(module: NoizuPromptLingua.Projects.Project, id: @wid)
+  @other_wiki R.ref(module: NoizuPromptLingua.Projects.Project, id: @other_wid)
+  @group_a R.ref(module: NoizuPromptLingua.Acl.Group, id: Ecto.UUID.generate())
+  @group_b R.ref(module: NoizuPromptLingua.Acl.Group, id: Ecto.UUID.generate())
+
+  defp rule(overrides) do
+    Map.merge(
+      %{
+        subject_ref: @user,
+        resource_ref: @wiki,
+        action: "project.read",
+        effect: "allow",
+        scope: nil,
+        priority: 0,
+        status: "active"
+      },
+      Map.new(overrides, fn {k, v} -> {k, v} end)
+    )
+  end
+
+  # ── ERPRef type ─────────────────────────────────────────────────────
+
+  describe "ERPRef type" do
+    test "casts a ref record" do
+      assert {:ok, @user} = ERPRef.cast(@user)
+    end
+
+    test "casts an entity struct through the ERP protocol" do
+      assert {:ok, ref} = ERPRef.cast(%NoizuPromptLingua.Users.User{id: @uid})
+      assert ref == R.ref(module: NoizuPromptLingua.Users.User, id: @uid)
+    end
+
+    test "rejects junk" do
+      assert :error = ERPRef.cast("not-a-ref")
+      assert :error = ERPRef.cast(42)
+      assert {:ok, nil} = ERPRef.cast(nil)
+    end
+
+    test "dump/load round-trips" do
+      {:ok, dumped} = ERPRef.dump(@user)
+      assert dumped == %{"type" => "NoizuPromptLingua.Users.User", "id" => @uid}
+      assert {:ok, @user} = ERPRef.load(dumped)
+    end
+
+    test "wildcard kind and id round-trip" do
+      global = R.ref(module: :any, id: :any)
+      {:ok, dumped} = ERPRef.dump(global)
+      assert dumped == %{"type" => "any", "id" => "any"}
+      assert {:ok, ^global} = ERPRef.load(dumped)
+
+      kind_wild = R.ref(module: NoizuPromptLingua.Projects.Project, id: :any)
+      {:ok, dumped} = ERPRef.dump(kind_wild)
+      assert {:ok, ^kind_wild} = ERPRef.load(dumped)
+    end
+
+    test "unknown module strings do not load" do
+      assert :error = ERPRef.load(%{"type" => "Never.Loaded.Module", "id" => "x"})
+    end
+  end
+
+  # ── Resolver semantics ──────────────────────────────────────────────
+
+  describe "resolver" do
+    test "direct grant" do
+      rules = [rule([])]
+      assert {:allow, _} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+      assert Resolver.allowed?(rules, [@user], "project.read", @wiki)
+    end
+
+    test "no match defaults to deny" do
+      assert {:deny, :default} = Resolver.evaluate([], [@user], "project.read", @wiki)
+      refute Resolver.allowed?([], [@user], "project.read", @wiki)
+    end
+
+    test "default can be flipped to allow" do
+      assert {:allow, :default} =
+               Resolver.evaluate([], [@user], "project.read", @wiki, default: :allow)
+    end
+
+    test "direct deny wins over allow" do
+      rules = [
+        rule(effect: "allow"),
+        rule(effect: "deny", priority: -5)
+      ]
+
+      assert {:deny, matched} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+      assert matched.effect == "deny"
+    end
+
+    test "deny wins regardless of priority" do
+      rules = [
+        rule(effect: "deny", priority: 0),
+        rule(effect: "allow", priority: 100)
+      ]
+
+      assert {:deny, _} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+    end
+
+    test "action must match exactly unless wildcard" do
+      rules = [rule([])]
+      assert {:deny, :default} = Resolver.evaluate(rules, [@user], "project.write", @wiki)
+
+      wild = [rule(action: "*")]
+      assert {:allow, _} = Resolver.evaluate(wild, [@user], "project.write", @wiki)
+    end
+
+    test "group grants apply via subject candidates" do
+      rules = [rule(subject_ref: @group_a)]
+      assert {:allow, _} = Resolver.evaluate(rules, [@user, @group_a], "project.read", @wiki)
+      assert {:deny, :default} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+    end
+
+    test "multi-group union" do
+      rules = [
+        rule(subject_ref: @group_a, action: "project.read"),
+        rule(subject_ref: @group_b, action: "project.write")
+      ]
+
+      subjects = [@user, @group_a, @group_b]
+      assert Resolver.allowed?(rules, subjects, "project.read", @wiki)
+      assert Resolver.allowed?(rules, subjects, "project.write", @wiki)
+      assert {:deny, :default} = Resolver.evaluate(rules, subjects, "project.delete", @wiki)
+    end
+
+    test "group deny wins over direct allow" do
+      rules = [
+        rule(subject_ref: @user, effect: "allow"),
+        rule(subject_ref: @group_a, effect: "deny")
+      ]
+
+      subjects = [@user, @group_a]
+      assert {:deny, _} = Resolver.evaluate(rules, subjects, "project.read", @wiki)
+    end
+
+    test "resource kind wildcard matches any id of the kind" do
+      rules = [rule(resource_ref: R.ref(module: NoizuPromptLingua.Projects.Project, id: :any))]
+      assert Resolver.allowed?(rules, [@user], "project.read", @wiki)
+      assert Resolver.allowed?(rules, [@user], "project.read", @other_wiki)
+
+      assert {:deny, :default} =
+               Resolver.evaluate(rules, [@user], "project.read", R.ref(module: NoizuPromptLingua.Organizations.Organization, id: @wid))
+    end
+
+    test "global wildcard rule matches every resource" do
+      rules = [rule(resource_ref: R.ref(module: :any, id: :any), action: "*")]
+      assert Resolver.allowed?(rules, [@user], "anything.atall", @wiki)
+      assert Resolver.allowed?(rules, [@user], "whatever", @other_wiki)
+    end
+
+    test "exact resource does not leak to other ids" do
+      rules = [rule([])]
+      assert {:deny, :default} = Resolver.evaluate(rules, [@user], "project.read", @other_wiki)
+    end
+
+    test "scope filtering" do
+      rules = [rule(scope: "mcp")]
+      assert Resolver.allowed?(rules, [@user], "project.read", @wiki, scope: "mcp")
+      assert {:deny, :default} = Resolver.evaluate(rules, [@user], "project.read", @wiki, scope: "wiki")
+      # nil-scope requests see only nil-scope rules
+      assert {:deny, :default} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+      global = [rule(scope: nil)]
+      assert Resolver.allowed?(global, [@user], "project.read", @wiki)
+      assert Resolver.allowed?(global, [@user], "project.read", @wiki, scope: "mcp")
+    end
+
+    test "archived rules are ignored" do
+      rules = [rule(status: "archived")]
+      assert {:deny, :default} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+    end
+
+    test "top-priority rule is reported among winning effect" do
+      rules = [
+        rule(effect: "allow", priority: 1),
+        rule(effect: "allow", priority: 50)
+      ]
+
+      assert {:allow, matched} = Resolver.evaluate(rules, [@user], "project.read", @wiki)
+      assert matched.priority == 50
+    end
+
+    test "explain reports all matches" do
+      rules = [
+        rule(effect: "allow", priority: 1),
+        rule(effect: "allow", priority: 50),
+        rule(effect: "deny", subject_ref: @group_a)
+      ]
+
+      subjects = [@user, @group_a]
+      explanation = Resolver.explain(rules, subjects, "project.read", @wiki)
+
+      assert explanation.verdict == :deny
+      assert explanation.matched.deny != []
+      assert length(explanation.matched.allow) == 2
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua/acl_test.exs
+++ b/backend/test/noizu_prompt_lingua/acl_test.exs
@@ -1,0 +1,202 @@
+defmodule NoizuPromptLingua.AclTest do
+  @moduledoc """
+  DB-backed tests for the ACL context: group/member/rule CRUD, group
+  expansion (incl. nested + multi-group), and end-to-end `resolve/4` through
+  the sandboxed repo.
+  """
+
+  use NoizuPromptLingua.DataCase, async: true
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  alias NoizuPromptLingua.Acl
+
+  @user_kind NoizuPromptLingua.Users.User
+  @project_kind NoizuPromptLingua.Projects.Project
+
+  defp uid, do: Ecto.UUID.generate()
+  defp user_ref, do: R.ref(module: @user_kind, id: uid())
+  defp project_ref, do: R.ref(module: @project_kind, id: uid())
+
+  # Groups need a ref so rules can target them; we point them at synthetic
+  # Project-entity ids purely as opaque group identifiers.
+  defp group!(name) do
+    {:ok, group} =
+      Acl.create_group(%{
+        name: "acl-" <> name <> "-" <> Ecto.UUID.generate(),
+        ref: R.ref(module: @project_kind, id: uid())
+      })
+
+    group
+  end
+
+  defp member!(group, ref, opts \\ []), do: {:ok, _} = Acl.add_member(group, ref, opts)
+
+  defp rule!(subject_ref, resource_ref, action, effect, extra \\ []) do
+    attrs =
+      %{subject_ref: subject_ref, resource_ref: resource_ref, action: action, effect: effect}
+      |> Map.merge(Map.new(extra))
+
+    {:ok, rule} = Acl.create_rule(attrs)
+    rule
+  end
+
+  describe "group + membership CRUD" do
+    test "create/get/find by name" do
+      ref = user_ref()
+      {:ok, group} = Acl.create_group(%{name: "acl-test-owners", ref: ref})
+
+      assert group.id == Acl.get_group(group.id).id
+      assert group.id == Acl.get_group_by_name("acl-test-owners").id
+      assert group.ref == ref
+    end
+
+    test "add/remove member + unique constraint" do
+      group = group!("m")
+      ref = user_ref()
+      assert {:ok, _} = Acl.add_member(group, ref)
+      assert {:error, _} = Acl.add_member(group, ref)
+      assert [%{member_ref: ^ref}] = Acl.members(group)
+
+      assert {:ok, 1} = Acl.remove_member(group, ref)
+      assert [] = Acl.members(group)
+    end
+
+    test "groups_for finds direct memberships; archived groups excluded" do
+      g = group!("a")
+      ref = user_ref()
+      member!(g, ref)
+      assert [%{id: id}] = Acl.groups_for(ref)
+      assert id == g.id
+
+      Acl.archive_group(g)
+      assert [] = Acl.groups_for(ref)
+    end
+
+    test "expired membership excluded from expansion" do
+      g = group!("exp")
+      ref = user_ref()
+      member!(g, ref, expires_at: DateTime.add(DateTime.utc_now(), -3600))
+
+      assert [] = Acl.groups_for(ref)
+      assert [^ref] = Acl.subject_candidates(ref)
+    end
+  end
+
+  describe "subject_candidates (group expansion)" do
+    test "direct group ref joins the candidate set" do
+      user = user_ref()
+      g = group!("d")
+      member!(g, user)
+
+      candidates = Acl.subject_candidates(user)
+      assert user in candidates
+      assert g.ref in candidates
+    end
+
+    test "nested groups expand transitively; cycles are guarded" do
+      user = user_ref()
+      inner = group!("inner")
+      outer = group!("outer")
+
+      member!(inner, user)
+      member!(outer, inner.ref)
+      # cycle: inner ↔ outer
+      member!(inner, outer.ref)
+
+      candidates = Acl.subject_candidates(user)
+      assert user in candidates
+      assert inner.ref in candidates
+      assert outer.ref in candidates
+    end
+
+    test "multi-group fan-out" do
+      user = user_ref()
+      g1 = group!("m1")
+      g2 = group!("m2")
+      member!(g1, user)
+      member!(g2, user)
+
+      candidates = Acl.subject_candidates(user)
+      assert g1.ref in candidates and g2.ref in candidates
+    end
+  end
+
+  describe "resolve (DB-backed)" do
+    test "direct grant resolves; other actions default-deny" do
+      user = user_ref()
+      project = project_ref()
+      rule!(user, project, "project.read", "allow")
+
+      assert {:allow, _} = Acl.resolve(user, "project.read", project)
+      assert Acl.allowed?(user, "project.read", project)
+      assert {:deny, :default} = Acl.resolve(user, "project.write", project)
+    end
+
+    test "grant via group membership" do
+      user = user_ref()
+      project = project_ref()
+      g = group!("grant")
+      member!(g, user)
+      rule!(g.ref, project, "project.read", "allow")
+
+      assert Acl.allowed?(user, "project.read", project)
+      # another user in no group stays denied
+      refute Acl.allowed?(user_ref(), "project.read", project)
+    end
+
+    test "deny beats allow from different paths" do
+      user = user_ref()
+      project = project_ref()
+      rule!(user, project, "project.read", "allow")
+
+      g = group!("deny")
+      member!(g, user)
+      rule!(g.ref, project, "project.read", "deny")
+
+      assert {:deny, _} = Acl.resolve(user, "project.read", project)
+    end
+
+    test "nested group grant" do
+      user = user_ref()
+      project = project_ref()
+
+      inner = group!("inner")
+      outer = group!("outer")
+      member!(inner, user)
+      member!(outer, inner.ref)
+      rule!(outer.ref, project, "project.read", "allow")
+
+      assert Acl.allowed?(user, "project.read", project)
+    end
+
+    test "kind wildcard rule + scope filtering end-to-end" do
+      user = user_ref()
+      project = project_ref()
+      other_project = project_ref()
+
+      rule!(user, R.ref(module: @project_kind, id: :any), "project.read", "allow", scope: "mcp")
+
+      assert Acl.allowed?(user, "project.read", project, scope: "mcp")
+      assert Acl.allowed?(user, "project.read", other_project, scope: "mcp")
+      assert {:deny, :default} = Acl.resolve(user, "project.read", project, scope: "wiki")
+    end
+
+    test "archived rule stops resolving" do
+      user = user_ref()
+      project = project_ref()
+      rule = rule!(user, project, "project.read", "allow")
+      assert Acl.allowed?(user, "project.read", project)
+
+      Acl.archive_rule(rule)
+      assert {:deny, :default} = Acl.resolve(user, "project.read", project)
+    end
+
+    test "resource kind wildcard + action wildcard end-to-end" do
+      user = user_ref()
+      rule!(user, R.ref(module: @project_kind, id: :any), "*", "allow")
+      assert Acl.allowed?(user, "anything.else", project_ref())
+    end
+  end
+end

--- a/backend/test/support/acl_test_schema.ex
+++ b/backend/test/support/acl_test_schema.ex
@@ -1,0 +1,118 @@
+defmodule NoizuPromptLingua.AclTestSchema do
+  @moduledoc """
+  Idempotently ensures the Liquibase 081 ACL tables (acl_groups,
+  acl_group_members, acl_rules) exist on the test DB so the ACL suites are
+  self-contained on top of whatever Liquibase state the test DB has.
+  Mirrors `MarketingSignupTestSchema` / `OAuthTestSchema`.
+  """
+  alias NoizuPromptLingua.Repo
+
+  def ensure! do
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE TABLE IF NOT EXISTS acl_groups (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        name varchar(255) NOT NULL,
+        description text,
+        ref jsonb,
+        status varchar(16) NOT NULL DEFAULT 'active'
+          CHECK (status IN ('active', 'archived')),
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+        inserted_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_acl_groups_name ON acl_groups (name)",
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE INDEX IF NOT EXISTS idx_acl_groups_ref ON acl_groups ((ref->>'type'), (ref->>'id'))",
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE TABLE IF NOT EXISTS acl_group_members (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        group_id uuid NOT NULL REFERENCES acl_groups(id) ON DELETE CASCADE,
+        member_ref jsonb NOT NULL,
+        expires_at timestamptz,
+        inserted_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT uq_acl_group_members_group_member UNIQUE (group_id, member_ref)
+      )
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE INDEX IF NOT EXISTS idx_acl_group_members_group ON acl_group_members (group_id)",
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE INDEX IF NOT EXISTS idx_acl_group_members_member
+        ON acl_group_members ((member_ref->>'type'), (member_ref->>'id'))
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE TABLE IF NOT EXISTS acl_rules (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        subject_ref jsonb NOT NULL,
+        resource_ref jsonb NOT NULL,
+        action varchar(255) NOT NULL,
+        effect varchar(16) NOT NULL
+          CHECK (effect IN ('allow', 'deny')),
+        scope varchar(255),
+        priority integer NOT NULL DEFAULT 0,
+        status varchar(16) NOT NULL DEFAULT 'active'
+          CHECK (status IN ('active', 'archived')),
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+        inserted_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE INDEX IF NOT EXISTS idx_acl_rules_subject
+        ON acl_rules ((subject_ref->>'type'), (subject_ref->>'id'))
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE INDEX IF NOT EXISTS idx_acl_rules_resource
+        ON acl_rules ((resource_ref->>'type'), (resource_ref->>'id'))
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE INDEX IF NOT EXISTS idx_acl_rules_action ON acl_rules (action)",
+      []
+    )
+  end
+end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -64,6 +64,9 @@ NoizuPromptLingua.McpOverviewTestSchema.ensure!()
 # Ensure OAuth AS tables (Liquibase 074) exist for OAuth suite.
 NoizuPromptLingua.OAuthTestSchema.ensure!()
 
+# Ensure ACL/group tables (Liquibase 081) exist for the ACL suite.
+NoizuPromptLingua.AclTestSchema.ensure!()
+
 # Overview generation uses the deterministic (network-free) adapter in tests; the real
 # LLM adapter (Generator.LLM) is the runtime default. Embeddings already run deterministic
 # (set below), so the whole mcp_overview flow is offline in the suite.


### PR DESCRIPTION
Phase 0 / F1 of the tobor.locker overhaul (TOBOR-PLAN.md). Tables `acl_groups`/`acl_group_members`/`acl_rules`, ERP-ref subject/resource binding, deny-wins resolver, Liquibase 081 + idempotent test schema, 36 tests.

**Review (spec-compliance lane, 2026-08-31 — full report: `TOBOR-REVIEW.md` at trl-infra root):**
- Resolver semantics sound: deny-wins, fail-closed, cycle-guarded expansion, parameterized SQL.
- DIVERGENT CONTRACT: JSONB module-atom refs vs spec (kind,uuid) columns; missing slug/scope-chain/`expires_at`/dedupe index; Ecto migration added alongside Liquibase (dual-DDL — pick one).
- ⚠ Fixes needed: nil-resource dead `== NULL` clause; sref-string inputs crash at dump; BFS frontier cap drops whole frontier >16.
- Contract rulings pending (see TOBOR-REVIEW.md §Rulings) before merge.

Rebase risk low (1 behind main, helm-values drift only).