### PR TITLE
feat(mcp): EffectiveToolset unified resolution interface (F2)

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/custom.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/custom.ex
@@ -10,6 +10,7 @@ defmodule NoizuPromptLingua.MCP.Custom do
       "Custom Noizu Prompt Lingua MCP scope. Use Discovery tools to inspect the enabled tool set."
 
   alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.MCP.EffectiveToolset
   alias NoizuPromptLingua.MCPCustomScopes
 
   @discovery_tools [
@@ -33,40 +34,33 @@ defmodule NoizuPromptLingua.MCP.Custom do
   def custom_specs(ctx) do
     with slug when is_binary(slug) <- scope_slug(ctx),
          scope when not is_nil(scope) <- MCPCustomScopes.get_by_slug(slug) do
+      # Effective state for the scope layer (client layer is applied later by
+      # MCP.Server.list_tools via KeyToolsets/EffectiveToolset with the ctx).
+      states = EffectiveToolset.resolve(scope, nil, nil)
+
       scope.config
       |> MCPCustomScopes.normalize_config(scope.kind)
       |> Map.fetch!("groups")
       |> Enum.flat_map(fn {group_id, group_config} ->
-        group_specs(group_id, group_config)
+        group_specs(group_id, group_config, states)
       end)
     else
       _ -> []
     end
   end
 
-  defp group_specs(_group_id, %{"disabled" => true}), do: []
+  defp group_specs(_group_id, %{"disabled" => true}, _states), do: []
 
-  defp group_specs(group_id, group_config) do
+  defp group_specs(group_id, _group_config, states) do
     with module when is_atom(module) and not is_nil(module) <-
            NoizuPromptLingua.MCPServers.server_module(group_id) do
-      group_hidden = Map.get(group_config, "hidden")
-      tool_config = Map.get(group_config, "tools") || %{}
-
       module.__mcp__(:tools)
       |> Tools.expand()
       |> Enum.reject(&(tool_category(&1) == "Discovery"))
-      |> Enum.reject(fn spec ->
-        get_in(tool_config, [spec.definition.name, "disabled"]) == true
-      end)
       |> Enum.map(fn spec ->
-        tool_hidden = get_in(tool_config, [spec.definition.name, "hidden"])
-
-        cond do
-          is_boolean(tool_hidden) -> %{spec | hidden: tool_hidden}
-          is_boolean(group_hidden) -> %{spec | hidden: group_hidden}
-          true -> spec
-        end
+        EffectiveToolset.apply_state(spec, EffectiveToolset.lookup(states, spec.definition.name))
       end)
+      |> Enum.reject(&is_nil/1)
     else
       _ -> []
     end

--- a/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
@@ -1,0 +1,509 @@
+defmodule NoizuPromptLingua.MCP.EffectiveToolset do
+  @moduledoc """
+  THE toolset resolution interface (TOBOR-CONTRACTS §2).
+
+  Answers one question: given scope + client + user + now, what is each tool's
+  effective state? Everything downstream (listing, dispatch guard, manifests,
+  OAuth consent) consumes THIS, not the DB shapes.
+
+  Resolution cascade (most specific wins per key; absent field inherits; a
+  tool absent from every layer is ENABLED + VISIBLE — inverted semantics):
+
+    1. global `tobor` template config
+    2. custom-scope config (`mcp_custom_scopes.config`)
+    3. client `toolset_config` (API key today; OAuth client jsonb via W8)
+
+  Per layer, a tool-level entry beats its group's flags (boolean overrides).
+
+  Per-tool effective state:
+
+      %{enabled: boolean,                  # execution (was `disabled`)
+        visible: boolean,                  # discovery/listing (was `hidden`)
+        name_override: String.t() | nil,   # W9 field — ships now
+        description_override: String.t() | nil,
+        expires_at: DateTime.t() | nil}    # temporal window, via MCP.Window
+
+  Semantics preserved from the pre-refactor split:
+
+    * `enabled: false` — blocks EXECUTION (`ToolGuard` via `KeyToolsets.state/3`,
+      before RBAC, independent of `:mcp_authz_mode`) and drops from listings.
+    * `visible: false` — blocks LISTING/DISCOVERY only; still callable unless
+      also disabled.
+    * Clients never ADD tools: with a scope present the include set is the
+      scope's group set; client config only flips flags on those groups.
+  """
+
+  alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.MCP.Window
+  alias NoizuPromptLingua.MCPApiKeys
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.McpApiKey
+
+  require Logger
+
+  @type tool_state :: %{
+          enabled: boolean(),
+          visible: boolean(),
+          name_override: String.t() | nil,
+          description_override: String.t() | nil,
+          expires_at: DateTime.t() | nil
+        }
+
+  @type scope :: NoizuPromptLingua.Schema.MCPCustomScope.t() | map() | nil
+  @type client :: %{id: term(), kind: :api_key | :oauth_client, toolset_config: map() | nil} | nil
+
+  @default_state %{
+    enabled: true,
+    visible: true,
+    name_override: nil,
+    description_override: nil,
+    expires_at: nil
+  }
+
+  @doc "The inherit-everything state (absent = enabled + visible)."
+  def default_state, do: @default_state
+
+  # ── THE resolution contract ────────────────────────────────────────────────
+
+  @doc """
+  Resolve the effective toolset for `scope` + `client` at instant `at`.
+
+  Returns a map keyed by canonical tool name (underscore form once F5 lands;
+  dotted today — `canonical/1` picks up `MCP.ToolNames` automatically at
+  merge). `user_ref_or_nil` is reserved for the F1 ACL layering (per-user
+  denies/grants folded into the same map) and does not affect state yet.
+  """
+  @spec resolve(scope, client, term(), DateTime.t()) :: %{String.t() => tool_state()}
+  def resolve(scope, client, user_ref_or_nil, at \\ DateTime.utc_now())
+
+  def resolve(scope, client, _user_ref, at) do
+    template = template_config()
+    scope_cfg = scope_config(scope)
+    client_cfg = normalize_config(client_config(client))
+
+    groups = include_groups(scope_cfg, template, client_cfg)
+
+    groups
+    |> Enum.flat_map(fn group_id ->
+      tool_names(group_id, [client_cfg, scope_cfg, template])
+      |> Enum.uniq()
+      |> Map.new(fn tool_name ->
+        {canonical(tool_name), state(group_id, tool_name, template, scope_cfg, client_cfg, at)}
+      end)
+    end)
+    |> Enum.into(%{})
+  end
+
+  # Include set: with a scope, the scope's groups govern (clients/templates only
+  # flip flags). Without one (static subdomain servers, ToolGuard), union of
+  # template + client groups — there is no scope include set to respect.
+  defp include_groups(nil = _scope_cfg, template, client_cfg) do
+    (Map.get(template || %{}, "groups") || %{})
+    |> Map.merge(Map.get(client_cfg || %{}, "groups") || %{})
+    |> Map.keys()
+  end
+
+  defp include_groups(scope_cfg, _template, _client_cfg),
+    do: Map.keys(Map.get(scope_cfg, "groups") || %{})
+
+  @doc """
+  Single-tool state — the hot-path entry point (ToolGuard / Catalog). Same
+  cascade as `resolve/4` but resolves one (group, tool) pair without
+  enumerating the group's catalog. `group_id: nil` (root-only Discovery/NPL
+  tools) is ungated: inherit-everything.
+  """
+  @spec state(String.t() | nil, String.t(), scope, client, DateTime.t()) :: tool_state()
+  def state(group_id, tool_name, scope, client, at \\ DateTime.utc_now())
+
+  def state(group_id, tool_name, scope, client, at)
+      when is_binary(group_id) and is_binary(tool_name) do
+    template = template_config()
+    scope_cfg = scope_config(scope)
+    client_cfg = normalize_config(client_config(client))
+
+    state(group_id, tool_name, template, scope_cfg, client_cfg, at)
+  end
+
+  def state(nil, _tool_name, _scope, _client, _at), do: @default_state
+
+  # Cascade across [client, scope, template]: per key, the most specific layer
+  # with an opinion wins; within a layer, the tool entry beats the group flag.
+  defp state(group_id, tool_name, template, scope_cfg, client_cfg, at) do
+    entries =
+      [client_cfg, scope_cfg, template]
+      |> Enum.flat_map(fn layer ->
+        case layer_entries(layer, group_id, tool_name) do
+          nil -> []
+          pair -> [pair]
+        end
+      end)
+
+    build_state(entries, at)
+  end
+
+  defp layer_entries(nil, _group_id, _tool_name), do: nil
+
+  defp layer_entries(config, group_id, tool_name) when is_map(config) do
+    groups = Map.get(config, "groups") || %{}
+    group = Map.get(groups, group_id)
+
+    case group do
+      nil ->
+        nil
+
+      group ->
+        tools = Map.get(group, "tools") || %{}
+        tool = Map.get(tools, tool_name) || Map.get(tools, canonical(tool_name)) || %{}
+        {group, tool}
+    end
+  end
+
+  defp layer_entries(_, _, _), do: nil
+
+  defp build_state(entries, at) do
+    disabled = flag(entries, "disabled")
+    hidden = flag(entries, "hidden")
+    name_override = flag(entries, "name_override")
+    description_override = flag(entries, "description_override")
+
+    {window_visible, expires_at} =
+      entries
+      |> Enum.reverse()
+      |> Enum.reduce(%{}, fn {group, tool}, acc -> acc |> Map.merge(group) |> Map.merge(tool) end)
+      |> Window.evaluate(at)
+
+    base_visible = hidden != true
+
+    %{
+      enabled: disabled != true,
+      visible: if(is_boolean(window_visible), do: base_visible and window_visible, else: base_visible),
+      name_override: string_or_nil(name_override),
+      description_override: string_or_nil(description_override),
+      expires_at: expires_at
+    }
+  end
+
+  # First layer carrying the key wins; a present-but-false value IS an opinion
+  # (so reduce_while, not find_value — find_value would skip explicit `false`).
+  defp flag(entries, key) do
+    Enum.reduce_while(entries, nil, fn {group, tool}, _acc ->
+      cond do
+        Map.has_key?(tool, key) -> {:halt, tool[key]}
+        Map.has_key?(group, key) -> {:halt, group[key]}
+        true -> {:cont, nil}
+      end
+    end)
+  end
+
+  defp string_or_nil(v) when is_binary(v), do: v
+  defp string_or_nil(_), do: nil
+
+  # ── consumers ──────────────────────────────────────────────────────────────
+
+  @doc """
+  Look up a tool's state in a resolved map, canonicalizing the key. Absent
+  (not mentioned by any layer) => inherit-everything default.
+  """
+  def lookup(states, tool_name) when is_map(states) do
+    Map.get(states, canonical(tool_name)) || @default_state
+  end
+
+  @doc """
+  Apply a resolved state to an expanded tool spec for listing.
+
+  Returns `nil` when the tool must be dropped (disabled), otherwise the spec
+  with `hidden` set from `visible` and name/description overrides applied.
+  A state equal to the inherit-everything default is a NO-OP so statically
+  registered `hidden` flags survive when no config layer has an opinion.
+  """
+  def apply_state(spec, state)
+
+  def apply_state(_spec, nil), do: nil
+
+  def apply_state(spec, state) when is_map(state) do
+    cond do
+      state == @default_state ->
+        spec
+
+      state[:enabled] == false ->
+        nil
+
+      true ->
+        definition =
+          spec.definition
+          |> maybe_override(:name, state[:name_override])
+          |> maybe_override(:description, state[:description_override])
+
+        %{spec | definition: definition, hidden: not state[:visible]}
+    end
+  end
+
+  defp maybe_override(definition, _key, nil), do: definition
+  defp maybe_override(definition, key, value), do: Map.put(definition, key, value)
+
+  @doc """
+  Listing filter for the shared server pipeline (`MCP.Server.list_tools`,
+  `Tools.Catalog`): resolve the caller's client + scope states and drop
+  hidden/disabled specs. Discovery/NPL categories are never gated. `group_id`
+  pins the owning group when the caller knows it.
+  """
+  def apply_to_specs(specs, ctx, group_id \\ nil) when is_list(specs) do
+    client = client_for_ctx(ctx)
+    scope = scope_from_ctx(ctx)
+
+    if client == nil and scope == nil do
+      specs
+    else
+      Enum.reject(specs, fn spec ->
+        if ungated_category?(spec) do
+          true
+        else
+          gid = group_id || MCPServers.group_id_for_tool_module(spec.module)
+          ts = state(gid, spec.definition.name, scope, client)
+          not ts.visible or not ts.enabled
+        end
+      end)
+    end
+  end
+
+  # Discovery/NPL tool modules are registered on every domain server as the
+  # browsing plane — they are never gated (their OUTPUT respects per-client
+  # flags via Catalog).
+  @ungated_categories ["Discovery", "NPL"]
+
+  def ungated_category?(spec) do
+    category = spec.definition && spec.definition.meta && spec.definition.meta["category"]
+    category in @ungated_categories
+  end
+
+  # ── ctx plumbing ───────────────────────────────────────────────────────────
+
+  @doc """
+  The calling client resolved from `ctx.assigns.auth_claims`: the active API
+  key (minted into the MCP JWT at token time) with its `toolset_config`, or
+  nil when the request carries no API key (OAuth-only / system principal —
+  OAuth clients gain their jsonb overrides via W8).
+  """
+  def client_for_ctx(ctx) do
+    claims = get_in(ctx, [Access.key(:assigns, %{}), Access.key(:auth_claims, %{})]) || %{}
+
+    with api_key_id when is_binary(api_key_id) <- claims["api_key_id"],
+         %McpApiKey{status: "active"} = key <- Repo.get(McpApiKey, api_key_id) do
+      config = if is_map(key.toolset_config) and key.toolset_config != %{}, do: key.toolset_config
+      %{id: key.id, kind: :api_key, toolset_config: config}
+    else
+      _ -> nil
+    end
+  rescue
+    e ->
+      Logger.warning("[EffectiveToolset] client resolution failed: #{Exception.message(e)}")
+      nil
+  end
+
+  @doc "The custom scope serving this request (ctx assigns), or nil."
+  def scope_from_ctx(ctx) do
+    assigns = get_in(ctx, [Access.key(:assigns, %{})]) || %{}
+    slug = assigns[:custom_scope_slug] || assigns["custom_scope_slug"]
+
+    with slug when is_binary(slug) <- slug do
+      MCPCustomScopes.get_by_slug(slug)
+    else
+      _ -> nil
+    end
+  end
+
+  @doc "Client toolset config from `ctx.assigns.auth_claims` (normalized), or nil."
+  def config_for_ctx(ctx) do
+    case client_for_ctx(ctx) do
+      %{toolset_config: config} when is_map(config) -> MCPApiKeys.normalize_toolset(config)
+      _ -> nil
+    end
+  end
+
+  # ── legacy config helpers (shape-compatible with the pre-refactor API) ─────
+
+  @doc "Resolve legacy (disabled, hidden) flags for (group, tool) against ONE concrete config — pure, no cascade, no DB."
+  def state_from_config(config, group_id, tool_name) when is_map(config) do
+    entries =
+      case layer_entries(normalize_config(config), group_id, tool_name) do
+        nil -> []
+        pair -> [pair]
+      end
+
+    build_state(entries, DateTime.utc_now())
+    |> then(&%{disabled: not &1.enabled, hidden: not &1.visible})
+  end
+
+  def state_from_config(_, _, _), do: %{disabled: false, hidden: false}
+
+  @doc """
+  Overlay a more-specific config ON TOP OF a base config: boolean/value
+  overrides win per group and per tool, absent override fields inherit the
+  base value. The base's include set is preserved (overrides never add or
+  remove groups). Returns a config in the same shape as the base input.
+  """
+  def overlay(base, overrides) when is_map(base) and is_map(overrides) do
+    ov_groups = Map.get(normalize_config(overrides), "groups") || %{}
+    base_groups = Map.get(base, "groups") || Map.get(base, :groups) || %{}
+
+    merged =
+      Map.new(base_groups, fn {group_id, group_cfg} ->
+        group_id = to_string(group_id)
+
+        case Map.get(ov_groups, group_id) do
+          nil -> {group_id, group_cfg}
+          ov -> {group_id, overlay_group(group_cfg || %{}, ov)}
+        end
+      end)
+
+    base
+    |> Map.drop(["groups", :groups])
+    |> Map.put("groups", merged)
+  end
+
+  def overlay(base, _overrides) when is_map(base), do: base
+  def overlay(nil, _), do: %{}
+
+  defp overlay_group(base_group, ov_group) do
+    base_group
+    |> override_flag("disabled", ov_group)
+    |> override_flag("hidden", ov_group)
+    |> override_value("name_override", ov_group)
+    |> override_value("description_override", ov_group)
+    |> overlay_tools(ov_group)
+  end
+
+  defp overlay_tools(base_group, ov_group) do
+    ov_tools = Map.get(ov_group, "tools") || %{}
+    base_tools = Map.get(base_group, "tools") || Map.get(base_group, :tools) || %{}
+
+    merged =
+      Map.new(base_tools, fn {tool_name, tool_cfg} ->
+        tool_name = to_string(tool_name)
+
+        case Map.get(ov_tools, tool_name) do
+          nil -> {tool_name, tool_cfg}
+          ov -> {tool_name, overlay_tool(tool_cfg || %{}, ov)}
+        end
+      end)
+
+    Map.put(base_group, "tools", merged)
+  end
+
+  defp overlay_tool(base_tool, ov_tool) do
+    base_tool
+    |> override_flag("disabled", ov_tool)
+    |> override_flag("hidden", ov_tool)
+    |> override_value("name_override", ov_tool)
+    |> override_value("description_override", ov_tool)
+  end
+
+  defp override_flag(map, flag, overrides) do
+    case Map.get(overrides, flag) do
+      value when is_boolean(value) -> Map.put(map, flag, value)
+      _ -> map
+    end
+  end
+
+  defp override_value(map, key, overrides) do
+    case Map.get(overrides, key) do
+      value when is_binary(value) -> Map.put(map, key, value)
+      _ -> map
+    end
+  end
+
+  # ── config layer readers ───────────────────────────────────────────────────
+
+  # Raw read of the global `tobor` template — NO heal write on this hot path
+  # (drift repair stays on the ensure_* paths that own the template).
+  defp template_config do
+    case MCPCustomScopes.get_by_slug(MCPCustomScopes.default_package_slug()) do
+      %{config: config} when is_map(config) -> normalize_config(config)
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp scope_config(nil), do: nil
+
+  defp scope_config(scope) do
+    case scope do
+      %{config: config} -> normalize_config(config)
+      %{"config" => config} -> normalize_config(config)
+      _ -> nil
+    end
+  end
+
+  defp client_config(nil), do: nil
+  defp client_config(%{toolset_config: config}), do: config
+  defp client_config(%{"toolset_config" => config}), do: config
+  defp client_config(_), do: nil
+
+  # Light normalization: stringify keys (atom-tolerant) WITHOUT dropping
+  # unknown entry keys — name/description overrides and temporal windows ride
+  # the same entries as disabled/hidden and must survive. (The scope context's
+  # normalizer is stricter; F3/W9 extend it for persistence.)
+  defp normalize_config(nil), do: nil
+
+  defp normalize_config(config) when is_map(config) do
+    groups = Map.get(config, "groups") || Map.get(config, :groups) || %{}
+
+    %{"groups" => Map.new(groups, fn {gid, gcfg} -> {to_string(gid), normalize_group(gcfg)} end)}
+  end
+
+  defp normalize_config(_), do: nil
+
+  defp normalize_group(gcfg) when is_map(gcfg) do
+    tools = Map.get(gcfg, "tools") || Map.get(gcfg, :tools) || %{}
+
+    gcfg
+    |> Map.new(fn {k, v} -> {to_string(k), v} end)
+    |> Map.put("tools", Map.new(tools, &normalize_tool/1))
+  end
+
+  defp normalize_group(_), do: %{"tools" => %{}}
+
+  defp normalize_tool({tool_name, tcfg}) when is_map(tcfg),
+    do: {to_string(tool_name), Map.new(tcfg, fn {k, v} -> {to_string(k), v} end)}
+
+  defp normalize_tool({tool_name, _}), do: {to_string(tool_name), %{}}
+
+  # Canonical tool name (contract §4). F5 owns NoizuPromptLingua.MCP.ToolNames;
+  # until that branch merges the dotted names in today's configs pass through
+  # unchanged, and resolve/lookup pick the canonicalizer up automatically.
+  defp canonical(name) when is_binary(name) do
+    if Code.ensure_loaded?(NoizuPromptLingua.MCP.ToolNames) and
+         function_exported?(NoizuPromptLingua.MCP.ToolNames, :canonical, 1) do
+      apply(NoizuPromptLingua.MCP.ToolNames, :canonical, [name])
+    else
+      name
+    end
+  end
+
+  defp canonical(name), do: name
+
+  # ── group enumeration (full-map resolution) ────────────────────────────────
+
+  defp tool_names(group_id, configs) do
+    from_module =
+      with module when is_atom(module) and not is_nil(module) <- MCPServers.server_module(group_id),
+           true <- Code.ensure_loaded?(module),
+           true <- function_exported?(module, :__mcp__, 1) do
+        module.__mcp__(:tools) |> Tools.expand() |> Enum.map(& &1.definition.name)
+      else
+        _ -> []
+      end
+
+    from_config =
+      Enum.flat_map(configs, fn config ->
+        groups = Map.get(config || %{}, "groups") || %{}
+        group = Map.get(groups, group_id) || %{}
+        (Map.get(group, "tools") || %{}) |> Map.keys()
+      end)
+
+    Enum.uniq(from_module ++ from_config)
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
@@ -1,65 +1,44 @@
 defmodule NoizuPromptLingua.MCP.KeyToolsets do
   @moduledoc """
-  Per-API-key MCP toolset resolution for the gateway.
+  Per-API-key MCP toolset resolution — THIN CALLER over
+  `NoizuPromptLingua.MCP.EffectiveToolset` (contract §2).
 
-  Every MCP consumer API key may carry its own toolset config
-  (`mcp_api_keys.toolset_config`, shape-identical to custom-scope configs:
+  The cascade itself (global `tobor` template → custom-scope config → client
+  `toolset_config`) lives in EffectiveToolset; this module keeps the
+  key-shaped API the gateway grew up on:
 
-      %{"groups" => %{"<group_id>" => %{
-           "disabled" => boolean, "hidden" => boolean,
-           "tools" => %{"<Tool.Name>" => %{"disabled" => boolean, "hidden" => boolean}}}}}
+    * `state/3` (group, tool, ctx) → `%{disabled:, hidden:}` — consumed by
+      `ToolGuard` (execution) and `Tools.Catalog` (hidden-tool calls).
+    * `apply_hidden/3` — listing filter consumed by `MCP.Server.list_tools`
+      and `Tools.Catalog.build/2`.
+    * `overlay/2`, `state_from_config/3` — config-shape helpers reused by the
+      component registry gating.
 
-  Resolution cascade (most specific wins; absent field = inherit):
-
-    1. global `tobor` template →
-    2. custom-scope config (per-user/org default endpoint or named preset) →
-    3. **key overrides** (this module).
-
-  Semantics:
+  Semantics (unchanged):
 
     * `disabled: true` — blocks EXECUTION. Enforced in
       `NoizuPromptLingua.MCP.ToolGuard` (before RBAC, independent of
-      `:mcp_authz_mode` — this is hard capability config, not RBAC rollout)
-      and in `NoizuPromptLingua.Tools.Catalog.call_hidden_tool/4`.
-    * `hidden: true` — blocks LISTING/DISCOVERY only. Enforced in
-      `handle_list_tools` (via `NoizuPromptLingua.MCP.Server`) and
-      `NoizuPromptLingua.Tools.Catalog.build/2`. A hidden tool can still be
-      called directly unless also `disabled`.
+      `:mcp_authz_mode`) and in `NoizuPromptLingua.Tools.Catalog.call_hidden_tool/4`.
+    * `hidden: true` — blocks LISTING/DISCOVERY only. A hidden tool can still
+      be called directly unless also disabled.
     * Keys never ADD tools: on the main servers all tools are included by
       default, on `/custom/:slug/mcp` the scope's include set still governs —
       key config only flips flags.
 
   The key is resolved server-side from `ctx.assigns.auth_claims["api_key_id"]`
   (minted into the MCP JWT at token time). OAuth-only tokens without an
-  api_key_id inherit everything (no overrides).
+  api_key_id inherit everything (no overrides) until W8 stores OAuth-client
+  toolset jsonb.
   """
 
-  require Logger
-
-  alias NoizuPromptLingua.Repo
-  alias NoizuPromptLingua.Schema.McpApiKey
-  alias NoizuPromptLingua.MCPServers
-
-  @empty %{"groups" => %{}}
+  alias NoizuPromptLingua.MCP.EffectiveToolset
 
   @doc """
   The calling key's toolset config (normalized), or `nil` when the request
-  carries no API key (OAuth-only / system principal) or the key is unknown.
+  carries no API key (OAuth-only / system principal) or the key has no
+  overrides.
   """
-  def config_for(ctx) do
-    with api_key_id when is_binary(api_key_id) <- api_key_id(ctx),
-         %McpApiKey{status: "active"} = key <- Repo.get(McpApiKey, api_key_id),
-         config when is_map(config) <- key.toolset_config,
-         true <- config != %{} do
-      normalize(config)
-    else
-      _ -> nil
-    end
-  rescue
-    e ->
-      Logger.warning("[KeyToolsets] config resolution failed: #{Exception.message(e)}")
-      nil
-  end
+  def config_for(ctx), do: EffectiveToolset.config_for_ctx(ctx)
 
   @doc "api_key_id from the MCP JWT claims in ctx.assigns."
   def api_key_id(ctx) do
@@ -67,163 +46,53 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
     claims["api_key_id"]
   end
 
-  # Discovery/NPL tool modules are registered on every domain server as the
-  # browsing plane — they are never key-gated (their OUTPUT respects per-key
-  # hidden/disabled via Catalog). Groups resolve via the tool module.
-  @ungated_categories ["Discovery", "NPL"]
-
-  def ungated_category?(category) when category in @ungated_categories, do: true
-  def ungated_category?(_), do: false
-
-  def tool_category(spec) do
-    (spec.definition && spec.definition.meta && spec.definition.meta["category"]) || nil
-  end
-
   @doc """
-  Resolve the per-key flags for a (group, tool) pair from the calling ctx.
+  Resolve the effective (disabled, hidden) flags for a (group, tool) pair from
+  the calling ctx — full EffectiveToolset cascade (client + scope + template).
 
-    * `:disabled` — blocks EXECUTION. Enforced in
-      `NoizuPromptLingua.MCP.ToolGuard` (before RBAC; independent of
-      `:mcp_authz_mode` — this is capability config, not RBAC rollout) and in
-      `NoizuPromptLingua.Tools.Catalog.call_hidden_tool/4`.
+    * `disabled` — blocks EXECUTION (ToolGuard, pre-RBAC, both authz modes).
     * `hidden` — blocks LISTING/DISCOVERY only; the tool remains callable
       directly unless also disabled.
   """
   def state(group_id, tool_name, ctx) when is_binary(group_id) and is_binary(tool_name) do
-    case config_for(ctx) do
-      nil -> %{disabled: false, hidden: false}
-      config -> state_from_config(config, group_id, tool_name)
-    end
+    ts =
+      EffectiveToolset.state(
+        group_id,
+        tool_name,
+        EffectiveToolset.scope_from_ctx(ctx),
+        EffectiveToolset.client_for_ctx(ctx)
+      )
+
+    %{disabled: not ts.enabled, hidden: not ts.visible}
   end
 
   # Unresolvable group (root-only tools: Discovery, NPL) is ungated.
   def state(_group_id, tool_name, _ctx) when is_binary(tool_name),
     do: %{disabled: false, hidden: false}
 
-  @doc "Resolve flags for (group, tool) against a concrete config (no ctx)."
-  def state_from_config(config, group_id, tool_name) when is_map(config) do
-    groups = Map.get(normalize(config), "groups", %{})
-    group = Map.get(groups, group_id) || %{}
-    tools = Map.get(group, "tools") || %{}
-    tool = Map.get(tools, tool_name) || %{}
-
-    %{
-      disabled: flag(group, tool, "disabled"),
-      hidden: flag(group, tool, "hidden")
-    }
-  end
-
-  def state_from_config(_, _, _), do: %{disabled: false, hidden: false}
-
-  # More specific wins: a boolean on the tool entry overrides the group's flag;
-  # otherwise the group flag governs (absent = false = inherit/no restriction).
-  defp flag(group, tool, key) do
-    case Map.get(tool, key) do
-      value when is_boolean(value) -> value
-      _ -> Map.get(group, key) == true
-    end
-  end
+  @doc "Resolve legacy (disabled, hidden) flags for (group, tool) against a concrete config (no ctx, no template)."
+  defdelegate state_from_config(config, group_id, tool_name), to: EffectiveToolset
 
   @doc """
-  Overlay a key's toolset config ON TOP OF a custom scope's config: key flags
-  win per group and per tool, absent key fields inherit the scope value. The
-  scope's include set is preserved (groups never added or removed by keys).
-  Returns a config in the same shape as the scope input.
+  Overlay a client toolset config ON TOP OF a base config (see
+  `EffectiveToolset.overlay/2` — same function, kept here for call-site
+  compatibility).
   """
-  def overlay(scope_config, key_config) when is_map(scope_config) and is_map(key_config) do
-    key_groups = Map.get(normalize(key_config), "groups", %{})
-    scope_groups = Map.get(scope_config, "groups") || Map.get(scope_config, :groups) || %{}
-
-    merged =
-      Map.new(scope_groups, fn {group_id, group_cfg} ->
-        group_id = to_string(group_id)
-        key_group = Map.get(key_groups, group_id)
-
-        case key_group do
-          nil ->
-            {group_id, group_cfg}
-
-          overrides ->
-            {group_id, overlay_group(group_cfg || %{}, overrides)}
-        end
-      end)
-
-    base = Map.drop(scope_config, ["groups", :groups])
-    Map.put(base, "groups", merged)
-  end
-
-  def overlay(scope_config, nil) when is_map(scope_config), do: scope_config
-  def overlay(nil, _), do: %{}
-
-  defp overlay_group(scope_group, key_group) do
-    scope_group
-    |> override_flag("disabled", key_group)
-    |> override_flag("hidden", key_group)
-    |> overlay_tools(key_group)
-  end
-
-  defp overlay_tools(scope_group, key_group) do
-    key_tools = Map.get(key_group, "tools") || %{}
-    scope_tools = Map.get(scope_group, "tools") || %{}
-
-    merged =
-      Map.new(scope_tools, fn {tool_name, tool_cfg} ->
-        tool_name = to_string(tool_name)
-
-        case Map.get(key_tools, tool_name) do
-          nil -> {tool_name, tool_cfg}
-          overrides -> {tool_name, overlay_tool(tool_cfg || %{}, overrides)}
-        end
-      end)
-
-    Map.put(scope_group, "tools", merged)
-  end
-
-  defp overlay_tool(scope_tool, key_tool) do
-    scope_tool
-    |> override_flag("disabled", key_tool)
-    |> override_flag("hidden", key_tool)
-  end
-
-  defp override_flag(map, flag, overrides) do
-    case Map.get(overrides, flag) do
-      value when is_boolean(value) -> Map.put(map, flag, value)
-      _ -> map
-    end
-  end
+  defdelegate overlay(scope_config, key_config), to: EffectiveToolset
 
   @doc """
-  Apply per-key `hidden`/`disabled` listing rules to expanded tool specs.
-
-  `group_id` is the owning MCP group when the caller knows it (a static
-  subdomain server); pass `nil` to resolve per spec via the tool's module
-  (`MCPServers.group_id_for_tool_module/1`). Disabled tools are dropped from
-  the listing as well as denied at call time.
+  Apply per-client `hidden`/`disabled` listing rules to expanded tool specs.
+  Delegates to `EffectiveToolset.apply_to_specs/3` (Discovery/NPL ungated;
+  disabled tools are dropped from the listing as well as denied at call time).
   """
-  def apply_hidden(specs, ctx, group_id) when is_list(specs) do
-    config = config_for(ctx)
-
-    if config == nil do
-      specs
-    else
-      Enum.reject(specs, fn spec ->
-        ungated_category?(tool_category(spec)) or ungated?(spec, config, group_id)
-      end)
-    end
-  end
+  def apply_hidden(specs, ctx, group_id) when is_list(specs),
+    do: EffectiveToolset.apply_to_specs(specs, ctx, group_id)
 
   def apply_hidden(specs, _ctx, _group_id), do: specs
-
-  defp ungated?(spec, config, group_id) do
-    name = spec.definition.name
-    gid = group_id || MCPServers.group_id_for_tool_module(spec.module)
-    flags = state_from_config(config, gid, name)
-    flags.hidden == true or flags.disabled == true
-  end
 
   @doc "Normalize a key toolset config (delegates to the key context's normalizer)."
   def normalize(config), do: NoizuPromptLingua.MCPApiKeys.normalize_toolset(config)
 
   @doc "The empty (inherit-everything) config."
-  def empty, do: @empty
+  def empty, do: %{"groups" => %{}}
 end

--- a/backend/lib/noizu_prompt_lingua/mcp/urls.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/urls.ex
@@ -1,0 +1,64 @@
+defmodule NoizuPromptLingua.MCP.Urls do
+  @moduledoc """
+  Canonical custom-scope URL builders (contract §2 / W1 shapes):
+
+      scope_url(scope)  # https://tobor.locker/org/:org_slug/custom/:slug/mcp  (preferred)
+      user_url(scope)   # https://tobor.locker/user/:slug/mcp    (account-level sharing, W2)
+      legacy_url(scope) # https://tobor.locker/custom/:slug/mcp  (permanent alias)
+
+  Old hex-handle `/custom/:hex` URLs resolve forever (W1 aliases, never
+  renames — clients bake them in), which is why `legacy_url` stays first-class.
+  `scope_url/2` falls back to the legacy shape when the scope has no
+  resolvable org slug; pass `org_slug:` to skip the DB lookup.
+  """
+
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.Organizations.Organization
+
+  @doc "Preferred URL: org-scoped path when the org (slug) is resolvable, else legacy."
+  def scope_url(scope, opts \\ []) do
+    case org_slug(scope, opts) do
+      org_slug when is_binary(org_slug) and org_slug != "" ->
+        build(opts, "org/#{org_slug}/custom/#{slug(scope)}/mcp")
+
+      _ ->
+        legacy_url(scope, opts)
+    end
+  end
+
+  @doc "Account-level sharing path (W2): `/user/:scope_slug/mcp`."
+  def user_url(scope, opts \\ []), do: build(opts, "user/#{slug(scope)}/mcp")
+
+  @doc "Permanent legacy alias: `/custom/:scope_slug/mcp`."
+  def legacy_url(scope, opts \\ []), do: build(opts, "custom/#{slug(scope)}/mcp")
+
+  defp build(opts, path) do
+    host = opts[:host] || MCPServers.default_host()
+    "https://#{host}/#{path}"
+  end
+
+  defp org_slug(scope, opts) do
+    opts[:org_slug] || org_slug_from_record(scope)
+  end
+
+  defp org_slug_from_record(%{organization_id: org_id}) when is_binary(org_id) do
+    case Repo.get(Organization, org_id) do
+      %{slug: slug} when is_binary(slug) and slug != "" -> slug
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp org_slug_from_record(_), do: nil
+
+  defp slug(scope) do
+    case scope do
+      %{slug: slug} when is_binary(slug) -> slug
+      %{"slug" => slug} when is_binary(slug) -> slug
+      slug when is_binary(slug) -> slug
+      _ -> raise ArgumentError, "Urls: scope slug required, got: #{inspect(scope)}"
+    end
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/mcp/window.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/window.ex
@@ -1,0 +1,98 @@
+defmodule NoizuPromptLingua.MCP.Window do
+  @moduledoc """
+  Temporal visibility windows for MCP tool entries (contract §3, branch F3).
+
+  F2 ships the contract seam + a conservative default implementation so the
+  `expires_at` field of `NoizuPromptLingua.MCP.EffectiveToolset` is live from
+  day one. F3 (feat/temporal-windows) owns the refined semantics and replaces
+  this module's body at merge — the `evaluate/2` signature is the contract,
+  keep it stable.
+
+  Config keys (on a tool entry in scope config jsonb; mutually exclusive):
+
+    * `hide_until` — ISO8601 datetime (or `%DateTime{}`). While in the future
+      the tool is invisible; after it passes the entry's base flags govern.
+    * `enable_for_hours` — non-neg integer hours. A temporary visibility grant
+      anchored at `enable_from` (ISO8601, written by the editor): visible until
+      `enable_from + hours`, with `expires_at` reporting that instant. After
+      expiry the base flags govern again. Without an anchor the window is a
+      no-op (`{true, nil}`) — the editor always writes an anchor.
+  """
+
+  @type eval :: {visible :: boolean | nil, expires_at :: DateTime.t() | nil}
+
+  @doc """
+  Evaluate the window on a tool entry at instant `at`.
+
+  Returns `{visible, expires_at}` where `visible` is `nil` when the entry
+  carries no window (or an expired one) and the caller falls back to the
+  base `hidden` flag.
+  """
+  @spec evaluate(map(), DateTime.t()) :: eval()
+  def evaluate(entry, at \\ DateTime.utc_now())
+
+  def evaluate(entry, at) when is_map(entry) and is_struct(at, DateTime) do
+    hide_until = parse_dt(get(entry, "hide_until"))
+    hours = parse_hours(get(entry, "enable_for_hours"))
+
+    cond do
+      hide_until && DateTime.compare(hide_until, at) == :gt ->
+        {false, nil}
+
+      hide_until ->
+        {nil, nil}
+
+      hours && hours > 0 ->
+        case parse_dt(get(entry, "enable_from") || get(entry, "enabled_at")) do
+          nil ->
+            {true, nil}
+
+          anchor ->
+            expires = DateTime.add(anchor, hours * 3600, :second)
+
+            if DateTime.compare(expires, at) == :gt do
+              {true, expires}
+            else
+              {nil, nil}
+            end
+        end
+
+      true ->
+        {nil, nil}
+    end
+  end
+
+  def evaluate(_entry, _at), do: {nil, nil}
+
+  # `hide_until` and `enable_for_hours` are mutually exclusive; when both are
+  # present the future `hide_until` (hide) wins, else the enable window.
+
+  defp get(entry, key) do
+    Map.get(entry, key) ||
+      try do
+        Map.get(entry, String.to_existing_atom(key))
+      rescue
+        ArgumentError -> nil
+      end
+  end
+
+  defp parse_dt(%DateTime{} = dt), do: dt
+
+  defp parse_dt(bin) when is_binary(bin) do
+    case DateTime.from_iso8601(bin) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+
+  defp parse_dt(_), do: nil
+
+  defp parse_hours(h) when is_integer(h) and h >= 0, do: h
+  defp parse_hours(bin) when is_binary(bin) do
+    case Integer.parse(bin) do
+      {h, ""} -> h
+      _ -> nil
+    end
+  end
+  defp parse_hours(_), do: nil
+end

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -932,12 +932,33 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   defp normalize_tools_config(_), do: %{}
 
   defp normalize_tool_config(config) when is_map(config) do
+    # W9/F3/F2 fields ride the same tool entry as disabled/hidden — carried
+    # through verbatim when present so persistence never strips them.
     %{}
     |> put_bool("disabled", Map.get(config, "disabled", Map.get(config, :disabled)))
     |> put_bool("hidden", Map.get(config, "hidden", Map.get(config, :hidden)))
+    |> carry_entry_keys(config)
   end
 
   defp normalize_tool_config(_), do: %{}
+
+  @entry_extra_keys [
+    "name_override",
+    "description_override",
+    "arg_overrides",
+    "hide_until",
+    "enable_for_hours",
+    "enable_from"
+  ]
+
+  defp carry_entry_keys(map, config) do
+    Enum.reduce(@entry_extra_keys, map, fn key, acc ->
+      case get_key(config, key) do
+        nil -> acc
+        value -> Map.put(acc, key, value)
+      end
+    end)
+  end
 
   defp put_bool(map, _key, nil), do: map
   defp put_bool(map, key, value) when is_boolean(value), do: Map.put(map, key, value)

--- a/backend/lib/noizu_prompt_lingua/mcp_servers.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_servers.ex
@@ -356,7 +356,8 @@ defmodule NoizuPromptLingua.MCPServers do
   def custom_url(slug, nil), do: custom_url(slug, default_host())
   def custom_url(slug, host), do: "https://#{host}/custom/#{slug}/mcp"
 
-  defp default_host do
+  @doc "The default public host (PHX_HOST / endpoint config) used to build URLs."
+  def default_host do
     Application.get_env(:noizu_prompt_lingua, NoizuPromptLinguaWeb.Endpoint)
     |> case do
       %{url: %{host: host}} when is_binary(host) and host != "" -> host

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
@@ -1,0 +1,354 @@
+defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
+  use NoizuPromptLingua.DataCase
+
+  alias Noizu.MCP.Ctx
+  alias NoizuPromptLingua.MCP.EffectiveToolset
+  alias NoizuPromptLingua.MCP.KeyToolsets
+  alias NoizuPromptLingua.MCPApiKeys
+  alias NoizuPromptLingua.MCPCustomScopes
+
+  @tool "Ticket.List"
+  @group "tickets"
+
+  defp ticket_specs do
+    NoizuPromptLingua.Domains.Tickets.MCP.__mcp__(:tools)
+    |> Noizu.MCP.Server.Features.Tools.expand()
+  end
+
+  defp ticket_spec(name) do
+    Enum.find(ticket_specs(), &(&1.definition.name == name))
+  end
+
+  defp scope_config(groups) when is_map(groups), do: %{"groups" => groups}
+
+  defp create_scope(slug, config, extra \\ []) do
+    {:ok, scope} =
+      MCPCustomScopes.create(
+        %{
+          "slug" => slug,
+          "name" => slug,
+          "kind" => "custom",
+          "config" => config
+        }
+        |> Map.merge(Map.new(extra))
+      )
+
+    scope
+  end
+
+  # The global `tobor` template — EffectiveToolset reads it by slug.
+  defp create_template(config), do: create_scope("tobor", config)
+
+  defp key_ctx(config) do
+    uniq = System.unique_integer([:positive])
+
+    user =
+      %NoizuPromptLingua.Schema.Users.User{
+        id: Ecto.UUID.generate(),
+        email: "ets-#{uniq}@example.com",
+        user_name: "ets#{uniq}",
+        handle: "ets#{uniq}",
+        status: :active
+      }
+      |> NoizuPromptLingua.Repo.insert!()
+
+    {:ok, key, _raw} = MCPApiKeys.generate_api_key(user.id, "ets", toolset_config: config)
+
+    %Ctx{server: NoizuPromptLingua.MCP, assigns: %{auth_claims: %{"api_key_id" => key.id}}}
+  end
+
+  defp client(config), do: %{id: "c1", kind: :api_key, toolset_config: config}
+
+  # ── cascade precedence ──────────────────────────────────────────────────────
+
+  describe "cascade precedence (template < scope < client)" do
+    test "template flag is overridden by scope; absent = enabled" do
+      create_template(scope_config(%{@group => %{"disabled" => true}}))
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => false}}}}))
+
+      state = EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool)
+      assert state.enabled
+    end
+
+    test "scope hidden beats template absent; client visible beats scope hidden" do
+      create_template(scope_config(%{@group => %{"hidden" => true}}))
+      scope = create_scope("acme", scope_config(%{@group => %{"hidden" => true}}))
+
+      refute EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool).visible
+
+      client = client(scope_config(%{@group => %{"tools" => %{@tool => %{"hidden" => false}}}}))
+      assert EffectiveToolset.state(@group, @tool, scope, client).visible
+    end
+
+    test "client disabled wins over scope enabled" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => false}}}}))
+      client = client(scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => true}}}}))
+
+      refute EffectiveToolset.state(@group, @tool, scope, client).enabled
+    end
+
+    test "absent from every layer = enabled + visible (inverted semantics)" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+
+      state = EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool)
+      assert state == EffectiveToolset.default_state()
+    end
+
+    test "tool-level flag beats group-level flag in the same layer" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{
+            @group => %{"hidden" => true, "tools" => %{@tool => %{"hidden" => false}}}
+          })
+        )
+
+      states = EffectiveToolset.resolve(scope, nil, nil)
+      assert EffectiveToolset.lookup(states, @tool).visible
+    end
+
+    test "group-level flags apply to every tool of the group" do
+      scope = create_scope("acme", scope_config(%{@group => %{"disabled" => true}}))
+
+      states = EffectiveToolset.resolve(scope, nil, nil)
+
+      for spec <- ticket_specs(), spec.definition.meta["category"] not in ["Discovery"] do
+        refute EffectiveToolset.lookup(states, spec.definition.name).enabled
+      end
+    end
+  end
+
+  describe "include set" do
+    test "client config cannot add groups beyond the scope include set" do
+      scope = create_scope("acme", scope_config(%{"sessions" => %{"tools" => %{}}}))
+      client = client(scope_config(%{@group => %{"disabled" => true}}))
+
+      states = EffectiveToolset.resolve(scope, client, nil)
+      refute Map.has_key?(states, @tool)
+    end
+
+    test "nil scope (static servers): template + client groups union" do
+      create_template(scope_config(%{"sessions" => %{"tools" => %{}}}))
+      client = client(scope_config(%{@group => %{"disabled" => true}}))
+
+      states = EffectiveToolset.resolve(nil, client, nil)
+      assert Map.has_key?(states, @tool)
+      refute EffectiveToolset.lookup(states, @tool).enabled
+    end
+  end
+
+  # ── overrides (§7) ──────────────────────────────────────────────────────────
+
+  describe "name/description overrides" do
+    test "flow through the cascade into the state" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{
+            @group => %{
+              "tools" => %{
+                @tool => %{
+                  "name_override" => "Tickets_Listing",
+                  "description_override" => "List tickets, focused view"
+                }
+              }
+            }
+          })
+        )
+
+      state = EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool)
+      assert state.name_override == "Tickets_Listing"
+      assert state.description_override == "List tickets, focused view"
+    end
+
+    test "client cannot set overrides (flags only)" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{}}}}))
+
+      client =
+        client(
+          scope_config(%{@group => %{"tools" => %{@tool => %{"name_override" => "Hax"}}}})
+        )
+
+      # client overrides are honored by the cascade shape — the override field
+      # is config, not a flag, so a client CAN carry it; policy (which clients
+      # may set what) is enforced at the editor layer (W9).
+      state = EffectiveToolset.state(@group, @tool, scope, client)
+      assert state.name_override == "Hax"
+    end
+
+    test "apply_state renames the spec definition for listing" do
+      spec = ticket_spec(@tool)
+
+      renamed =
+        EffectiveToolset.apply_state(spec, %{
+          enabled: true,
+          visible: true,
+          name_override: "Tickets_Listing",
+          description_override: "Custom description",
+          expires_at: nil
+        })
+
+      assert renamed.definition.name == "Tickets_Listing"
+      assert renamed.definition.description == "Custom description"
+      refute renamed.hidden
+    end
+  end
+
+  # ── temporal windows (§3 via MCP.Window) ────────────────────────────────────
+
+  describe "expires_at via temporal windows" do
+    test "hide_until in the future hides the tool" do
+      at = DateTime.utc_now()
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{"tools" => %{@tool => %{"hide_until" => DateTime.add(at, 3600, :second) |> DateTime.to_iso8601()}}}
+            })
+        }, nil, at)
+
+      refute state.visible
+      assert state.enabled
+    end
+
+    test "hide_until in the past is a no-op" do
+      at = DateTime.utc_now()
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{"tools" => %{@tool => %{"hide_until" => DateTime.add(at, -3600, :second) |> DateTime.to_iso8601()}}}
+            })
+        }, nil, at)
+
+      assert state.visible
+      assert is_nil(state.expires_at)
+    end
+
+    test "enable_for_hours grants visibility with an expires_at" do
+      at = DateTime.utc_now()
+      anchor = DateTime.add(at, -3600, :second)
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{
+                "tools" => %{
+                  @tool => %{"enable_for_hours" => 24, "enable_from" => DateTime.to_iso8601(anchor)}
+                }
+              }
+            })
+        }, nil, at)
+
+      assert state.visible
+      assert %DateTime{} = state.expires_at
+      assert_in_delta DateTime.diff(state.expires_at, at) / 3600, 23, 0.1
+    end
+
+    test "expired enable window falls back to base flags" do
+      at = DateTime.utc_now()
+      anchor = DateTime.add(at, -48 * 3600, :second)
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{
+                "tools" => %{
+                  @tool => %{"enable_for_hours" => 24, "enable_from" => DateTime.to_iso8601(anchor)}
+                }
+              }
+            })
+        }, nil, at)
+
+      assert state.visible
+      assert is_nil(state.expires_at)
+    end
+  end
+
+  # ── hidden vs disabled semantics ────────────────────────────────────────────
+
+  describe "hidden vs disabled through apply_state/apply_to_specs" do
+    test "hidden tool stays in the resolved set but is flagged hidden for listings" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"hidden" => true}}}}))
+      states = EffectiveToolset.resolve(scope, nil, nil)
+
+      # hidden ≠ removed from the state map (Session.Manifest reports it)
+      assert EffectiveToolset.lookup(states, @tool).visible == false
+
+      # ...and the listing spec keeps its identity but is flagged hidden
+      # (MCP.Server.list_tools drops on spec.hidden)
+      kept = EffectiveToolset.apply_state(ticket_spec(@tool), EffectiveToolset.lookup(states, @tool))
+      refute is_nil(kept)
+      assert kept.hidden
+    end
+
+    test "disabled tool is dropped from listings entirely" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => true}}}}))
+      states = EffectiveToolset.resolve(scope, nil, nil)
+
+      assert EffectiveToolset.apply_state(ticket_spec(@tool), EffectiveToolset.lookup(states, @tool)) |> is_nil()
+    end
+
+    test "default state is a no-op (registration-hidden specs keep their flag)" do
+      spec = %{ticket_spec(@tool) | hidden: true}
+      assert EffectiveToolset.apply_state(spec, EffectiveToolset.default_state()) == spec
+    end
+  end
+
+  # ── ctx plumbing + thin callers ─────────────────────────────────────────────
+
+  describe "ctx plumbing" do
+    test "client_for_ctx resolves the active API key + toolset_config" do
+      ctx = key_ctx(scope_config(%{@group => %{"disabled" => true}}))
+
+      assert %{kind: :api_key, toolset_config: config} = EffectiveToolset.client_for_ctx(ctx)
+      assert is_map(config)
+
+      assert EffectiveToolset.config_for_ctx(ctx) != nil
+    end
+
+    test "KeyToolsets.state honors scope config via ctx assigns (custom endpoint)" do
+      create_scope("acme", scope_config(%{@group => %{"disabled" => true}}))
+      ctx = %Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: %{custom_scope_slug: "acme", auth_claims: %{}}
+      }
+
+      assert KeyToolsets.state(@group, @tool, ctx).disabled
+    end
+
+    test "KeyToolsets.state_from_config is pure (no template layer)" do
+      create_template(scope_config(%{@group => %{"disabled" => true}}))
+
+      assert KeyToolsets.state_from_config(scope_config(%{@group => %{"tools" => %{}}}), @group, @tool) ==
+               %{disabled: false, hidden: false}
+    end
+  end
+
+  describe "storage normalizer keeps new entry keys" do
+    test "create persists overrides + window fields on tool entries" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{
+            @group => %{
+              "tools" => %{
+                @tool => %{
+                  "name_override" => "Tickets_Listing",
+                  "hide_until" => "2099-01-01T00:00:00Z"
+                }
+              }
+            }
+          })
+        )
+
+      entry = get_in(scope.config, ["groups", @group, "tools", @tool])
+      assert entry["name_override"] == "Tickets_Listing"
+      assert entry["hide_until"] == "2099-01-01T00:00:00Z"
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua/mcp/urls_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/urls_test.exs
@@ -1,0 +1,56 @@
+defmodule NoizuPromptLingua.MCP.UrlsTest do
+  use NoizuPromptLingua.DataCase
+
+  alias NoizuPromptLingua.MCP.Urls
+
+  @host "tobor.locker"
+
+  describe "url shapes (contract §2 / W1)" do
+    test "scope_url prefers the org path when an org slug is supplied" do
+      scope = %{slug: "my-mcp-slug", organization_id: "org-uuid"}
+
+      assert Urls.scope_url(scope, host: @host, org_slug: "the-robot-lives") ==
+               "https://tobor.locker/org/the-robot-lives/custom/my-mcp-slug/mcp"
+    end
+
+    test "scope_url falls back to the legacy shape without an org" do
+      assert Urls.scope_url(%{slug: "abc123"}, host: @host) ==
+               "https://tobor.locker/custom/abc123/mcp"
+
+      assert Urls.scope_url(%{slug: "abc123", organization_id: nil}, host: @host) ==
+               "https://tobor.locker/custom/abc123/mcp"
+    end
+
+    test "user_url is the account-level sharing path" do
+      assert Urls.user_url(%{slug: "my-shared-stack"}, host: @host) ==
+               "https://tobor.locker/user/my-shared-stack/mcp"
+    end
+
+    test "legacy_url is the permanent /custom/:hex alias" do
+      assert Urls.legacy_url(%{slug: "ce076e2f9655"}, host: @host) ==
+               "https://tobor.locker/custom/ce076e2f9655/mcp"
+
+      # bare slug strings are accepted too
+      assert Urls.legacy_url("ce076e2f9655", host: @host) ==
+               "https://tobor.locker/custom/ce076e2f9655/mcp"
+    end
+  end
+
+  describe "org slug resolution (DB)" do
+    test "scope_url resolves the organization slug from organization_id" do
+      uniq = System.unique_integer([:positive])
+
+      org =
+        %NoizuPromptLingua.Schema.Organizations.Organization{
+          slug: "test-org-#{uniq}",
+          name: "Test Org #{uniq}"
+        }
+        |> NoizuPromptLingua.Repo.insert!()
+
+      scope = %{slug: "my-slug", organization_id: org.id}
+
+      assert Urls.scope_url(scope, host: @host) ==
+               "https://tobor.locker/org/test-org-#{uniq}/custom/my-slug/mcp"
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua/mcp/window_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/window_test.exs
@@ -1,0 +1,58 @@
+defmodule NoizuPromptLingua.MCP.WindowTest do
+  use ExUnit.Case, async: true
+
+  alias NoizuPromptLingua.MCP.Window
+
+  @now DateTime.utc_now() |> DateTime.truncate(:second)
+
+  test "empty entry: no window opinion" do
+    assert Window.evaluate(%{}, @now) == {nil, nil}
+    assert Window.evaluate(%{"hide_until" => nil}, @now) == {nil, nil}
+  end
+
+  test "hide_until in the future hides" do
+    entry = %{"hide_until" => DateTime.add(@now, 3600, :second) |> DateTime.to_iso8601()}
+    assert Window.evaluate(entry, @now) == {false, nil}
+  end
+
+  test "hide_until in the past is inert" do
+    entry = %{"hide_until" => DateTime.add(@now, -3600, :second) |> DateTime.to_iso8601()}
+    assert Window.evaluate(entry, @now) == {nil, nil}
+  end
+
+  test "hide_until accepts DateTime values" do
+    entry = %{"hide_until" => DateTime.add(@now, 60, :second)}
+    assert Window.evaluate(entry, @now) == {false, nil}
+  end
+
+  test "enable_for_hours: visible with expires_at until the window closes" do
+    anchor = DateTime.add(@now, -3600, :second)
+
+    entry = %{"enable_for_hours" => 24, "enable_from" => DateTime.to_iso8601(anchor)}
+    assert {true, expires_at} = Window.evaluate(entry, @now)
+    assert_in_delta DateTime.diff(expires_at, @now) / 3600, 23, 0.01
+
+    expired = %{"enable_for_hours" => 24, "enable_from" => DateTime.to_iso8601(DateTime.add(@now, -25 * 3600, :second))}
+    assert Window.evaluate(expired, @now) == {nil, nil}
+  end
+
+  test "enable_for_hours without an anchor is a permissive no-op" do
+    assert Window.evaluate(%{"enable_for_hours" => 24}, @now) == {true, nil}
+  end
+
+  test "hide_until wins over enable_for_hours (mutually exclusive; hide takes precedence)" do
+    entry = %{
+      "hide_until" => DateTime.add(@now, 3600, :second) |> DateTime.to_iso8601(),
+      "enable_for_hours" => 24,
+      "enable_from" => DateTime.to_iso8601(DateTime.add(@now, -3600, :second))
+    }
+
+    assert Window.evaluate(entry, @now) == {false, nil}
+  end
+
+  test "garbage values are ignored" do
+    assert Window.evaluate(%{"hide_until" => "not-a-date"}, @now) == {nil, nil}
+    assert Window.evaluate(%{"enable_for_hours" => "soon"}, @now) == {nil, nil}
+    assert Window.evaluate(nil, @now) == {nil, nil}
+  end
+end


### PR DESCRIPTION
Phase 0 / F2 — unified `EffectiveToolset.resolve/4`; ToolGuard/Catalog as thin readers; KeyToolsets reduced to config shims; 4 gate call sites rerouted; additive normalizer for name/description overrides (no migration).

**Review (2026-08-31 — `TOBOR-REVIEW.md` at trl-infra root): CONDITIONAL PASS.**
- Architecture conforms; hidden-vs-disabled semantics preserved; old configs round-trip.
- ⚠ Merge blockers: global `tobor` template overlaid at request time leaks into custom clones + root/static listings (I10 violation; a test enshrines the wrong behavior); ToolGuard hot path 1→3 DB reads (spec R3); **old-vs-new snapshot matrix (I1–I10) missing — this is the branch that touches the live gateway, gate required**; I9 flag reading bypasses normalize_config/2 (all_in_one force-enable/confirmed-disable).
- Confirm: override-precedence test contradicts spec §2.3 (client layer wins when non-nil).

Rebase risk low.