### PR TITLE
feat(mcp): F3 temporal windows — Window.evaluate + config-schema validation

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/window.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/window.ex
@@ -1,0 +1,227 @@
+defmodule NoizuPromptLingua.MCP.Window do
+  @moduledoc """
+  F3 temporal windows: time-boxed visibility for tools in scope-config jsonb.
+
+  Fields on a tool entry (see `TOBOR-CONTRACTS.md` §3):
+
+      %{"hide_until" => iso8601_utc | nil,          # hidden until this instant
+        "enable_for_hours" => pos_integer | nil}    # visible for N hours from anchor
+
+  The two are **mutually exclusive** — a tool entry may carry one or neither,
+  never both. Absent fields mean "no window" (tool visibility is governed by the
+  static `hidden`/`disabled` flags per the inverted default-visible semantics).
+
+  Anchoring: `enable_for_hours` needs a start instant; it is stamped at
+  normalize time (when the scope config is written) as `enabled_at` (UTC
+  ISO8601), following the same stamp-on-write precedent as
+  `disabled_confirmed_at` in `NoizuPromptLingua.MCPCustomScopes`. An entry with
+  `enable_for_hours` but no `enabled_at` (hand-edited jsonb) evaluates as an
+  inert window — write-side normalization re-anchors it.
+
+  Naive-vs-UTC: naive datetime inputs (strings without an offset,
+  `NaiveDateTime` structs) are interpreted as **UTC** — the repo-wide split
+  precedent (cf. `chat_message.ex` microsecond/UTC notes,
+  `dashboard.ex` Z-suffixed serialization).
+
+  Evaluation is consumed by `NoizuPromptLingua.MCP.EffectiveToolset` (F2):
+
+      {visible, expires_at} = Window.evaluate(entry, at)
+
+    * `hide_until` in the future → `{false, hide_until}` (hidden; state expires
+      when the hide lifts).
+    * `hide_until` past → `{true, nil}` (window over).
+    * `enable_for_hours` live → `{true, expires_at}` (visible; expires when the
+      window closes).
+    * `enable_for_hours` elapsed → `{true, nil}` (window inert; the entry's
+      static flags govern again — windows expire out, they never permanently
+      flip state).
+  """
+
+  @until_field "hide_until"
+  @hours_field "enable_for_hours"
+  @anchor_field "enabled_at"
+
+  @type window :: %{
+          hide_until: DateTime.t() | nil,
+          enable_for_hours: pos_integer() | nil
+        }
+
+  @doc "Field names as stored in scope-config jsonb."
+  def fields, do: %{until: @until_field, hours: @hours_field, anchor: @anchor_field}
+
+  ## ------------------------------------------------------------------
+  ## Parsing / validation
+  ## ------------------------------------------------------------------
+
+  @doc """
+  Parse the window fields off a config entry (group or tool level).
+
+      {:ok, %{hide_until: dt | nil, enable_for_hours: n | nil}}
+      | {:error, :mutually_exclusive | {:invalid_datetime, field} | {:invalid_hours, msg} | :invalid_entry}
+
+  Accepts atom or string keys; `hide_until` as `DateTime`, `NaiveDateTime`
+  (assumed UTC), or ISO8601 string (naive strings assumed UTC);
+  `enable_for_hours` as a positive integer (zero/negative rejected).
+  """
+  def parse(entry) when is_map(entry) do
+    with {:ok, hide_until} <- parse_until(raw(entry, @until_field)),
+         {:ok, hours} <- parse_hours(raw(entry, @hours_field)) do
+      if hide_until && hours do
+        {:error, :mutually_exclusive}
+      else
+        {:ok, %{hide_until: hide_until, enable_for_hours: hours}}
+      end
+    end
+  end
+
+  def parse(_), do: {:error, :invalid_entry}
+
+  @doc """
+  Changeset-style validation of an entry's window fields. Returns a list of
+  error messages (empty = valid). Mirrors `parse/1` rejections so write paths
+  can surface them per tool entry.
+  """
+  def validate_entry(entry) when is_map(entry) do
+    case parse(entry) do
+      {:ok, _} ->
+        []
+
+      {:error, :mutually_exclusive} ->
+        ["hide_until and enable_for_hours are mutually exclusive"]
+
+      {:error, {:invalid_datetime, field}} ->
+        ["#{field}: invalid datetime (expected ISO8601 UTC)"]
+
+      {:error, {:invalid_hours, msg}} ->
+        ["enable_for_hours: #{msg}"]
+    end
+  end
+
+  def validate_entry(_), do: ["entry must be an object"]
+
+  @doc """
+  Normalize an entry's window fields onto `base` (the normalized tool config
+  being built by `MCPCustomScopes.normalize_tool_config/1`).
+
+    * valid `hide_until` → stored as ISO8601 UTC string.
+    * valid `enable_for_hours` → stored as integer, with `enabled_at` anchored
+      to the existing anchor (re-parsed) or stamped `DateTime.utc_now()`.
+    * invalid values (unparseable datetime, zero/negative/non-integer hours,
+      mutually-exclusive pair) are dropped — same silent-drop policy as the
+      boolean flag normalizers; strict rejection happens at the changeset.
+  """
+  def normalize_entry(base, config) when is_map(base) and is_map(config) do
+    case parse(config) do
+      {:ok, %{hide_until: %DateTime{} = until}} ->
+        Map.put(base, @until_field, DateTime.to_iso8601(until))
+
+      {:ok, %{enable_for_hours: hours}} when is_integer(hours) ->
+        anchor = parse_until(raw(config, @anchor_field)) |> elem(1)
+        anchor = anchor || DateTime.utc_now()
+
+        base
+        |> Map.put(@hours_field, hours)
+        |> Map.put(@anchor_field, DateTime.to_iso8601(anchor))
+
+      _ ->
+        base
+    end
+  end
+
+  def normalize_entry(base, _), do: base
+
+  ## ------------------------------------------------------------------
+  ## Evaluation
+  ## ------------------------------------------------------------------
+
+  @doc "Evaluate at now (convenience)."
+  def evaluate(entry), do: evaluate(entry, DateTime.utc_now())
+
+  @doc """
+  Evaluate the window for a config entry at instant `at`.
+
+      Window.evaluate(entry, at) :: {visible :: boolean, expires_at :: DateTime.t() | nil}
+
+  `expires_at` is the instant the reported visibility stops holding (a
+  re-evaluation hint for `EffectiveToolset`, not a hard flip). Entries without
+  a window (or with an inert/unanchored one) evaluate `{true, nil}` — the
+  inverted default-visible semantics.
+  """
+  def evaluate(entry, at)
+
+  def evaluate(entry, %DateTime{} = at) when is_map(entry) do
+    case parse(entry) do
+      {:ok, %{hide_until: %DateTime{} = until}} ->
+        hidden? = DateTime.compare(at, until) == :lt
+        {not hidden?, if(hidden?, do: until, else: nil)}
+
+      {:ok, %{enable_for_hours: hours}} when is_integer(hours) ->
+        case parse_until(raw(entry, @anchor_field)) do
+          {:ok, %DateTime{} = enabled_at} ->
+            expires = DateTime.add(enabled_at, hours * 3600, :second)
+
+            if DateTime.compare(at, expires) == :lt do
+              {true, expires}
+            else
+              # Window elapsed → inert: static flags govern again.
+              {true, nil}
+            end
+
+          _ ->
+            # Unanchored window is inert — cannot have elapsed, cannot govern.
+            {true, nil}
+        end
+
+      _ ->
+        {true, nil}
+    end
+  end
+
+  # Naive `at` is treated as UTC (repo naive-vs-UTC precedent).
+  def evaluate(entry, %NaiveDateTime{} = at) do
+    evaluate(entry, DateTime.from_naive!(at, "Etc/UTC"))
+  end
+
+  def evaluate(_, _), do: {true, nil}
+
+  ## ------------------------------------------------------------------
+  ## Internals
+  ## ------------------------------------------------------------------
+
+  defp raw(entry, key) when is_binary(key) do
+    Map.get(entry, key) || Map.get(entry, String.to_atom(key))
+  end
+
+  defp parse_until(nil), do: {:ok, nil}
+
+  defp parse_until(%DateTime{} = dt), do: {:ok, dt}
+
+  defp parse_until(%NaiveDateTime{} = ndt),
+    do: {:ok, DateTime.from_naive!(ndt, "Etc/UTC")}
+
+  defp parse_until(bin) when is_binary(bin) do
+    case DateTime.from_iso8601(bin) do
+      {:ok, dt, _offset} ->
+        {:ok, dt}
+
+      {:error, _} ->
+        # No offset → naive ISO8601; assume UTC per repo precedent.
+        case NaiveDateTime.from_iso8601(bin) do
+          {:ok, ndt} -> {:ok, DateTime.from_naive!(ndt, "Etc/UTC")}
+          {:error, _} -> {:error, {:invalid_datetime, @until_field}}
+        end
+    end
+  end
+
+  defp parse_until(_), do: {:error, {:invalid_datetime, @until_field}}
+
+  defp parse_hours(nil), do: {:ok, nil}
+  defp parse_hours(h) when is_integer(h) and h > 0, do: {:ok, h}
+  defp parse_hours(0), do: {:error, {:invalid_hours, "must be a positive integer (got 0)"}}
+
+  defp parse_hours(h) when is_integer(h),
+    do: {:error, {:invalid_hours, "must be a positive integer (got #{h})"}}
+
+  defp parse_hours(_),
+    do: {:error, {:invalid_hours, "must be a positive integer"}}
+end

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -18,6 +18,7 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
 
   alias NoizuPromptLingua.Repo
   alias NoizuPromptLingua.Schema.MCPCustomScope
+  alias NoizuPromptLingua.MCP.Window
   alias NoizuPromptLingua.MCPServers
   alias NoizuPromptLingua.Tools.Catalog
 
@@ -935,6 +936,9 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
     %{}
     |> put_bool("disabled", Map.get(config, "disabled", Map.get(config, :disabled)))
     |> put_bool("hidden", Map.get(config, "hidden", Map.get(config, :hidden)))
+    # F3 temporal windows (hide_until / enable_for_hours); invalid values are
+    # dropped here — strict rejection lives on the scope changeset.
+    |> Window.normalize_entry(config)
   end
 
   defp normalize_tool_config(_), do: %{}

--- a/backend/lib/noizu_prompt_lingua/schema/mcp_custom_scope.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/mcp_custom_scope.ex
@@ -15,6 +15,8 @@ defmodule NoizuPromptLingua.Schema.MCPCustomScope do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias NoizuPromptLingua.MCP.Window
+
   @kinds ~w(custom all_in_one core_variant)
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -69,6 +71,37 @@ defmodule NoizuPromptLingua.Schema.MCPCustomScope do
     |> String.downcase()
   end
 
-  defp validate_config(:config, value) when is_map(value), do: []
+  defp validate_config(:config, value) when is_map(value) do
+    validate_window_entries(value)
+  end
+
   defp validate_config(:config, _), do: [config: "must be an object"]
+
+  # F3 temporal windows: every tool entry in the config jsonb is validated via
+  # `NoizuPromptLingua.MCP.Window.validate_entry/1` (mutual exclusion of
+  # hide_until/enable_for_hours, datetime + positive-integer shape). Errors are
+  # keyed to the offending entry path.
+  defp validate_window_entries(config) do
+    groups = Map.get(config, "groups") || Map.get(config, :groups) || %{}
+
+    if is_map(groups) do
+      Enum.flat_map(groups, fn {group_id, group_cfg} ->
+        tools = group_tools(group_cfg)
+
+        Enum.flat_map(tools, fn {tool_name, tool_cfg} ->
+          tool_cfg
+          |> Kernel.||(%{})
+          |> Window.validate_entry()
+          |> Enum.map(&{:config, "groups.#{group_id}.tools.#{tool_name}: #{&1}"})
+        end)
+      end)
+    else
+      []
+    end
+  end
+
+  defp group_tools(group_cfg) when is_map(group_cfg),
+    do: Map.get(group_cfg, "tools") || Map.get(group_cfg, :tools) || %{}
+
+  defp group_tools(_), do: %{}
 end

--- a/backend/test/noizu_prompt_lingua/mcp/window_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/window_test.exs
@@ -1,0 +1,334 @@
+defmodule NoizuPromptLingua.MCP.WindowTest do
+  use ExUnit.Case, async: true
+
+  alias NoizuPromptLingua.MCP.Window
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.Schema.MCPCustomScope
+
+  @now ~U[2026-08-31 12:00:00Z]
+  @future ~U[2026-09-07 12:00:00Z]
+  @past ~U[2026-08-24 12:00:00Z]
+
+  # ------------------------------------------------------------------
+  # parse/1
+  # ------------------------------------------------------------------
+
+  describe "parse/1" do
+    test "no window fields parses to nils" do
+      assert {:ok, %{hide_until: nil, enable_for_hours: nil}} = Window.parse(%{})
+      assert {:ok, %{hide_until: nil, enable_for_hours: nil}} =
+               Window.parse(%{"disabled" => true, "hidden" => false})
+    end
+
+    test "hide_until accepts DateTime" do
+      assert {:ok, %{hide_until: hide_until, enable_for_hours: nil}} =
+               Window.parse(%{"hide_until" => @future})
+
+      assert hide_until == @future
+    end
+
+    test "hide_until accepts NaiveDateTime (assumed UTC)" do
+      assert {:ok, %{hide_until: hide_until}} =
+               Window.parse(%{"hide_until" => DateTime.to_naive(@future)})
+
+      assert hide_until == @future
+    end
+
+    test "hide_until accepts ISO8601 with offset" do
+      assert {:ok, %{hide_until: %DateTime{}}} =
+               Window.parse(%{"hide_until" => "2026-09-07T12:00:00Z"})
+    end
+
+    test "hide_until accepts naive ISO8601 string (assumed UTC)" do
+      assert {:ok, %{hide_until: %DateTime{time_zone: "Etc/UTC"}}} =
+               Window.parse(%{"hide_until" => "2026-09-07T12:00:00"})
+    end
+
+    test "hide_until rejects non-datetime values" do
+      assert {:error, {:invalid_datetime, "hide_until"}} =
+               Window.parse(%{"hide_until" => "tomorrow"})
+
+      assert {:error, {:invalid_datetime, "hide_until"}} = Window.parse(%{"hide_until" => 123})
+    end
+
+    test "enable_for_hours accepts positive integers" do
+      assert {:ok, %{hide_until: nil, enable_for_hours: 24}} =
+               Window.parse(%{"enable_for_hours" => 24})
+    end
+
+    test "enable_for_hours=0 is rejected" do
+      assert {:error, {:invalid_hours, _}} = Window.parse(%{"enable_for_hours" => 0})
+    end
+
+    test "negative / non-integer enable_for_hours rejected" do
+      assert {:error, {:invalid_hours, _}} = Window.parse(%{"enable_for_hours" => -1})
+      assert {:error, {:invalid_hours, _}} = Window.parse(%{"enable_for_hours" => "24"})
+      assert {:error, {:invalid_hours, _}} = Window.parse(%{"enable_for_hours" => 1.5})
+    end
+
+    test "both fields set is rejected (mutually exclusive)" do
+      assert {:error, :mutually_exclusive} =
+               Window.parse(%{"hide_until" => @future, "enable_for_hours" => 24})
+    end
+
+    test "atom keys accepted" do
+      assert {:ok, %{enable_for_hours: 24}} =
+               Window.parse(%{hide_until: nil, enable_for_hours: 24})
+    end
+
+    test "non-map input rejected" do
+      assert {:error, :invalid_entry} = Window.parse("nope")
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # validate_entry/1
+  # ------------------------------------------------------------------
+
+  describe "validate_entry/1" do
+    test "valid entries yield no errors" do
+      assert [] = Window.validate_entry(%{})
+      assert [] = Window.validate_entry(%{"hide_until" => "2026-09-07T12:00:00Z"})
+      assert [] = Window.validate_entry(%{"enable_for_hours" => 1})
+    end
+
+    test "mutually exclusive pair yields an error message" do
+      assert [msg] = Window.validate_entry(%{"hide_until" => @future, "enable_for_hours" => 24})
+      assert msg =~ "mutually exclusive"
+    end
+
+    test "past hide_until is structurally valid (expiry is evaluation, not validation)" do
+      assert [] = Window.validate_entry(%{"hide_until" => @past})
+    end
+
+    test "zero hours yields an error message" do
+      assert [msg] = Window.validate_entry(%{"enable_for_hours" => 0})
+      assert msg =~ "positive integer"
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # evaluate/2
+  # ------------------------------------------------------------------
+
+  describe "evaluate/2 — hide_until" do
+    test "future hide_until is hidden until the instant" do
+      assert {false, expires_at} = Window.evaluate(%{"hide_until" => @future}, @now)
+      assert expires_at == @future
+    end
+
+    test "past hide_until is visible with no expiry" do
+      assert {true, nil} = Window.evaluate(%{"hide_until" => @past}, @now)
+    end
+
+    test "exactly at hide_until becomes visible" do
+      assert {true, nil} = Window.evaluate(%{"hide_until" => @now}, @now)
+    end
+
+    test "no window is visible with no expiry" do
+      assert {true, nil} = Window.evaluate(%{}, @now)
+      assert {true, nil} = Window.evaluate(%{"hidden" => true}, @now)
+    end
+
+    test "string hide_until evaluates like a parsed datetime" do
+      assert {false, %DateTime{}} =
+               Window.evaluate(%{"hide_until" => "2026-09-07T12:00:00Z"}, @now)
+    end
+  end
+
+  describe "evaluate/2 — enable_for_hours" do
+    test "live window is visible and reports its expiry" do
+      entry = %{"enable_for_hours" => 24, "enabled_at" => "2026-08-31T00:00:00Z"}
+      expires = ~U[2026-09-01 00:00:00Z]
+
+      assert {true, ^expires} = Window.evaluate(entry, @now)
+    end
+
+    test "elapsed window is inert: visible, no expiry" do
+      entry = %{"enable_for_hours" => 24, "enabled_at" => "2026-08-29T00:00:00Z"}
+      assert {true, nil} = Window.evaluate(entry, @now)
+    end
+
+    test "boundary: exactly at expiry the window has elapsed" do
+      entry = %{"enable_for_hours" => 12, "enabled_at" => "2026-08-31T00:00:00Z"}
+      assert {true, nil} = Window.evaluate(entry, ~U[2026-08-31 12:00:00Z])
+    end
+
+    test "unanchored window is inert" do
+      assert {true, nil} = Window.evaluate(%{"enable_for_hours" => 24}, @now)
+    end
+
+    test "naive at is treated as UTC" do
+      entry = %{"enable_for_hours" => 1, "enabled_at" => "2026-08-31T00:00:00Z"}
+
+      assert {true, %DateTime{time_zone: "Etc/UTC"}} =
+               Window.evaluate(entry, ~N[2026-08-31 00:30:00])
+    end
+
+    test "garbage input evaluates visible (inverted semantics)" do
+      assert {true, nil} = Window.evaluate(nil, @now)
+      assert {true, nil} = Window.evaluate(%{"enable_for_hours" => "x"}, @now)
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # normalize_entry/2
+  # ------------------------------------------------------------------
+
+  describe "normalize_entry/2" do
+    test "carries hide_until as ISO8601 UTC string" do
+      base = %{"disabled" => true}
+
+      normalized = Window.normalize_entry(base, %{"hide_until" => @future})
+      assert normalized["hide_until"] == "2026-09-07T12:00:00Z"
+      assert normalized["disabled"] == true
+      refute Map.has_key?(normalized, "enable_for_hours")
+    end
+
+    test "stamps enabled_at when anchoring enable_for_hours" do
+      normalized = Window.normalize_entry(%{}, %{"enable_for_hours" => 24})
+
+      assert normalized["enable_for_hours"] == 24
+      assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(normalized["enabled_at"])
+
+      # anchor is fresh (stamped now)
+      stamped = DateTime.from_iso8601(normalized["enabled_at"]) |> elem(1)
+      assert DateTime.diff(DateTime.utc_now(), stamped) < 5
+    end
+
+    test "keeps an existing anchor (re-normalize does not slide the window)" do
+      config = %{
+        "enable_for_hours" => 24,
+        "enabled_at" => "2026-08-30T00:00:00Z"
+      }
+
+      normalized = Window.normalize_entry(%{}, config)
+      assert normalized["enabled_at"] == "2026-08-30T00:00:00Z"
+    end
+
+    test "drops invalid values silently (strict rejection lives on the changeset)" do
+      assert Window.normalize_entry(%{}, %{"hide_until" => "someday"}) == %{}
+      assert Window.normalize_entry(%{}, %{"enable_for_hours" => 0}) == %{}
+      assert Window.normalize_entry(%{}, %{"hide_until" => @future, "enable_for_hours" => 24}) == %{}
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Config-schema integration
+  # ------------------------------------------------------------------
+
+  describe "MCPCustomScopes.normalize_config/2 window carry-through" do
+    test "window fields survive normalization on a tool entry" do
+      config = %{
+        "groups" => %{
+          "sessions" => %{
+            "tools" => %{
+              "Session_Create" => %{"hidden" => true, "hide_until" => "2026-09-07T12:00:00Z"}
+            }
+          }
+        }
+      }
+
+      normalized = MCPCustomScopes.normalize_config(config, "custom")
+      tool = normalized["groups"]["sessions"]["tools"]["Session_Create"]
+
+      assert tool["hidden"] == true
+      assert tool["hide_until"] == "2026-09-07T12:00:00Z"
+    end
+
+    test "enable_for_hours gains an anchor through normalization" do
+      config = %{
+        "groups" => %{
+          "sessions" => %{"tools" => %{"Session_List" => %{"enable_for_hours" => 48}}}
+        }
+      }
+
+      tool = MCPCustomScopes.normalize_config(config, "custom")["groups"]["sessions"]["tools"]["Session_List"]
+      assert tool["enable_for_hours"] == 48
+      assert is_binary(tool["enabled_at"])
+    end
+
+    test "evaluates end-to-end after normalization round-trip" do
+      config = %{
+        "groups" => %{
+          "sessions" => %{"tools" => %{"Session_Create" => %{"hide_until" => "2026-09-07T12:00:00Z"}}}
+        }
+      }
+
+      tool = MCPCustomScopes.normalize_config(config, "custom")["groups"]["sessions"]["tools"]["Session_Create"]
+      assert {false, %DateTime{}} = Window.evaluate(tool, @now)
+      assert {true, nil} = Window.evaluate(tool, ~U[2026-09-08 12:00:00Z])
+    end
+  end
+
+  describe "MCPCustomScope.changeset/2 window validation" do
+    defp config_changeset(config) do
+      MCPCustomScope.changeset(%MCPCustomScope{}, %{
+        "slug" => "win-test",
+        "name" => "win test",
+        "config" => config
+      })
+    end
+
+    test "valid window config passes" do
+      cs =
+        config_changeset(%{
+          "groups" => %{
+            "sessions" => %{
+              "tools" => %{
+                "Session_Create" => %{"hide_until" => "2026-09-07T12:00:00Z"},
+                "Session_List" => %{"enable_for_hours" => 24}
+              }
+            }
+          }
+        })
+
+      refute cs.errors[:config]
+    end
+
+    test "mutually exclusive pair on a tool entry is rejected with the entry path" do
+      cs =
+        config_changeset(%{
+          "groups" => %{
+            "sessions" => %{
+              "tools" => %{
+                "Session_Create" => %{"hide_until" => "2026-09-07T12:00:00Z", "enable_for_hours" => 24}
+              }
+            }
+          }
+        })
+
+      assert [{:config, {msg, _}}] = cs.errors
+      assert msg =~ "groups.sessions.tools.Session_Create"
+      assert msg =~ "mutually exclusive"
+    end
+
+    test "zero enable_for_hours is rejected with the entry path" do
+      cs =
+        config_changeset(%{
+          "groups" => %{
+            "projects" => %{"tools" => %{"Project_List" => %{"enable_for_hours" => 0}}}
+          }
+        })
+
+      assert [{:config, {msg, _}}] = cs.errors
+      assert msg =~ "groups.projects.tools.Project_List"
+      assert msg =~ "positive integer"
+    end
+
+    test "invalid hide_until value is rejected" do
+      cs =
+        config_changeset(%{
+          "groups" => %{"sessions" => %{"tools" => %{"Session_List" => %{"hide_until" => 42}}}}
+        })
+
+      assert [{:config, {msg, _}}] = cs.errors
+      assert msg =~ "invalid datetime"
+    end
+
+    test "non-map config still rejected" do
+      cs = config_changeset("bogus")
+      assert cs.errors[:config]
+    end
+  end
+end


### PR DESCRIPTION
Phase 0 / F3 — time-boxed tool overrides (hide_until / enable_for_hours) in scope/toolset config jsonb, 30+ boundary tests.

**Review (2026-08-31 — `TOBOR-REVIEW.md` at trl-infra root): NON-COMPLIANT + 1 CRASH.**
- Implements per-entry fields (TOBOR-CONTRACTS §3), not the windows-array spec — contract ruling needed; simpler shape may be ratified if wiring lands.
- ⚠ CRASH: `mcp/window.ex` normalize_entry/2 — malformed `enabled_at` anchor → `elem/1` error tuple is truthy → `DateTime.to_iso8601(tuple)` raises on every subsequent config write. Fix under any contract.
- ⚠ Integration not wired: Window consumed nowhere except the scope normalizer; key_toolsets/ToolGuard enforcement absent; F2 hook shape mismatch ({visible, expires_at} vs {:delta, delta, expires_at}); enable_* never lifts disabled.
- No >7d prune, no set_at (anchor never resets on re-set).

Rebase risk low.