### PR TITLE
feat(frontend): add shared ui-kit components (F4)

### DIFF
--- a/frontend/src/components/kit/acl-editor.tsx
+++ b/frontend/src/components/kit/acl-editor.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { useState } from 'react';
+import { TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { kitBtnSm, kitFieldLabel, kitInput } from './shared';
+
+/**
+ * ACL shapes bind against the F1 acl-core contract: subject and resource are
+ * opaque ERP ref strings (`{:ref, Type, id}` serialized), effect is allow/deny,
+ * scope is a free-form string supplied by the host. This component knows
+ * nothing about backend code — the host owns persistence.
+ */
+
+export type AclEffect = 'allow' | 'deny';
+
+export interface AclRule {
+  /** Client-side id (host-assigned or generated). */
+  id: string;
+  /** Opaque ERP ref string, e.g. subject user/org/group ref. */
+  subject: string;
+  /** Opaque ERP ref string for the protected entity. */
+  resource: string;
+  effect: AclEffect;
+  /** Permission scope label (e.g. "read", "write", "admin"). */
+  scope: string;
+}
+
+export interface AclGroup {
+  id: string;
+  name: string;
+  /** Member subject refs (opaque ERP ref strings). */
+  members: string[];
+}
+
+export interface AclState {
+  rules: AclRule[];
+  groups: AclGroup[];
+}
+
+interface ACLEditorProps {
+  value: AclState;
+  onChange: (next: AclState) => void;
+  /** Suggested subject refs for datalist autocomplete. */
+  subjectSuggestions?: string[];
+  /** Suggested resource refs for datalist autocomplete. */
+  resourceSuggestions?: string[];
+  /** Allowed scope labels (free-form when omitted). */
+  scopeOptions?: string[];
+  readOnly?: boolean;
+}
+
+let seq = 0;
+function localId() {
+  seq += 1;
+  return `acl-${Date.now()}-${seq}`;
+}
+
+/**
+ * Grant/deny rule editor with named permission groups. Pure controlled
+ * component: emits the full next state via onChange; never mutates props.
+ * Accessible: labeled inputs, datalist suggestions, aria-labels on icon buttons.
+ */
+export default function ACLEditor({
+  value,
+  onChange,
+  subjectSuggestions = [],
+  resourceSuggestions = [],
+  scopeOptions = [],
+  readOnly = false,
+}: ACLEditorProps) {
+  const { rules, groups } = value;
+  const [newGroupMembers, setNewGroupMembers] = useState<Record<string, string>>({});
+
+  function updateRules(next: AclRule[]) {
+    onChange({ rules: next, groups });
+  }
+
+  function updateGroups(next: AclGroup[]) {
+    onChange({ rules, groups: next });
+  }
+
+  function addRule() {
+    updateRules([
+      ...rules,
+      { id: localId(), subject: '', resource: '', effect: 'allow', scope: scopeOptions[0] ?? 'read' },
+    ]);
+  }
+
+  function patchRule(id: string, patch: Partial<AclRule>) {
+    updateRules(rules.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      {/* Rules */}
+      <section aria-label="ACL rules">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+          <h4 style={{ margin: 0, fontSize: 12, fontWeight: 600, color: 'var(--text-0)' }}>Rules</h4>
+          {!readOnly ? (
+            <button type="button" onClick={addRule} style={kitBtnSm}>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <PlusIcon style={{ width: 12, height: 12 }} aria-hidden="true" /> Add rule
+              </span>
+            </button>
+          ) : null}
+        </div>
+        {rules.length === 0 ? (
+          <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0 }}>No rules — access falls through to defaults.</p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {rules.map((rule, idx) => (
+              <div
+                key={rule.id}
+                role="group"
+                aria-label={`Rule ${idx + 1}`}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto 1fr 1fr auto 1fr auto',
+                  gap: 6,
+                  alignItems: 'end',
+                  padding: 8,
+                  borderRadius: 6,
+                  background: 'var(--bg-3)',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                <div>
+                  <label htmlFor={`acl-effect-${rule.id}`} style={kitFieldLabel}>Effect</label>
+                  <select
+                    id={`acl-effect-${rule.id}`}
+                    value={rule.effect}
+                    disabled={readOnly}
+                    onChange={(e) => patchRule(rule.id, { effect: e.target.value as AclEffect })}
+                    style={{
+                      ...kitInput,
+                      color: rule.effect === 'deny' ? 'var(--red, #ef4444)' : 'var(--green, #22c55e)',
+                      fontWeight: 600,
+                    }}
+                  >
+                    <option value="allow">allow</option>
+                    <option value="deny">deny</option>
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor={`acl-subject-${rule.id}`} style={kitFieldLabel}>Subject ref</label>
+                  <input
+                    id={`acl-subject-${rule.id}`}
+                    list="acl-subject-suggestions"
+                    value={rule.subject}
+                    readOnly={readOnly}
+                    placeholder="user/org/group ref"
+                    onChange={(e) => patchRule(rule.id, { subject: e.target.value })}
+                    style={{ ...kitInput, width: '100%', fontFamily: 'monospace' }}
+                  />
+                </div>
+                <div>
+                  <label htmlFor={`acl-resource-${rule.id}`} style={kitFieldLabel}>Resource ref</label>
+                  <input
+                    id={`acl-resource-${rule.id}`}
+                    list="acl-resource-suggestions"
+                    value={rule.resource}
+                    readOnly={readOnly}
+                    placeholder="entity ref"
+                    onChange={(e) => patchRule(rule.id, { resource: e.target.value })}
+                    style={{ ...kitInput, width: '100%', fontFamily: 'monospace' }}
+                  />
+                </div>
+                <div>
+                  <label htmlFor={`acl-scope-${rule.id}`} style={kitFieldLabel}>Scope</label>
+                  {scopeOptions.length > 0 ? (
+                    <select
+                      id={`acl-scope-${rule.id}`}
+                      value={rule.scope}
+                      disabled={readOnly}
+                      onChange={(e) => patchRule(rule.id, { scope: e.target.value })}
+                      style={{ ...kitInput, width: '100%' }}
+                    >
+                      {scopeOptions.map((s) => (
+                        <option key={s} value={s}>{s}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      id={`acl-scope-${rule.id}`}
+                      value={rule.scope}
+                      readOnly={readOnly}
+                      onChange={(e) => patchRule(rule.id, { scope: e.target.value })}
+                      style={{ ...kitInput, width: '100%' }}
+                    />
+                  )}
+                </div>
+                <span style={{ fontSize: 10, color: 'var(--text-3)', paddingBottom: 6 }}>
+                  {rule.effect === 'deny' ? 'blocks' : 'grants'} access
+                </span>
+                {!readOnly ? (
+                  <button
+                    type="button"
+                    onClick={() => updateRules(rules.filter((r) => r.id !== rule.id))}
+                    style={{ ...kitBtnSm, border: 0, background: 'transparent', color: 'var(--red, #ef4444)', paddingBottom: 4 }}
+                    aria-label={`Delete rule ${idx + 1}`}
+                  >
+                    <TrashIcon style={{ width: 14, height: 14 }} aria-hidden="true" />
+                  </button>
+                ) : (
+                  <span />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        <datalist id="acl-subject-suggestions">
+          {subjectSuggestions.map((s) => <option key={s} value={s} />)}
+        </datalist>
+        <datalist id="acl-resource-suggestions">
+          {resourceSuggestions.map((s) => <option key={s} value={s} />)}
+        </datalist>
+      </section>
+
+      {/* Groups */}
+      <section aria-label="Permission groups">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+          <h4 style={{ margin: 0, fontSize: 12, fontWeight: 600, color: 'var(--text-0)' }}>Permission groups</h4>
+          {!readOnly ? (
+            <button
+              type="button"
+              onClick={() => updateGroups([...groups, { id: localId(), name: `group-${groups.length + 1}`, members: [] }])}
+              style={kitBtnSm}
+            >
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                <PlusIcon style={{ width: 12, height: 12 }} aria-hidden="true" /> Add group
+              </span>
+            </button>
+          ) : null}
+        </div>
+        {groups.length === 0 ? (
+          <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0 }}>No groups defined.</p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {groups.map((group, gIdx) => (
+              <div
+                key={group.id}
+                style={{
+                  padding: 10,
+                  borderRadius: 6,
+                  background: 'var(--bg-3)',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 8 }}>
+                  <label htmlFor={`acl-group-name-${group.id}`} style={{ ...kitFieldLabel, marginBottom: 0 }}>
+                    Name
+                  </label>
+                  <input
+                    id={`acl-group-name-${group.id}`}
+                    value={group.name}
+                    readOnly={readOnly}
+                    onChange={(e) =>
+                      updateGroups(groups.map((g) => (g.id === group.id ? { ...g, name: e.target.value } : g)))
+                    }
+                    style={{ ...kitInput, flex: 1 }}
+                  />
+                  {!readOnly ? (
+                    <button
+                      type="button"
+                      onClick={() => updateGroups(groups.filter((g) => g.id !== group.id))}
+                      style={{ ...kitBtnSm, border: 0, background: 'transparent', color: 'var(--red, #ef4444)' }}
+                      aria-label={`Delete group ${group.name}`}
+                    >
+                      <TrashIcon style={{ width: 14, height: 14 }} aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 6 }}>
+                  {group.members.length === 0 ? (
+                    <span style={{ fontSize: 11, color: 'var(--text-3)' }}>No members.</span>
+                  ) : (
+                    group.members.map((m, mIdx) => (
+                      <span
+                        key={m}
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 4,
+                          fontSize: 10,
+                          fontFamily: 'monospace',
+                          padding: '2px 6px',
+                          borderRadius: 999,
+                          background: 'var(--accent-dim, var(--bg-2))',
+                          border: '1px solid var(--border)',
+                          color: 'var(--text-1)',
+                        }}
+                      >
+                        {m}
+                        {!readOnly ? (
+                          <button
+                            type="button"
+                            aria-label={`Remove member ${m} from group ${group.name}`}
+                            onClick={() =>
+                              updateGroups(
+                                groups.map((g) =>
+                                  g.id === group.id
+                                    ? { ...g, members: g.members.filter((_, i) => i !== mIdx) }
+                                    : g,
+                                ),
+                              )
+                            }
+                            style={{ border: 0, background: 'transparent', cursor: 'pointer', color: 'var(--text-3)', padding: 0 }}
+                          >
+                            ✕
+                          </button>
+                        ) : null}
+                      </span>
+                    ))
+                  )}
+                </div>
+                {!readOnly ? (
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <input
+                      value={newGroupMembers[group.id] ?? ''}
+                      placeholder="add member ref…"
+                      aria-label={`Add member to group ${group.name}`}
+                      onChange={(e) => setNewGroupMembers((prev) => ({ ...prev, [group.id]: e.target.value }))}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          const member = (newGroupMembers[group.id] ?? '').trim();
+                          if (!member) return;
+                          updateGroups(
+                            groups.map((g) =>
+                              g.id === group.id && !g.members.includes(member)
+                                ? { ...g, members: [...g.members, member] }
+                                : g,
+                            ),
+                          );
+                          setNewGroupMembers((prev) => ({ ...prev, [group.id]: '' }));
+                        }
+                      }}
+                      style={{ ...kitInput, flex: 1, fontFamily: 'monospace' }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const member = (newGroupMembers[group.id] ?? '').trim();
+                        if (!member) return;
+                        updateGroups(
+                          groups.map((g) =>
+                            g.id === group.id && !g.members.includes(member)
+                              ? { ...g, members: [...g.members, member] }
+                              : g,
+                          ),
+                        );
+                        setNewGroupMembers((prev) => ({ ...prev, [group.id]: '' }));
+                      }}
+                      style={kitBtnSm}
+                    >
+                      Add
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/kit/context-menu.tsx
+++ b/frontend/src/components/kit/context-menu.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { kitMenuSurface, kitMenuItem } from './shared';
+
+export interface ContextMenuItem {
+  /** Stable id passed back via onSelect. */
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  shortcut?: string;
+  destructive?: boolean;
+  disabled?: boolean;
+  /** Render a separator above this item. */
+  separatorBefore?: boolean;
+  /** Nested items shown on hover/focus. */
+  submenu?: ContextMenuItem[];
+}
+
+interface ContextMenuProps {
+  /** Menu definition. Rebuilt per invocation is fine. */
+  items: ContextMenuItem[];
+  /** Fired with the id of the activated (non-disabled) item. */
+  onSelect: (id: string) => void;
+  /** Fired when the menu is dismissed without selection. */
+  onClose?: () => void;
+  /** Wrapped content; right-clicking it opens the menu. */
+  children: ReactNode;
+  /** Disable the context menu entirely (children still render). */
+  disabled?: boolean;
+  /** Accessible label for the menu. */
+  menuLabel?: string;
+}
+
+/**
+ * Right-click context menu. Wrap any content; the menu opens at the cursor,
+ * supports icons, destructive styling, disabled items, separators, shortcuts,
+ * and one level of submenu. Keyboard: arrows navigate, Enter/Space activate,
+ * Right opens a submenu, Esc / click-outside dismisses.
+ */
+export default function ContextMenu({
+  items,
+  onSelect,
+  onClose,
+  children,
+  disabled = false,
+  menuLabel = 'Context menu',
+}: ContextMenuProps) {
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const [openSubmenuIdx, setOpenSubmenuIdx] = useState<number | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const menuId = useId();
+
+  const isOpen = pos !== null;
+
+  const close = useCallback(() => {
+    setPos(null);
+    setActiveIdx(-1);
+    setOpenSubmenuIdx(null);
+    onClose?.();
+  }, [onClose]);
+
+  // Clamp the open menu inside the viewport.
+  useEffect(() => {
+    if (!isOpen || !menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    if (rect.right > window.innerWidth || rect.bottom > window.innerHeight) {
+      setPos((p) => p && {
+        x: Math.max(4, Math.min(p.x, window.innerWidth - rect.width - 4)),
+        y: Math.max(4, Math.min(p.y, window.innerHeight - rect.height - 4)),
+      });
+    }
+  }, [isOpen]);
+
+  // Dismiss on outside click / scroll / Esc handled in keydown below.
+  useEffect(() => {
+    if (!isOpen) return;
+    function onPointerDown(e: PointerEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) close();
+    }
+    function onScrollOrBlur() {
+      close();
+    }
+    window.addEventListener('pointerdown', onPointerDown, true);
+    window.addEventListener('resize', onScrollOrBlur);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown, true);
+      window.removeEventListener('resize', onScrollOrBlur);
+    };
+  }, [isOpen, close]);
+
+  // Focus the menu when it opens so keyboard nav works immediately.
+  useEffect(() => {
+    if (isOpen) menuRef.current?.focus();
+  }, [isOpen]);
+
+  function openAt(x: number, y: number) {
+    setPos({ x, y });
+    setActiveIdx(firstEnabledIndex(items));
+    setOpenSubmenuIdx(null);
+  }
+
+  function activate(item: ContextMenuItem) {
+    if (item.disabled || item.submenu?.length) return;
+    onSelect(item.id);
+    close();
+  }
+
+  function onKeyDown(e: ReactKeyboardEvent) {
+    if (!isOpen) return;
+    const flat = items;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const dir = e.key === 'ArrowDown' ? 1 : -1;
+      let idx = activeIdx;
+      for (let i = 0; i < flat.length; i++) {
+        idx = (idx + dir + flat.length) % flat.length;
+        if (!flat[idx].disabled) break;
+      }
+      setActiveIdx(idx);
+      setOpenSubmenuIdx(null);
+      return;
+    }
+    if (e.key === 'ArrowRight') {
+      const item = flat[activeIdx];
+      if (item?.submenu?.length) {
+        e.preventDefault();
+        setOpenSubmenuIdx(activeIdx);
+      }
+      return;
+    }
+    if (e.key === 'ArrowLeft' && openSubmenuIdx !== null) {
+      e.preventDefault();
+      setOpenSubmenuIdx(null);
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      const item = flat[activeIdx];
+      if (item) activate(item);
+    }
+  }
+
+  return (
+    <div
+      onContextMenu={(e) => {
+        if (disabled) return;
+        e.preventDefault();
+        openAt(e.clientX, e.clientY);
+      }}
+    >
+      {children}
+      {isOpen && (
+        <div
+          ref={menuRef}
+          id={menuId}
+          role="menu"
+          aria-label={menuLabel}
+          tabIndex={-1}
+          onKeyDown={onKeyDown}
+          style={{
+            position: 'fixed',
+            left: pos.x,
+            top: pos.y,
+            outline: 'none',
+            ...kitMenuSurface,
+          }}
+        >
+          {items.map((item, idx) => (
+            <div key={item.id} style={{ position: 'relative' }}>
+              {item.separatorBefore && (
+                <div role="separator" style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
+              )}
+              <button
+                type="button"
+                role="menuitem"
+                aria-disabled={item.disabled || undefined}
+                aria-haspopup={item.submenu?.length ? 'menu' : undefined}
+                aria-expanded={item.submenu?.length ? openSubmenuIdx === idx : undefined}
+                style={{
+                  ...kitMenuItem({ destructive: item.destructive, disabled: item.disabled }),
+                  ...(activeIdx === idx && !item.disabled
+                    ? { background: 'var(--accent-dim, var(--bg-3))' }
+                    : {}),
+                }}
+                onMouseEnter={() => {
+                  setActiveIdx(idx);
+                  setOpenSubmenuIdx(item.submenu?.length ? idx : null);
+                }}
+                onClick={() => activate(item)}
+              >
+                {item.icon ? <span aria-hidden="true" style={{ display: 'inline-flex', width: 16 }}>{item.icon}</span> : null}
+                <span style={{ flex: 1 }}>{item.label}</span>
+                {item.shortcut ? (
+                  <span style={{ fontSize: 10, color: 'var(--text-3)' }}>{item.shortcut}</span>
+                ) : null}
+                {item.submenu?.length ? (
+                  <span aria-hidden="true" style={{ fontSize: 10, color: 'var(--text-3)' }}>▸</span>
+                ) : null}
+              </button>
+              {item.submenu?.length && openSubmenuIdx === idx ? (
+                <div
+                  role="menu"
+                  aria-label={item.label}
+                  style={{
+                    position: 'absolute',
+                    left: '100%',
+                    top: 0,
+                    ...kitMenuSurface,
+                    zIndex: 1001,
+                  }}
+                >
+                  {item.submenu.map((sub) => (
+                    <button
+                      key={sub.id}
+                      type="button"
+                      role="menuitem"
+                      aria-disabled={sub.disabled || undefined}
+                      style={kitMenuItem({ destructive: sub.destructive, disabled: sub.disabled })}
+                      onClick={() => activate(sub)}
+                    >
+                      {sub.icon ? <span aria-hidden="true" style={{ display: 'inline-flex', width: 16 }}>{sub.icon}</span> : null}
+                      <span style={{ flex: 1 }}>{sub.label}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function firstEnabledIndex(items: ContextMenuItem[]): number {
+  const idx = items.findIndex((i) => !i.disabled);
+  return idx === -1 ? 0 : idx;
+}

--- a/frontend/src/components/kit/index.ts
+++ b/frontend/src/components/kit/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared UI kit (F4) — generic, reusable, typed frontend components for the
+ * tobor.locker MCP overhaul. Consumers: W3 (TabbedPopunder), W6/W7
+ * (ContextMenu, SlideOverSidebar, ACLEditor, ToolTogglesGrid,
+ * TempWindowEditor). All components are pure/controlled and bind against
+ * plain data shapes — no backend imports.
+ */
+export { default as ContextMenu } from './context-menu';
+export type { ContextMenuItem } from './context-menu';
+
+export { default as SlideOverSidebar } from './slideover-sidebar';
+export type { SlideOverTab } from './slideover-sidebar';
+
+export { default as ACLEditor } from './acl-editor';
+export type { AclEffect, AclRule, AclGroup, AclState } from './acl-editor';
+
+export { default as ToolTogglesGrid } from './tool-toggles-grid';
+export type { ToolToggleEntry, ToolToggleGroup } from './tool-toggles-grid';
+
+export { default as TempWindowEditor } from './temp-window-editor';
+export type { TempWindow } from './temp-window-editor';
+
+export { default as TabbedPopunder } from './tabbed-popunder';
+export type { TabbedPopunderTab } from './tabbed-popunder';

--- a/frontend/src/components/kit/shared.ts
+++ b/frontend/src/components/kit/shared.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+
+/**
+ * Shared style primitives for the ui-kit components.
+ * Matches the repo convention of CSS-variable inline styling
+ * (see components/mcp-setup-panel.tsx).
+ */
+
+export const kitBtnSm: CSSProperties = {
+  padding: '4px 10px',
+  fontSize: 11,
+  borderRadius: 4,
+  border: '1px solid var(--border)',
+  background: 'var(--bg-2)',
+  color: 'var(--text-1)',
+  cursor: 'pointer',
+  fontFamily: 'var(--font)',
+};
+
+export const kitBtnDanger: CSSProperties = {
+  ...kitBtnSm,
+  borderColor: 'var(--red, #b91c1c)',
+  color: 'var(--red, #b91c1c)',
+};
+
+export const kitInput: CSSProperties = {
+  padding: '4px 8px',
+  fontSize: 12,
+  borderRadius: 4,
+  border: '1px solid var(--border)',
+  background: 'var(--bg-3)',
+  color: 'var(--text-1)',
+  fontFamily: 'var(--font)',
+};
+
+export const kitFieldLabel: CSSProperties = {
+  display: 'block',
+  fontSize: 10,
+  fontWeight: 600,
+  color: 'var(--text-3)',
+  marginBottom: 2,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+};
+
+export const kitMenuSurface: CSSProperties = {
+  background: 'var(--bg-2)',
+  border: '1px solid var(--border)',
+  borderRadius: 6,
+  boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+  padding: 4,
+  minWidth: 180,
+  zIndex: 1000,
+};
+
+export const kitMenuItem = (opts: { destructive?: boolean; disabled?: boolean }): CSSProperties => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  width: '100%',
+  padding: '6px 10px',
+  fontSize: 12,
+  border: 0,
+  borderRadius: 4,
+  textAlign: 'left',
+  cursor: opts.disabled ? 'default' : 'pointer',
+  fontFamily: 'var(--font)',
+  background: 'transparent',
+  color: opts.disabled
+    ? 'var(--text-3)'
+    : opts.destructive
+      ? 'var(--red, #ef4444)'
+      : 'var(--text-1)',
+  opacity: opts.disabled ? 0.55 : 1,
+});

--- a/frontend/src/components/kit/slideover-sidebar.tsx
+++ b/frontend/src/components/kit/slideover-sidebar.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
+import { Fragment, useState, type ReactNode } from 'react';
+import { kitBtnSm } from './shared';
+
+export interface SlideOverTab {
+  id: string;
+  label: string;
+  content: ReactNode;
+}
+
+interface SlideOverSidebarProps {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  /** Tabs to render in the sidebar header; each tab swaps the body content. */
+  tabs?: SlideOverTab[];
+  /** Controlled active tab id (pair with onTabChange). */
+  activeTab?: string;
+  /** Uncontrolled initial tab when activeTab is not provided. */
+  initialTabId?: string;
+  onTabChange?: (id: string) => void;
+  /** Sidebar width in px (default 420). */
+  width?: number;
+  /** Which edge the panel slides in from (default right). */
+  side?: 'left' | 'right';
+  /** Extra footer content (e.g. Save/Cancel). */
+  footer?: ReactNode;
+}
+
+/**
+ * Slide-over sidebar panel with optional tabbed content. Built on Headless UI
+ * Dialog for overlay, ESC-close, click-outside and focus trapping. Tab state
+ * works controlled (activeTab + onTabChange) or uncontrolled (initialTabId).
+ *
+ * Intended host: scope settings ("Edit Scope" / "Manage Clients" tabs).
+ */
+export default function SlideOverSidebar({
+  open,
+  onClose,
+  title,
+  tabs = [],
+  activeTab,
+  initialTabId,
+  onTabChange,
+  width = 420,
+  side = 'right',
+  footer,
+}: SlideOverSidebarProps) {
+  const [internalTab, setInternalTab] = useState<string | null>(initialTabId ?? tabs[0]?.id ?? null);
+  const currentTabId = activeTab ?? internalTab;
+  const activeTabDef = tabs.find((t) => t.id === currentTabId) ?? tabs[0] ?? null;
+
+  function selectTab(id: string) {
+    if (activeTab === undefined) setInternalTab(id);
+    onTabChange?.(id);
+  }
+
+  return (
+    <Transition show={open} as={Fragment}>
+      <Dialog onClose={onClose} className="relative z-[900]">
+        {/* Overlay */}
+        <TransitionChild
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div
+            style={{
+              position: 'fixed',
+              inset: 0,
+              background: 'rgba(0,0,0,0.5)',
+            }}
+            aria-hidden="true"
+          />
+        </TransitionChild>
+
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            display: 'flex',
+            justifyContent: side === 'right' ? 'flex-end' : 'flex-start',
+            pointerEvents: 'none',
+          }}
+        >
+          <TransitionChild
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom={side === 'right' ? 'translate-x-full' : '-translate-x-full'}
+            enterTo="translate-x-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="translate-x-0"
+            leaveTo={side === 'right' ? 'translate-x-full' : '-translate-x-full'}
+          >
+            <DialogPanel
+              style={{
+                pointerEvents: 'auto',
+                width,
+                maxWidth: '100vw',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                background: 'var(--bg-2)',
+                borderLeft: side === 'right' ? '1px solid var(--border)' : undefined,
+                borderRight: side === 'left' ? '1px solid var(--border)' : undefined,
+                boxShadow: '0 0 32px rgba(0,0,0,0.4)',
+              }}
+            >
+              {/* Header */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                  padding: '12px 16px',
+                  borderBottom: '1px solid var(--border)',
+                }}
+              >
+                {title ? (
+                  <DialogTitle style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--text-0)' }}>
+                    {title}
+                  </DialogTitle>
+                ) : (
+                  <span />
+                )}
+                <button type="button" onClick={onClose} style={kitBtnSm} aria-label="Close sidebar">
+                  ✕
+                </button>
+              </div>
+
+              {/* Tabs */}
+              {tabs.length > 0 ? (
+                <div
+                  role="tablist"
+                  aria-label="Sidebar sections"
+                  style={{
+                    display: 'flex',
+                    borderBottom: '1px solid var(--border)',
+                    background: 'var(--bg-3)',
+                  }}
+                >
+                  {tabs.map((t) => {
+                    const selected = activeTabDef?.id === t.id;
+                    return (
+                      <button
+                        key={t.id}
+                        type="button"
+                        role="tab"
+                        id={`slideover-tab-${t.id}`}
+                        aria-selected={selected}
+                        aria-controls={`slideover-panel-${t.id}`}
+                        onClick={() => selectTab(t.id)}
+                        style={{
+                          flex: 1,
+                          padding: '8px 12px',
+                          fontSize: 12,
+                          fontWeight: selected ? 600 : 400,
+                          border: 0,
+                          borderBottom: `2px solid ${selected ? 'var(--accent)' : 'transparent'}`,
+                          background: 'transparent',
+                          color: selected ? 'var(--text-0)' : 'var(--text-2)',
+                          cursor: 'pointer',
+                          fontFamily: 'var(--font)',
+                        }}
+                      >
+                        {t.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : null}
+
+              {/* Body */}
+              <div
+                role="tabpanel"
+                id={activeTabDef ? `slideover-panel-${activeTabDef.id}` : undefined}
+                aria-labelledby={activeTabDef ? `slideover-tab-${activeTabDef.id}` : undefined}
+                style={{
+                  flex: 1,
+                  overflowY: 'auto',
+                  padding: 16,
+                }}
+              >
+                {activeTabDef ? activeTabDef.content : null}
+              </div>
+
+              {/* Footer */}
+              {footer ? (
+                <div
+                  style={{
+                    padding: '10px 16px',
+                    borderTop: '1px solid var(--border)',
+                    background: 'var(--bg-3)',
+                  }}
+                >
+                  {footer}
+                </div>
+              ) : null}
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/kit/tabbed-popunder.tsx
+++ b/frontend/src/components/kit/tabbed-popunder.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
+import { Fragment, useState, type ReactNode } from 'react';
+
+export interface TabbedPopunderTab {
+  id: string;
+  label: string;
+  /** Renders the tab body. Called only for the active tab. */
+  render: () => ReactNode;
+}
+
+interface TabbedPopunderProps {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  /** Tab config — label + render pairs (e.g. claude cli / grok / codex / opencode). */
+  tabs: TabbedPopunderTab[];
+  /** Controlled active tab id (pair with onTabChange). */
+  activeTab?: string;
+  /** Uncontrolled initial tab when activeTab is not provided. */
+  initialTabId?: string;
+  onTabChange?: (id: string) => void;
+  /** Max panel width in px (default 640). */
+  maxWidth?: number;
+}
+
+/**
+ * Modal "popunder" with a config-driven tab selector — a centered dialog with
+ * overlay, ESC-close, click-outside and focus trapping (Headless UI Dialog).
+ * Tab state works controlled (activeTab + onTabChange) or uncontrolled.
+ *
+ * Intended host: "Setup MCP" per-CLI instructions (W3).
+ */
+export default function TabbedPopunder({
+  open,
+  onClose,
+  title,
+  tabs,
+  activeTab,
+  initialTabId,
+  onTabChange,
+  maxWidth = 640,
+}: TabbedPopunderProps) {
+  const [internalTab, setInternalTab] = useState<string | null>(initialTabId ?? tabs[0]?.id ?? null);
+  const currentTabId = activeTab ?? internalTab;
+  const activeTabDef = tabs.find((t) => t.id === currentTabId) ?? tabs[0] ?? null;
+
+  function selectTab(id: string) {
+    if (activeTab === undefined) setInternalTab(id);
+    onTabChange?.(id);
+  }
+
+  return (
+    <Transition show={open} as={Fragment}>
+      <Dialog onClose={onClose} className="relative z-[900]">
+        <TransitionChild
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div
+            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)' }}
+            aria-hidden="true"
+          />
+        </TransitionChild>
+
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'center',
+            padding: '8vh 16px 16px',
+            pointerEvents: 'none',
+          }}
+        >
+          <TransitionChild
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-2"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-2"
+          >
+            <DialogPanel
+              style={{
+                pointerEvents: 'auto',
+                width: '100%',
+                maxWidth,
+                maxHeight: '84vh',
+                display: 'flex',
+                flexDirection: 'column',
+                background: 'var(--bg-2)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-md)',
+                boxShadow: '0 16px 48px rgba(0,0,0,0.45)',
+              }}
+            >
+              {/* Header */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                  padding: '12px 16px',
+                  borderBottom: '1px solid var(--border)',
+                }}
+              >
+                {title ? (
+                  <DialogTitle style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--text-0)' }}>
+                    {title}
+                  </DialogTitle>
+                ) : (
+                  <span />
+                )}
+                <button
+                  type="button"
+                  onClick={onClose}
+                  aria-label="Close dialog"
+                  style={{
+                    padding: '2px 8px',
+                    fontSize: 12,
+                    borderRadius: 4,
+                    border: '1px solid var(--border)',
+                    background: 'transparent',
+                    color: 'var(--text-2)',
+                    cursor: 'pointer',
+                    fontFamily: 'var(--font)',
+                  }}
+                >
+                  ✕
+                </button>
+              </div>
+
+              {/* Tab bar */}
+              <div
+                role="tablist"
+                aria-label="Sections"
+                style={{
+                  display: 'flex',
+                  gap: 4,
+                  padding: '8px 12px 0',
+                  borderBottom: '1px solid var(--border)',
+                  background: 'var(--bg-3)',
+                  overflowX: 'auto',
+                }}
+              >
+                {tabs.map((t) => {
+                  const selected = activeTabDef?.id === t.id;
+                  return (
+                    <button
+                      key={t.id}
+                      type="button"
+                      role="tab"
+                      id={`popunder-tab-${t.id}`}
+                      aria-selected={selected}
+                      aria-controls={`popunder-panel-${t.id}`}
+                      onClick={() => selectTab(t.id)}
+                      style={{
+                        padding: '7px 12px',
+                        fontSize: 12,
+                        fontWeight: selected ? 600 : 400,
+                        border: 0,
+                        borderBottom: `2px solid ${selected ? 'var(--accent)' : 'transparent'}`,
+                        background: 'transparent',
+                        color: selected ? 'var(--text-0)' : 'var(--text-2)',
+                        cursor: 'pointer',
+                        fontFamily: 'var(--font)',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {t.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Body */}
+              <div
+                role="tabpanel"
+                id={activeTabDef ? `popunder-panel-${activeTabDef.id}` : undefined}
+                aria-labelledby={activeTabDef ? `popunder-tab-${activeTabDef.id}` : undefined}
+                style={{ flex: 1, overflowY: 'auto', padding: 16 }}
+              >
+                {activeTabDef ? activeTabDef.render() : null}
+              </div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/kit/temp-window-editor.tsx
+++ b/frontend/src/components/kit/temp-window-editor.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { kitBtnSm, kitFieldLabel, kitInput } from './shared';
+
+export interface TempWindow {
+  /** ISO 8601 datetime; tool stays hidden until this instant (F3 field). */
+  hide_until: string | null;
+  /** Hours from apply-time the tool is enabled; null = no timed enable. */
+  enable_for_hours: number | null;
+}
+
+interface TempWindowEditorProps {
+  value: TempWindow;
+  onChange: (next: TempWindow) => void;
+  readOnly?: boolean;
+}
+
+type Mode = 'none' | 'hide_until' | 'enable_for';
+
+function modeOf(v: TempWindow): Mode {
+  if (v.hide_until) return 'hide_until';
+  if (v.enable_for_hours !== null) return 'enable_for';
+  return 'none';
+}
+
+/**
+ * Editor for time-boxed tool visibility (binds the F3 temporal-windows shape:
+ * `hide_until` + `enable_for_hours`). Presets for common windows plus custom
+ * datetime/hours entry. The two windows are mutually exclusive — applying one
+ * clears the other, mirroring the F3 evaluation semantics (hide_until wins
+ * until it lapses, then enable_for_hours takes over).
+ */
+export default function TempWindowEditor({ value, onChange, readOnly = false }: TempWindowEditorProps) {
+  const mode = modeOf(value);
+
+  function setMode(next: Mode) {
+    if (next === 'none') {
+      onChange({ hide_until: null, enable_for_hours: null });
+    } else if (next === 'hide_until') {
+      // Default to 24h out, expressed in the user's local input format.
+      const d = new Date(Date.now() + 24 * 3600 * 1000);
+      onChange({ hide_until: toLocalInput(d), enable_for_hours: null });
+    } else {
+      onChange({ hide_until: null, enable_for_hours: 24 });
+    }
+  }
+
+  const summary = describe(value);
+
+  return (
+    <fieldset
+      disabled={readOnly}
+      style={{
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        padding: 12,
+        margin: 0,
+        background: 'var(--bg-3)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <legend style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-0)', padding: '0 4px' }}>
+        Time-boxed visibility
+      </legend>
+
+      <div role="radiogroup" aria-label="Visibility window mode" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+        {(
+          [
+            { id: 'none' as const, label: 'Always visible' },
+            { id: 'hide_until' as const, label: 'Hide until…' },
+            { id: 'enable_for' as const, label: 'Enable for…' },
+          ]
+        ).map((opt) => (
+          <button
+            key={opt.id}
+            type="button"
+            role="radio"
+            aria-checked={mode === opt.id}
+            onClick={() => setMode(opt.id)}
+            style={{
+              ...kitBtnSm,
+              ...(mode === opt.id
+                ? { background: 'var(--accent)', color: 'white', borderColor: 'var(--accent)' }
+                : {}),
+            }}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {mode === 'hide_until' ? (
+        <div>
+          <label htmlFor="temp-window-hide-until" style={kitFieldLabel}>Hidden until</label>
+          <input
+            id="temp-window-hide-until"
+            type="datetime-local"
+            value={value.hide_until ? toLocalInput(new Date(value.hide_until)) : ''}
+            onChange={(e) => onChange({ ...value, hide_until: e.target.value ? new Date(e.target.value).toISOString() : null })}
+            style={{ ...kitInput, width: '100%' }}
+          />
+          <div style={{ display: 'flex', gap: 6, marginTop: 6, flexWrap: 'wrap' }}>
+            {HIDE_PRESETS.map((p) => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => onChange({ ...value, hide_until: new Date(Date.now() + p.ms).toISOString() })}
+                style={kitBtnSm}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {mode === 'enable_for' ? (
+        <div>
+          <label htmlFor="temp-window-enable-hours" style={kitFieldLabel}>Enabled for (hours)</label>
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input
+              id="temp-window-enable-hours"
+              type="number"
+              min={1}
+              step={1}
+              value={value.enable_for_hours ?? ''}
+              onChange={(e) => {
+                const n = e.target.value === '' ? null : Math.max(1, Math.floor(Number(e.target.value)));
+                onChange({ ...value, enable_for_hours: Number.isNaN(n as number) ? null : n });
+              }}
+              style={{ ...kitInput, width: 90 }}
+            />
+            {[1, 8, 24, 72].map((h) => (
+              <button
+                key={h}
+                type="button"
+                onClick={() => onChange({ ...value, enable_for_hours: h })}
+                style={kitBtnSm}
+              >
+                {h}h
+              </button>
+            ))}
+          </div>
+          <p style={{ fontSize: 10, color: 'var(--text-3)', margin: '6px 0 0' }}>
+            The tool becomes visible/enabled when applied and auto-hides once the window lapses.
+          </p>
+        </div>
+      ) : null}
+
+      {mode !== 'none' ? (
+        <p style={{ fontSize: 10, color: 'var(--text-2)', margin: 0 }} aria-live="polite">
+          {summary}
+        </p>
+      ) : null}
+    </fieldset>
+  );
+}
+
+const HIDE_PRESETS: { label: string; ms: number }[] = [
+  { label: '1h', ms: 3600 * 1000 },
+  { label: 'Until tomorrow', ms: 24 * 3600 * 1000 },
+  { label: '1 week', ms: 7 * 24 * 3600 * 1000 },
+  { label: '30 days', ms: 30 * 24 * 3600 * 1000 },
+];
+
+/** ISO datetime → value accepted by <input type="datetime-local"> (local time). */
+function toLocalInput(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function describe(v: TempWindow): string {
+  if (v.hide_until) {
+    return `Hidden until ${new Date(v.hide_until).toLocaleString()}.`;
+  }
+  if (v.enable_for_hours !== null) {
+    return `Enabled for the next ${v.enable_for_hours}h after saving, then hidden.`;
+  }
+  return 'No time window.';
+}

--- a/frontend/src/components/kit/tool-toggles-grid.tsx
+++ b/frontend/src/components/kit/tool-toggles-grid.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+export interface ToolToggleEntry {
+  name: string;
+  enabled: boolean;
+  hidden: boolean;
+}
+
+export interface ToolToggleGroup {
+  group: string;
+  tools: ToolToggleEntry[];
+}
+
+interface ToolTogglesGridProps {
+  groups: ToolToggleGroup[];
+  /** Emits the full next state (pure controlled component). */
+  onChange: (next: ToolToggleGroup[]) => void;
+  readOnly?: boolean;
+}
+
+/**
+ * Grid of grouped tool entries with per-tool enabled/hidden toggles and
+ * group-level toggles that cascade to every child tool. Pure controlled
+ * component — the host owns persistence.
+ *
+ * Semantics match the tobor.locker toolset model: `enabled` gates execution,
+ * `hidden` gates discovery (visible vs hidden in list_tools).
+ */
+export default function ToolTogglesGrid({ groups, onChange, readOnly = false }: ToolTogglesGridProps) {
+  function patchTool(groupName: string, toolName: string, patch: Partial<ToolToggleEntry>) {
+    onChange(
+      groups.map((g) =>
+        g.group !== groupName
+          ? g
+          : { ...g, tools: g.tools.map((t) => (t.name === toolName ? { ...t, ...patch } : t)) },
+      ),
+    );
+  }
+
+  function cascade(group: ToolToggleGroup, patch: (t: ToolToggleEntry) => Partial<ToolToggleEntry>) {
+    onChange(
+      groups.map((g) =>
+        g.group !== group.group
+          ? g
+          : { ...g, tools: g.tools.map((t) => ({ ...t, ...patch(t) })) },
+      ),
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }} role="group" aria-label="Tool toggles">
+      {groups.map((group) => {
+        const allEnabled = group.tools.length > 0 && group.tools.every((t) => t.enabled);
+        const allHidden = group.tools.length > 0 && group.tools.every((t) => t.hidden);
+        return (
+          <section
+            key={group.group}
+            aria-label={`Tool group ${group.group}`}
+            style={{
+              borderRadius: 6,
+              border: '1px solid var(--border)',
+              background: 'var(--bg-3)',
+              overflow: 'hidden',
+            }}
+          >
+            {/* Group header with cascading toggles */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '8px 12px',
+                borderBottom: '1px solid var(--border)',
+                background: 'var(--bg-2)',
+              }}
+            >
+              <span style={{ fontSize: 12, fontWeight: 600, flex: 1, color: 'var(--text-0)' }}>
+                {group.group}
+                <span style={{ fontWeight: 400, fontSize: 10, color: 'var(--text-3)', marginLeft: 6 }}>
+                  {group.tools.filter((t) => t.enabled).length}/{group.tools.length} enabled
+                </span>
+              </span>
+              <Toggle
+                id={`ttg-${group.group}-enabled`}
+                label="Enabled"
+                checked={allEnabled}
+                disabled={readOnly}
+                onChange={(v) => cascade(group, () => ({ enabled: v }))}
+              />
+              <Toggle
+                id={`ttg-${group.group}-hidden`}
+                label="Hidden"
+                checked={allHidden}
+                disabled={readOnly}
+                onChange={(v) => cascade(group, () => ({ hidden: v }))}
+              />
+            </div>
+
+            {/* Tool rows */}
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+                gap: 6,
+                padding: 10,
+              }}
+            >
+              {group.tools.map((tool) => (
+                <div
+                  key={tool.name}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    padding: '6px 10px',
+                    borderRadius: 4,
+                    background: 'var(--bg-2)',
+                    border: '1px solid var(--border)',
+                    opacity: tool.enabled ? 1 : 0.6,
+                  }}
+                >
+                  <span
+                    title={tool.name}
+                    style={{
+                      flex: 1,
+                      fontSize: 11,
+                      fontFamily: 'monospace',
+                      color: tool.enabled ? 'var(--text-0)' : 'var(--text-3)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {tool.name}
+                  </span>
+                  <Toggle
+                    id={`ttg-${group.group}-${tool.name}-enabled`}
+                    label="On"
+                    checked={tool.enabled}
+                    disabled={readOnly}
+                    onChange={(v) => patchTool(group.group, tool.name, { enabled: v })}
+                  />
+                  <Toggle
+                    id={`ttg-${group.group}-${tool.name}-hidden`}
+                    label="Hide"
+                    checked={tool.hidden}
+                    disabled={readOnly}
+                    onChange={(v) => patchTool(group.group, tool.name, { hidden: v })}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function Toggle({
+  id,
+  label,
+  checked,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label
+      htmlFor={id}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        fontSize: 10,
+        color: 'var(--text-2)',
+        cursor: disabled ? 'default' : 'pointer',
+        userSelect: 'none',
+      }}
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        style={{ accentColor: 'var(--accent)', margin: 0 }}
+      />
+      {label}
+    </label>
+  );
+}


### PR DESCRIPTION
Phase 0 / F4 — context menu, slide-over sidebar w/ tabs, ACL editor, tool-toggles grid, temp-window editor (+ unspecced TabbedPopunder/shared.ts for W3). Transport-free components; all 5 present and functional.

**Review (2026-08-31 — `TOBOR-REVIEW.md` at trl-infra root): OFF-SPEC CONTRACTS.**
- `types/tool-state.ts` (shared EntityRef/AclRule/EffectiveToolState) absent — F1/F2 contract binding never happened; Grid/ACLEditor use ad-hoc shapes. Needs the F1 ref-shape ruling, then retype.
- ⚠ A11y regressions vs RowMenu contract it extracts: Esc doesn't restore trigger focus, no Home/End, Tab doesn't dismiss, no scroll dismiss, submenu items keyboard-unreachable.
- ⚠ TempWindowEditor emits naive local datetime on mode-select (must be ISO before onChange); no maxHours clamp; duplicate DOM/datalist ids across instances.
- Styling is inline (repo rule: semantic BEM via styleguide CSS); no contract tests.

Rebase risk low (net-new files only).