### PR TITLE
feat(mcp): F5 underscore tool names — canonical `_` separator, dotted = alias

### DIFF
--- a/INTEGRATION-NOTES.md
+++ b/INTEGRATION-NOTES.md
@@ -1,0 +1,72 @@
+# INTEGRATION-NOTES.md — F5 underscore-names (branch feat/underscore-names)
+
+Contract: staging/TOBOR-CONTRACTS.md §4 (naming) + §2 (EffectiveToolset keyed by
+canonical underscore name — consumed as-is by F2).
+
+## What F5 changed (backend)
+
+| File | Change |
+|------|--------|
+| `backend/lib/noizu_prompt_lingua/mcp/tool_names.ex` | NEW. `canonical/1`, `alias?/1`, `dotted/1`, `canonical_spec/1`, `canonical_specs/1`. Canonical = underscore; dotted = alias. |
+| `backend/lib/noizu_prompt_lingua/mcp/server.ex` | `list_tools/3` normalizes specs to canonical names BEFORE hidden/disabled filtering + pagination — the wire `tools/list` payload never contains dots. |
+| `backend/lib/noizu_prompt_lingua/mcp/dispatch.ex` | Name matching via `ToolNames.canonical/1` both sides; matched spec canonicalized so ToolGuard + KeyToolsets + error text see the underscore name. Dotted dispatch works. |
+| `backend/lib/noizu_prompt_lingua/tools/catalog.ex` | `resolve_alias/1` now canonicalizes (was identity); `build/2` emits canonical names; `call_hidden_tool/4` canonicalizes specs before find — ToolCall hidden dispatch accepts dotted input. |
+| `backend/lib/noizu_prompt_lingua/tools/tool_summary.ex` | `get_tool` resolves alias before catalog match. |
+| `backend/lib/noizu_prompt_lingua/tools/tool_search.ex` | text search canonicalizes query so dotted queries match canonical names. |
+| `backend/lib/noizu_prompt_lingua/tools/tool_call.ex` | description + `tool` arg description document underscore canonical form; dotted accepted. |
+| `backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex` | `state_from_config` + `overlay_tools` probe tool keys in BOTH spellings (legacy dotted configs keep working against canonical lookups and vice versa). MINIMAL touch only — F2 is restructuring this module; reconcile at merge. |
+| `backend/lib/noizu_prompt_lingua/mcp/custom.ex` | `group_specs` config lookups probe both spellings via new `tool_config_entry/2`. MINIMAL touch only — F2 restructures; reconcile at merge. |
+
+## Key design facts for integrators
+
+1. **Tool declarations stay dotted** (27 `use Noizu.MCP.Server.Tool` modules, e.g.
+   `name: "Session.Create"`). The dotted registry name is the ALIAS SOURCE;
+   canonicalization happens at the emission/dispatch seam, not per-module. Do not
+   mass-rename tool modules at integration.
+2. **DB config jsonb keys** (`mcp_custom_scopes.config`, `mcp_api_keys.toolset_config`)
+   may hold either spelling; both are accepted at lookup. Existing dotted keys need
+   no migration. W9/W2 should WRITE canonical underscore keys going forward
+   (contract §7: overrides keyed by canonical name).
+3. `Catalog.specs/2` intentionally returns RAW specs (dotted names) — it is the
+   registry view (`Custom.catalog_specs/1` likewise). Canonical emission is in
+   `Catalog.build/2` + `Server.list_tools/3` + `Dispatch.call/4`.
+
+## F5's contract surface for later branches
+
+- W5 Session.Manifest: tool names in the manifest payload MUST be canonical
+  (`ToolNames.canonical/1` on whatever EffectiveToolset returns — contract §2
+  already keys resolve/2 by canonical name, so pass-through).
+- W9 name_override: overrides apply AFTER canonicalization; `name_override` value
+  is emitted verbatim (author may pick any legal name), lookups still canonical.
+- W8 per-client list_tools: route through `Server.list_tools/3` or re-apply
+  `ToolNames.canonical_specs/1` after client-specific filtering.
+
+## Tests
+
+- NEW `backend/test/noizu_prompt_lingua/mcp/tool_names_test.exs` — mapping table
+  (canonical/alias?), spec canonicalization, list_tools emits underscore-only,
+  dispatch normalization (dotted ≡ canonical, unknown-tool still errors, dotted
+  config keys honored).
+- Updated emission assertions in `custom_key_toolset_test.exs` +
+  `custom_scope_test.exs` (listing/discovery now canonical; dotted input proven
+  still accepted at ToolDefinition/ToolHelp).
+- Gate: `mix test test/noizu_prompt_lingua/mcp test/noizu_prompt_lingua/tools`
+  → 115 + 3 passed (2026-08-31, this worktree).
+
+## Submodule doc updates done
+
+- `docs/arch/mcp-tools.md` — all tool-name tables swept to underscore; naming
+  note added at top. (This was the only NPL-repo doc referencing dotted names.)
+
+## Monorepo-level doc updates NEEDED (NOT done here — outside worktree)
+
+Verified by grep 2026-08-31. Dotted NPL tool names ARE present:
+
+1. `/Users/keithbrings/Work/Space/Noizu/CLAUDE.md` line ~30 — `ToolCall(tool: "Session.Create", arguments: {` in the FIRST-ACTION session-registration snippet → change to `"Session_Create"`.
+2. `/Users/keithbrings/Work/Space/Noizu/AGENTS.md` line ~35 — same snippet, same change.
+3. `Portfolio/skills/` (skills submodule — sweep to underscore form):
+   - `foreman/` (12 files), `team-member/` (6), `persona-session/` (6), `qa-engineer/` (2), `agentic-project-manager/` (2), `prompt-optimizer/` (2), `pubsub-monitor/` (1).
+   - Grep: `\b(Session|Project|Organization|Ticket|Task|Key|Client|Wiki|Chat)\.[A-Z][a-z]`.
+   - Skills keep working pre-sweep (dotted = alias at dispatch).
+4. `staging/TOBOR-CONTRACTS.md` — already canonical; no change.
+5. Memory files under `~/.claude/.../memory/` quoting dotted NPL tool names — low priority, aliases keep resolving.

--- a/backend/lib/noizu_prompt_lingua/mcp/custom.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/custom.ex
@@ -56,10 +56,10 @@ defmodule NoizuPromptLingua.MCP.Custom do
       |> Tools.expand()
       |> Enum.reject(&(tool_category(&1) == "Discovery"))
       |> Enum.reject(fn spec ->
-        get_in(tool_config, [spec.definition.name, "disabled"]) == true
+        tool_config_entry(tool_config, spec.definition.name)["disabled"] == true
       end)
       |> Enum.map(fn spec ->
-        tool_hidden = get_in(tool_config, [spec.definition.name, "hidden"])
+        tool_hidden = tool_config_entry(tool_config, spec.definition.name)["hidden"]
 
         cond do
           is_boolean(tool_hidden) -> %{spec | hidden: tool_hidden}
@@ -70,6 +70,15 @@ defmodule NoizuPromptLingua.MCP.Custom do
     else
       _ -> []
     end
+  end
+
+  # Scope configs may key tool entries by the dotted spelling (Session.Create)
+  # or the canonical underscore form (Session_Create) — accept either (F5).
+  defp tool_config_entry(tool_config, name) do
+    canonical = NoizuPromptLingua.MCP.ToolNames.canonical(name)
+
+    Map.get(tool_config, name) || Map.get(tool_config, canonical) ||
+      Map.get(tool_config, NoizuPromptLingua.MCP.ToolNames.dotted(canonical)) || %{}
   end
 
   defp discovery_specs do

--- a/backend/lib/noizu_prompt_lingua/mcp/dispatch.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/dispatch.ex
@@ -10,16 +10,22 @@ defmodule NoizuPromptLingua.MCP.Dispatch do
   alias Noizu.MCP.Server.Features.Tools
   alias Noizu.MCP.Server.Tool.{Fields, Spec}
   alias Noizu.MCP.Types.ToolResult
-  alias NoizuPromptLingua.MCP.ToolGuard
+  alias NoizuPromptLingua.MCP.{ToolGuard, ToolNames}
 
   def call(server_mod, name, args, ctx) when is_atom(server_mod) and is_binary(name) do
     specs = expand_specs(server_mod, ctx)
 
-    case Enum.find(specs, &(lookup_name(&1.definition.name) == lookup_name(name))) do
+    # Names are matched on the canonical underscore form; dotted spellings
+    # (Session.Create) are aliases accepted at dispatch, never the wire name.
+    case Enum.find(specs, &(ToolNames.canonical(&1.definition.name) == ToolNames.canonical(name))) do
       nil ->
         {:error, Error.invalid_params("Unknown tool: #{name}")}
 
       %Spec{} = spec ->
+        # Canonicalize so ToolGuard/config keys and error text see the
+        # underscore name regardless of which alias the client dispatched.
+        spec = ToolNames.canonical_spec(spec)
+
         case ToolGuard.before_call(spec_to_guard(spec), args, ctx) do
           :ok ->
             run_spec(spec, args || %{}, ctx)
@@ -60,9 +66,8 @@ defmodule NoizuPromptLingua.MCP.Dispatch do
   end
 
   # Clients sanitize MCP tool names for their own tool-name charset
-  # ("Organization.Overview" -> "Organization_Overview"), so compare with
-  # dots and underscores folded to one form on both sides.
-  defp lookup_name(name) when is_binary(name), do: String.replace(name, ".", "_")
+  # ("Organization.Overview" -> "Organization_Overview"), so dispatch matches on
+  # the canonical underscore form; dotted spellings are accepted as aliases.
 
   defp run_spec(%Spec{} = spec, args, ctx) do
     case Schema.validate(spec.definition.input_schema, args) do

--- a/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
@@ -105,12 +105,22 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
     groups = Map.get(normalize(config), "groups", %{})
     group = Map.get(groups, group_id) || %{}
     tools = Map.get(group, "tools") || %{}
-    tool = Map.get(tools, tool_name) || %{}
+    tool = tool_entry(tools, tool_name) || %{}
 
     %{
       disabled: flag(group, tool, "disabled"),
       hidden: flag(group, tool, "hidden")
     }
+  end
+
+  # Configs in the wild may key tools by the dotted spelling (Session.Create)
+  # or the canonical underscore form (Session_Create) — accept either when
+  # probing (F5 naming: underscore canonical, dotted = alias).
+  defp tool_entry(tools, tool_name) do
+    canonical = NoizuPromptLingua.MCP.ToolNames.canonical(tool_name)
+
+    Map.get(tools, tool_name) || Map.get(tools, canonical) ||
+      Map.get(tools, NoizuPromptLingua.MCP.ToolNames.dotted(canonical))
   end
 
   def state_from_config(_, _, _), do: %{disabled: false, hidden: false}
@@ -170,7 +180,8 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
       Map.new(scope_tools, fn {tool_name, tool_cfg} ->
         tool_name = to_string(tool_name)
 
-        case Map.get(key_tools, tool_name) do
+        # Probe both spelling forms (F5: dotted aliases vs canonical underscore).
+        case tool_entry(key_tools, tool_name) do
           nil -> {tool_name, tool_cfg}
           overrides -> {tool_name, overlay_tool(tool_cfg || %{}, overrides)}
         end

--- a/backend/lib/noizu_prompt_lingua/mcp/server.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/server.ex
@@ -39,8 +39,10 @@ defmodule NoizuPromptLingua.MCP.Server do
 
   @doc """
   Shared `handle_list_tools` implementation: expand the server's tool set
-  (registered tools, or `catalog_specs/1` for dynamic servers), drop tools the
-  calling API key has hidden/disabled, drop static hidden tools, paginate.
+  (registered tools, or `catalog_specs/1` for dynamic servers), rewrite names to
+  canonical underscore form (dotted spellings are aliases, never emitted), drop
+  tools the calling API key has hidden/disabled, drop static hidden tools,
+  paginate.
   """
   def list_tools(server, cursor, ctx) do
     specs =
@@ -51,6 +53,7 @@ defmodule NoizuPromptLingua.MCP.Server do
       end
 
     specs
+    |> NoizuPromptLingua.MCP.ToolNames.canonical_specs()
     |> NoizuPromptLingua.MCP.KeyToolsets.apply_hidden(ctx, nil)
     |> Enum.reject(& &1.hidden)
     |> Enum.map(& &1.definition)

--- a/backend/lib/noizu_prompt_lingua/mcp/tool_names.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/tool_names.ex
@@ -1,0 +1,64 @@
+defmodule NoizuPromptLingua.MCP.ToolNames do
+  @moduledoc """
+  Server-wide MCP tool naming policy (F5): the canonical separator between the
+  group segment and the action segment is the UNDERSCORE — `Session_Create`,
+  `Organization_List`. Dotted forms (`Session.Create`) remain **aliases**:
+  accepted everywhere at dispatch/list time, never emitted.
+
+  Why: client agents sanitize `.` out of their own tool-name charsets, so two
+  spellings for one tool were already in circulation (some clients call
+  `Session_Create`, the wire name was `Session.Create`). One canonical form plus
+  alias acceptance removes the fork. Emission points (`handle_list_tools`,
+  `Catalog.build`, `Dispatch`) normalize through `canonical/1`; lookup points
+  accept either form.
+
+  Applies to ToolCall dispatch, list_tools, and (post-merge) Session.Manifest.
+  """
+
+  @doc """
+  Canonical name for a tool identifier. `Session.Create` -> `Session_Create`;
+  already-canonical and separator-free names pass through unchanged. Non-string
+  input is returned as-is (tolerant of upstream map access).
+  """
+  @spec canonical(term) :: String.t() | term
+  def canonical(name) when is_binary(name), do: String.replace(name, ".", "_")
+  def canonical(name), do: name
+
+  @doc """
+  True when the name is a dotted alias form (`Session.Create`) rather than the
+  canonical underscore form. Separator-free names are not aliases.
+  """
+  @spec alias?(term) :: boolean
+  def alias?(name) when is_binary(name), do: String.contains?(name, ".")
+  def alias?(_), do: false
+
+  @doc """
+  The dotted spelling of a canonical name — used only to probe legacy config
+  keys (toolset configs stored with `Session.Create` keys) when a canonical
+  lookup misses. Not an emission form.
+  """
+  @spec dotted(term) :: String.t() | term
+  def dotted(name) when is_binary(name), do: String.replace(name, "_", ".")
+  def dotted(name), do: name
+
+  @doc """
+  Rewrite a tool spec's definition name to canonical underscore form, for
+  emission points. Specs whose name is already canonical pass through.
+  """
+  def canonical_spec(%{definition: %{name: name} = defn} = spec) when is_binary(name) do
+    canonical_name = canonical(name)
+
+    if canonical_name == name do
+      spec
+    else
+      %{spec | definition: %{defn | name: canonical_name}}
+    end
+  end
+
+  def canonical_spec(spec), do: spec
+
+  @doc "Normalize a list of specs for emission (see `canonical_spec/1`)."
+  @spec canonical_specs([map()]) :: [map()]
+  def canonical_specs(specs) when is_list(specs), do: Enum.map(specs, &canonical_spec/1)
+  def canonical_specs(specs), do: specs
+end

--- a/backend/lib/noizu_prompt_lingua/tools/catalog.ex
+++ b/backend/lib/noizu_prompt_lingua/tools/catalog.ex
@@ -21,13 +21,17 @@ defmodule NoizuPromptLingua.Tools.Catalog do
           hidden: boolean()
         }
 
-  def resolve_alias(name) do
-    name
-  end
+  @doc """
+  Canonical tool name for a caller-supplied identifier. Dotted spellings
+  (`Session.Create`) are aliases; the canonical form is `Session_Create`
+  (see `NoizuPromptLingua.MCP.ToolNames`).
+  """
+  def resolve_alias(name), do: NoizuPromptLingua.MCP.ToolNames.canonical(name)
 
   def build(server \\ NoizuPromptLingua.MCP, ctx \\ nil) do
     specs =
       specs(server, ctx)
+      |> NoizuPromptLingua.MCP.ToolNames.canonical_specs()
       |> NoizuPromptLingua.MCP.KeyToolsets.apply_hidden(ctx, nil)
 
     Enum.map(specs, fn spec ->
@@ -77,7 +81,8 @@ defmodule NoizuPromptLingua.Tools.Catalog do
 
   def call_hidden_tool(name, arguments, server \\ NoizuPromptLingua.MCP, ctx \\ nil) do
     name = resolve_alias(name)
-    specs = specs(server, ctx)
+    # Canonicalize specs so dotted catalog names match the canonical lookup.
+    specs = NoizuPromptLingua.MCP.ToolNames.canonical_specs(specs(server, ctx))
 
     case Enum.find(specs, &(&1.definition.name == name)) do
       nil ->

--- a/backend/lib/noizu_prompt_lingua/tools/tool_call.ex
+++ b/backend/lib/noizu_prompt_lingua/tools/tool_call.ex
@@ -4,7 +4,8 @@ defmodule NoizuPromptLingua.Tools.ToolCall do
     description:
       "Invoke any hidden (discoverable) tool by name with arguments. " <>
         "This is the primary way to call domain tools that are not MCP-visible. " <>
-        "Supports alias resolution for old tool names.",
+        "Canonical names use underscore separators (Session_Create); the legacy " <>
+        "dotted spelling (Session.Create) is accepted as an alias.",
     category: "Discovery"
 
   input_schema(%{
@@ -12,7 +13,8 @@ defmodule NoizuPromptLingua.Tools.ToolCall do
     "properties" => %{
       "tool" => %{
         "type" => "string",
-        "description" => "Exact tool name (e.g., \"Project.Create\")"
+        "description" =>
+          "Exact tool name, canonical underscore form (e.g., \"Project_Create\"); dotted \"Project.Create\" accepted as alias"
       },
       "arguments" => %{
         "type" => "object",

--- a/backend/lib/noizu_prompt_lingua/tools/tool_search.ex
+++ b/backend/lib/noizu_prompt_lingua/tools/tool_search.ex
@@ -45,7 +45,8 @@ defmodule NoizuPromptLingua.Tools.ToolSearch do
 
   defp text_search(query, limit, server, ctx) do
     catalog = Catalog.build(server, ctx)
-    q = String.downcase(query)
+    # Dotted queries match the canonical underscore names the catalog emits.
+    q = String.downcase(NoizuPromptLingua.MCP.ToolNames.canonical(query))
 
     {exact, name_match, desc_match} =
       Enum.reduce(catalog, {[], [], []}, fn tool, {exact, names, descs} ->

--- a/backend/lib/noizu_prompt_lingua/tools/tool_summary.ex
+++ b/backend/lib/noizu_prompt_lingua/tools/tool_summary.ex
@@ -77,10 +77,13 @@ defmodule NoizuPromptLingua.Tools.ToolSummary do
   defp get_tool(path, server, ctx) do
     [cat_path, tool_name] = String.split(path, "#", parts: 2)
     catalog = Catalog.build(server, ctx)
+    # Dotted spellings (Session.Create) are accepted as aliases of the
+    # canonical underscore names the catalog emits.
+    canonical_name = Catalog.resolve_alias(tool_name)
 
     entry =
-      Enum.find(catalog, fn t -> t.name == tool_name and t.category == cat_path end) ||
-        Enum.find(catalog, fn t -> t.name == tool_name end)
+      Enum.find(catalog, fn t -> t.name == canonical_name and t.category == cat_path end) ||
+        Enum.find(catalog, fn t -> t.name == canonical_name end)
 
     case entry do
       nil ->

--- a/backend/test/noizu_prompt_lingua/mcp/custom_key_toolset_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/custom_key_toolset_test.exs
@@ -64,11 +64,12 @@ defmodule NoizuPromptLingua.MCP.CustomKeyToolsetTest do
     cat_names = Custom.catalog_specs(ctx) |> Enum.map(& &1.definition.name)
     assert "Session.Update" in cat_names
 
-    # listing: dropped
+    # listing: dropped. Listing emits canonical underscore names (F5 naming);
+    # catalog_specs returns raw registry names (dotted = alias source).
     {:ok, tools, _cursor} = NPLServer.list_tools(Custom, nil, ctx)
     listed = Enum.map(tools, & &1.name)
-    refute "Session.Update" in listed
-    assert "Session.Get" in listed
+    refute "Session_Update" in listed
+    assert "Session_Get" in listed
   end
 
   test "key-hidden hides from listing; scope-hidden still hides; both callable if enabled", %{
@@ -87,9 +88,9 @@ defmodule NoizuPromptLingua.MCP.CustomKeyToolsetTest do
     listed = Enum.map(tools, & &1.name)
 
     # scope-level hidden (Project.Create) and key-level hidden (Session.Get)
-    refute "Project.Create" in listed
-    refute "Session.Get" in listed
-    assert "Session.Update" in listed
+    refute "Project_Create" in listed
+    refute "Session_Get" in listed
+    assert "Session_Update" in listed
   end
 
   test "key group-level disabled hides that group's tools from listing", %{
@@ -107,8 +108,8 @@ defmodule NoizuPromptLingua.MCP.CustomKeyToolsetTest do
 
     # group disabled -> dropped from listing AND catalog calls denied by guard;
     # the OTHER group's tools remain
-    refute "Project.Get" in listed
-    assert "Session.Update" in listed
+    refute "Project_Get" in listed
+    assert "Session_Update" in listed
   end
 
   test "no key on the request -> scope config alone governs", %{scope: scope} do
@@ -116,8 +117,8 @@ defmodule NoizuPromptLingua.MCP.CustomKeyToolsetTest do
     {:ok, tools, _cursor} = NPLServer.list_tools(Custom, nil, ctx)
     listed = Enum.map(tools, & &1.name)
 
-    refute "Project.Create" in listed
-    assert "Session.Update" in listed
-    assert "Session.Get" in listed
+    refute "Project_Create" in listed
+    assert "Session_Update" in listed
+    assert "Session_Get" in listed
   end
 end

--- a/backend/test/noizu_prompt_lingua/mcp/custom_scope_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/custom_scope_test.exs
@@ -62,12 +62,14 @@ defmodule NoizuPromptLingua.MCP.CustomScopeTest do
     {:ok, search} = ToolSearch.call(%{query: "Project", mode: :text, limit: 10}, c)
     # Text search matches descriptions too — session tools legitimately mention
     # "project" in their docs. The scope contract is that no Project.* tool is
-    # reachable, not that the substring never appears.
-    assert search.matches |> Enum.map(& &1.name) |> Enum.all?(&String.starts_with?(&1, "Session."))
-    refute Enum.any?(search.matches, &String.starts_with?(&1.name, "Project."))
+    # reachable, not that the substring never appears. Names emit canonical
+    # underscore form (F5): Session_*, never dotted.
+    assert search.matches |> Enum.map(& &1.name) |> Enum.all?(&String.starts_with?(&1, "Session_"))
+    refute Enum.any?(search.matches, &String.starts_with?(&1.name, "Project_"))
 
     {:ok, definitions} = ToolDefinition.call(%{tool: "Session.Get,Project.Get"}, c)
-    assert [%{name: "Session.Get"}] = definitions.definitions
+    # dotted input accepted as alias; emitted name is canonical underscore
+    assert [%{name: "Session_Get"}] = definitions.definitions
     assert definitions.not_found == ["Project.Get"]
   end
 
@@ -82,7 +84,8 @@ defmodule NoizuPromptLingua.MCP.CustomScopeTest do
     {:ok, found} =
       ToolHelp.call(%{tool: "Ticket.Create", task: "create a task"}, ctx("tickets-only"))
 
-    assert found.tool == "Ticket.Create"
+    # dotted input accepted as alias; echoed name is canonical underscore (F5)
+    assert found.tool == "Ticket_Create"
 
     {:ok, missing} =
       ToolHelp.call(%{tool: "Project.Get", task: "inspect project"}, ctx("tickets-only"))

--- a/backend/test/noizu_prompt_lingua/mcp/tool_names_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/tool_names_test.exs
@@ -1,0 +1,136 @@
+defmodule NoizuPromptLingua.MCP.ToolNamesTest do
+  use NoizuPromptLingua.DataCase
+
+  # F5 underscore-names: canonical separator is `_`, dotted spellings are
+  # aliases accepted at dispatch/list time and NEVER emitted.
+
+  alias Noizu.MCP.Ctx
+  alias NoizuPromptLingua.MCP.Custom
+  alias NoizuPromptLingua.MCP.Dispatch
+  alias NoizuPromptLingua.MCP.Server, as: NPLServer
+  alias NoizuPromptLingua.MCP.ToolNames
+
+  describe "canonical/1 + alias?/1 mapping table" do
+    test "dotted names map to underscore canonical form" do
+      table = %{
+        "Session.Create" => "Session_Create",
+        "Session.Get" => "Session_Get",
+        "Organization.Overview" => "Organization_Overview",
+        "Project.List" => "Project_List",
+        "CustomerPersona.Draft" => "CustomerPersona_Draft",
+        # multi-segment: every dot folds
+        "A.B.C" => "A_B_C"
+      }
+
+      for {dotted, expected} <- table do
+        assert ToolNames.canonical(dotted) == expected
+        assert ToolNames.alias?(dotted)
+        refute ToolNames.alias?(expected)
+      end
+    end
+
+    test "canonical and separator-free names pass through" do
+      assert ToolNames.canonical("Session_Create") == "Session_Create"
+      assert ToolNames.canonical("ToolCall") == "ToolCall"
+      assert ToolNames.canonical("ToolCall") == "ToolCall"
+      refute ToolNames.alias?("ToolCall")
+    end
+
+    test "non-string input is tolerated" do
+      assert ToolNames.canonical(nil) == nil
+      assert ToolNames.canonical(:atom_name) == :atom_name
+      refute ToolNames.alias?(nil)
+    end
+
+    test "dotted/1 inverts canonical for legacy config probes" do
+      assert ToolNames.dotted("Session_Create") == "Session.Create"
+      assert ToolNames.dotted("ToolCall") == "ToolCall"
+    end
+
+    test "canonical_spec rewrites spec definition names; already-canonical untouched" do
+      dotted_spec = %{definition: %{name: "Session.Create", other: 1}, hidden: false}
+      assert %{definition: %{name: "Session_Create", other: 1}} = ToolNames.canonical_spec(dotted_spec)
+
+      canonical_spec = %{definition: %{name: "Session_Create"}, hidden: false}
+      assert ToolNames.canonical_spec(canonical_spec) == canonical_spec
+
+      # non-spec shapes pass through
+      assert ToolNames.canonical_spec(:junk) == :junk
+    end
+  end
+
+  describe "list_tools emits underscore-only names" do
+    setup do
+      {:ok, scope} =
+        NoizuPromptLingua.MCPCustomScopes.create(%{
+          "slug" => "f5-names",
+          "name" => "F5 Names",
+          "config" => %{"groups" => %{"sessions" => %{"tools" => %{}}}}
+        })
+
+      %{scope: scope}
+    end
+
+    test "listing never contains dotted names; canonical spellings present", %{scope: scope} do
+      ctx = %Ctx{assigns: %{custom_scope_slug: scope.slug}}
+      {:ok, tools, _cursor} = NPLServer.list_tools(Custom, nil, ctx)
+      listed = Enum.map(tools, & &1.name)
+
+      assert "Session_Create" in listed
+      assert "Session_Get" in listed
+      assert Enum.all?(listed, &not String.contains?(&1, "."))
+    end
+  end
+
+  describe "dispatch normalization" do
+    setup do
+      {:ok, scope} =
+        NoizuPromptLingua.MCPCustomScopes.create(%{
+          "slug" => "f5-dispatch",
+          "name" => "F5 Dispatch",
+          "config" => %{"groups" => %{"sessions" => %{"tools" => %{}}}}
+        })
+
+      %{scope: scope}
+    end
+
+    test "dotted alias dispatches the same tool as the canonical underscore name", %{
+      scope: scope
+    } do
+      ctx = %Ctx{
+        assigns: %{
+          custom_scope_slug: scope.slug,
+          auth_claims: %{"sub" => Ecto.UUID.generate()},
+          system_principal: true
+        }
+      }
+
+      dotted = Dispatch.call(Custom, "Session.Overview", %{}, ctx)
+      canonical = Dispatch.call(Custom, "Session_Overview", %{}, ctx)
+
+      # both resolve past the unknown-tool gate and run the same handler —
+      # identical result either way (tool-not-found would diverge).
+      assert dotted == canonical
+
+      unknown = Dispatch.call(Custom, "No.Such.Tool", %{}, ctx)
+      assert {:error, _} = unknown
+    end
+
+    test "dispatch of a dotted alias inside a hidden-but-not-disabled scope still resolves", %{
+      scope: scope
+    } do
+      {:ok, _} =
+        NoizuPromptLingua.MCPCustomScopes.update(scope.slug, %{
+          "config" => %{
+            "groups" => %{"sessions" => %{"tools" => %{"Session.Archive" => %{"hidden" => true}}}}
+          }
+        })
+
+      ctx = %Ctx{assigns: %{custom_scope_slug: scope.slug, system_principal: true}}
+
+      # dotted key in config + dotted dispatch: config lookup accepts both forms
+      result = Dispatch.call(Custom, "Session.Archive", %{}, ctx)
+      refute match?({:error, "Unknown tool: Session.Archive"}, result)
+    end
+  end
+end

--- a/docs/arch/mcp-tools.md
+++ b/docs/arch/mcp-tools.md
@@ -2,6 +2,8 @@
 
 The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable tools** callable via `ToolCall`. Tools are registered in `src/npl_mcp/launcher.py` using `@mcp_discoverable` (visible) or `register_discoverable()` (hidden).
 
+> **Naming (F5):** canonical tool names use UNDERSCORE separators (`Session_Create`, `Organization_List`). The legacy dotted spelling (`Session.Create`) is accepted as an alias at dispatch, discovery, and `ToolCall`, but is never emitted.
+
 ---
 
 ## Discovery (5 tools)
@@ -29,7 +31,7 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | Returns | When to Use |
 |------|-----------|---------|-------------|
-| **ToolSession.Generate** | `agent`, `brief`, `task`, `project`, `parent?`, `notes?` | UUID + action (created\|existing) | Create/lookup agent session by (project, agent, task) |
+| **ToolSession_Generate** | `agent`, `brief`, `task`, `project`, `parent?`, `notes?` | UUID + action (created\|existing) | Create/lookup agent session by (project, agent, task) |
 | **ToolSession** | `uuid`, `verbose?` | Session metadata | Retrieve session info by UUID |
 
 ---
@@ -39,11 +41,11 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 | Tool | Tier | Parameters | When to Use |
 |------|------|-----------|-------------|
 | **Instructions** | Visible | `uuid`, `session`, `version?`, `json?` | Retrieve versioned instruction document |
-| **Instructions.Create** | Visible | `title`, `description`, `tags[]`, `body`, `session` | Create new instruction with v1 |
-| **Instructions.List** | Visible | `session`, `query?`, `mode?`, `tags?`, `limit?` | Search/list instructions |
-| **Instructions.Update** | Hidden | `uuid`, `body`, `change_note?`, `session` | Create new version of instruction |
-| **Instructions.ActiveVersion** | Hidden | `uuid`, `version`, `session` | Switch active version |
-| **Instructions.Versions** | Hidden | `uuid`, `session` | List version history |
+| **Instructions_Create** | Visible | `title`, `description`, `tags[]`, `body`, `session` | Create new instruction with v1 |
+| **Instructions_List** | Visible | `session`, `query?`, `mode?`, `tags?`, `limit?` | Search/list instructions |
+| **Instructions_Update** | Hidden | `uuid`, `body`, `change_note?`, `session` | Create new version of instruction |
+| **Instructions_ActiveVersion** | Hidden | `uuid`, `version`, `session` | Switch active version |
+| **Instructions_Versions** | Hidden | `uuid`, `session` | List version history |
 
 ---
 
@@ -51,8 +53,8 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | Returns | When to Use |
 |------|-----------|---------|-------------|
-| **Agent.List** | — | Agent metadata list (name, model, description) | List available agent definitions |
-| **Agent.Load** | `name` | Full agent spec with markdown body | Load complete agent specification |
+| **Agent_List** | — | Agent metadata list (name, model, description) | List available agent definitions |
+| **Agent_Load** | `name` | Full agent spec with markdown body | Load complete agent specification |
 
 ---
 
@@ -60,10 +62,10 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Tasks.Create** | `title`, `description?`, `status?`, `priority?`, `assigned_to?`, `notes?` | Create a task |
-| **Tasks.Get** | `task_id` | Fetch task by ID |
-| **Tasks.List** | `status?`, `assigned_to?`, `limit?` | List tasks with filtering |
-| **Tasks.UpdateStatus** | `task_id`, `status`, `notes?` | Update status, append note |
+| **Tasks_Create** | `title`, `description?`, `status?`, `priority?`, `assigned_to?`, `notes?` | Create a task |
+| **Tasks_Get** | `task_id` | Fetch task by ID |
+| **Tasks_List** | `status?`, `assigned_to?`, `limit?` | List tasks with filtering |
+| **Tasks_UpdateStatus** | `task_id`, `status`, `notes?` | Update status, append note |
 
 ---
 
@@ -71,15 +73,15 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **TaskQueue.Create** | `name`, `description?`, `session_id?`, `chat_room_id?` | Create named task queue |
-| **TaskQueue.Get** | `queue_id` | Get queue with task counts |
-| **TaskQueue.List** | `status?`, `limit?` | List queues |
-| **TaskQueue.Feed** | `queue_id`, `since?`, `limit?` | Queue activity feed |
-| **Tasks.CreateInQueue** | `queue_id`, `title`, `description?`, `status?`, `priority?`, `assigned_to?`, `acceptance_criteria?`, `deadline?`, `complexity?` | Create task in queue |
-| **Tasks.AssignComplexity** | `task_id`, `complexity`, `notes?` | Set complexity score |
-| **Tasks.AddArtifact** | `task_id`, `artifact_type`, `artifact_id?`, `git_branch?`, `description?` | Link artifact/branch to task |
-| **Tasks.ListArtifacts** | `task_id` | List linked artifacts |
-| **Tasks.Feed** | `task_id`, `since?`, `limit?` | Task activity feed |
+| **TaskQueue_Create** | `name`, `description?`, `session_id?`, `chat_room_id?` | Create named task queue |
+| **TaskQueue_Get** | `queue_id` | Get queue with task counts |
+| **TaskQueue_List** | `status?`, `limit?` | List queues |
+| **TaskQueue_Feed** | `queue_id`, `since?`, `limit?` | Queue activity feed |
+| **Tasks_CreateInQueue** | `queue_id`, `title`, `description?`, `status?`, `priority?`, `assigned_to?`, `acceptance_criteria?`, `deadline?`, `complexity?` | Create task in queue |
+| **Tasks_AssignComplexity** | `task_id`, `complexity`, `notes?` | Set complexity score |
+| **Tasks_AddArtifact** | `task_id`, `artifact_type`, `artifact_id?`, `git_branch?`, `description?` | Link artifact/branch to task |
+| **Tasks_ListArtifacts** | `task_id` | List linked artifacts |
+| **Tasks_Feed** | `task_id`, `since?`, `limit?` | Task activity feed |
 
 ---
 
@@ -87,12 +89,12 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Artifact.Create** | `title`, `content?`, `kind?`, `description?`, `created_by?`, `notes?`, `binary_content_b64?`, `mime_type?` | Create text or binary artifact |
-| **Artifact.AddRevision** | `artifact_id`, `content?`, `notes?`, `created_by?`, `binary_content_b64?`, `mime_type?` | Add revision to artifact |
-| **Artifact.Get** | `artifact_id`, `revision?` | Fetch artifact with specific revision |
-| **Artifact.GetBinary** | `artifact_id`, `revision?` | Get binary content as base64 |
-| **Artifact.List** | `kind?`, `limit?` | List artifacts |
-| **Artifact.ListRevisions** | `artifact_id` | List revision summaries |
+| **Artifact_Create** | `title`, `content?`, `kind?`, `description?`, `created_by?`, `notes?`, `binary_content_b64?`, `mime_type?` | Create text or binary artifact |
+| **Artifact_AddRevision** | `artifact_id`, `content?`, `notes?`, `created_by?`, `binary_content_b64?`, `mime_type?` | Add revision to artifact |
+| **Artifact_Get** | `artifact_id`, `revision?` | Fetch artifact with specific revision |
+| **Artifact_GetBinary** | `artifact_id`, `revision?` | Get binary content as base64 |
+| **Artifact_List** | `kind?`, `limit?` | List artifacts |
+| **Artifact_ListRevisions** | `artifact_id` | List revision summaries |
 
 ---
 
@@ -100,12 +102,12 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Session.Create** | `title?`, `description?`, `status?`, `created_by?` | Create generic work session |
-| **Session.Get** | `session_id` | Fetch session |
-| **Session.List** | `status?`, `limit?` | List sessions |
-| **Session.Update** | `session_id`, `title?`, `status?`, `description?` | Update session metadata |
-| **Session.Contents** | `session_id` | Get aggregated chat rooms + artifacts |
-| **Session.Archive** | `session_id` | Archive a session |
+| **Session_Create** | `title?`, `description?`, `status?`, `created_by?` | Create generic work session |
+| **Session_Get** | `session_id` | Fetch session |
+| **Session_List** | `status?`, `limit?` | List sessions |
+| **Session_Update** | `session_id`, `title?`, `status?`, `description?` | Update session metadata |
+| **Session_Contents** | `session_id` | Get aggregated chat rooms + artifacts |
+| **Session_Archive** | `session_id` | Archive a session |
 
 ---
 
@@ -124,20 +126,20 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Chat.ListRooms** | `limit?` | List rooms by activity |
-| **Chat.CreateRoom** | `name`, `description?` | Create chat room |
-| **Chat.GetRoom** | `room_id` | Get room details |
-| **Chat.ListMessages** | `room_id`, `limit?`, `before_id?` | List messages (newest first) |
-| **Chat.SendMessage** | `room_id`, `content`, `author?` | Post message |
-| **Chat.AddMember** | `room_id`, `persona_slug` | Add persona to room |
-| **Chat.ListMembers** | `room_id` | List room members |
-| **Chat.CreateEvent** | `room_id`, `event_type`, `persona`, `data?` | Create structured event |
-| **Chat.ListEvents** | `room_id`, `since?`, `limit?` | List events |
-| **Chat.React** | `event_id`, `persona`, `emoji` | React to event |
-| **Chat.CreateTodo** | `room_id`, `persona`, `description`, `assigned_to?` | Create todo item |
-| **Chat.ShareArtifact** | `room_id`, `persona`, `artifact_id`, `revision?` | Share artifact in room |
-| **Chat.Notifications** | `persona`, `unread_only?` | List notifications |
-| **Chat.ReadNotification** | `notification_id` | Mark notification read |
+| **Chat_ListRooms** | `limit?` | List rooms by activity |
+| **Chat_CreateRoom** | `name`, `description?` | Create chat room |
+| **Chat_GetRoom** | `room_id` | Get room details |
+| **Chat_ListMessages** | `room_id`, `limit?`, `before_id?` | List messages (newest first) |
+| **Chat_SendMessage** | `room_id`, `content`, `author?` | Post message |
+| **Chat_AddMember** | `room_id`, `persona_slug` | Add persona to room |
+| **Chat_ListMembers** | `room_id` | List room members |
+| **Chat_CreateEvent** | `room_id`, `event_type`, `persona`, `data?` | Create structured event |
+| **Chat_ListEvents** | `room_id`, `since?`, `limit?` | List events |
+| **Chat_React** | `event_id`, `persona`, `emoji` | React to event |
+| **Chat_CreateTodo** | `room_id`, `persona`, `description`, `assigned_to?` | Create todo item |
+| **Chat_ShareArtifact** | `room_id`, `persona`, `artifact_id`, `revision?` | Share artifact in room |
+| **Chat_Notifications** | `persona`, `unread_only?` | List notifications |
+| **Chat_ReadNotification** | `notification_id` | Mark notification read |
 
 ---
 
@@ -145,11 +147,11 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Review.Create** | `artifact_id`, `revision_id`, `reviewer_persona` | Start review for artifact revision |
-| **Review.AddComment** | `review_id`, `location`, `comment`, `persona` | Add inline comment |
-| **Review.AddOverlay** | `review_id`, `x`, `y`, `comment`, `persona` | Add coordinate annotation (images) |
-| **Review.Get** | `review_id`, `include_comments?` | Fetch review with comments |
-| **Review.Complete** | `review_id`, `overall_comment?` | Mark review completed |
+| **Review_Create** | `artifact_id`, `revision_id`, `reviewer_persona` | Start review for artifact revision |
+| **Review_AddComment** | `review_id`, `location`, `comment`, `persona` | Add inline comment |
+| **Review_AddOverlay** | `review_id`, `x`, `y`, `comment`, `persona` | Add coordinate annotation (images) |
+| **Review_Get** | `review_id`, `include_comments?` | Fetch review with comments |
+| **Review_Complete** | `review_id`, `overall_comment?` | Mark review completed |
 
 ---
 
@@ -157,7 +159,7 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Orchestration.Trigger** | `feature_description`, `agent?` (default: npl-tdd-coder) | Queue feature for TDD pipeline |
+| **Orchestration_Trigger** | `feature_description`, `agent?` (default: npl-tdd-coder) | Queue feature for TDD pipeline |
 
 ---
 
@@ -165,8 +167,8 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Skill.Validate** | `content`, `filename?` | Validate skill file structure |
-| **Skill.Evaluate** | `content`, `filename?` | Score skill quality (0.0–1.0) across dimensions |
+| **Skill_Validate** | `content`, `filename?` | Validate skill file structure |
+| **Skill_Evaluate** | `content`, `filename?` | Score skill quality (0.0–1.0) across dimensions |
 
 ---
 
@@ -174,15 +176,15 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Tasker.Spawn** | `task`, `chat_room_id`, `parent_agent_id?`, `patterns?`, `session_id?`, `timeout_minutes?`, `nag_minutes?` | Spawn ephemeral tasker |
-| **Tasker.Get** | `tasker_id` | Fetch tasker status |
-| **Tasker.List** | `status?`, `session_id?` | List taskers |
-| **Tasker.Touch** | `tasker_id` | Reset idle timer |
-| **Tasker.Dismiss** | `tasker_id`, `reason?` | Terminate tasker |
-| **Tasker.KeepAlive** | `tasker_id` | Respond to nag |
-| **Fabric.Apply** | `content`, `pattern`, `model?`, `timeout?` | Apply fabric pattern |
-| **Fabric.Analyze** | `content`, `patterns[]`, `combine_results?` | Apply multiple patterns |
-| **Fabric.ListPatterns** | — | List available patterns |
+| **Tasker_Spawn** | `task`, `chat_room_id`, `parent_agent_id?`, `patterns?`, `session_id?`, `timeout_minutes?`, `nag_minutes?` | Spawn ephemeral tasker |
+| **Tasker_Get** | `tasker_id` | Fetch tasker status |
+| **Tasker_List** | `status?`, `session_id?` | List taskers |
+| **Tasker_Touch** | `tasker_id` | Reset idle timer |
+| **Tasker_Dismiss** | `tasker_id`, `reason?` | Terminate tasker |
+| **Tasker_KeepAlive** | `tasker_id` | Respond to nag |
+| **Fabric_Apply** | `content`, `pattern`, `model?`, `timeout?` | Apply fabric pattern |
+| **Fabric_Analyze** | `content`, `patterns[]`, `combine_results?` | Apply multiple patterns |
+| **Fabric_ListPatterns** | — | List available patterns |
 
 ---
 
@@ -192,16 +194,16 @@ The NPL MCP server exposes **58 MCP-visible tools** and **22 hidden discoverable
 
 | Tool | Parameters | When to Use |
 |------|-----------|-------------|
-| **Browser.Capture** | `url`, `viewport?`, `theme?`, `full_page?`, `session_key?` | Screenshot a web page |
-| **Browser.Interact.Navigate** | `session_id`, `url` | Navigate browser session |
-| **Browser.Interact.Click** | `session_id`, `selector` | Click element |
-| **Browser.Interact.Fill** | `session_id`, `selector`, `value` | Fill form field |
-| **Browser.Interact.GetState** | `session_id` | Get page state (URL, title, scroll) |
-| **Browser.ListSessions** | — | List active browser sessions |
-| **Browser.CloseSession** | `session_id` | Close browser session |
-| **Browser.Diff** | `baseline_bytes`, `comparison_bytes`, `threshold?` | Compare two screenshots |
-| **Browser.Checkpoint** | `name`, `urls[]`, `base_url?`, `viewports?`, `themes?` | Multi-URL visual checkpoint |
-| **Browser.CompareCheckpoints** | `baseline_slug`, `comparison_slug`, `threshold?` | Compare checkpoint sets |
+| **Browser_Capture** | `url`, `viewport?`, `theme?`, `full_page?`, `session_key?` | Screenshot a web page |
+| **Browser_Interact.Navigate** | `session_id`, `url` | Navigate browser session |
+| **Browser_Interact.Click** | `session_id`, `selector` | Click element |
+| **Browser_Interact.Fill** | `session_id`, `selector`, `value` | Fill form field |
+| **Browser_Interact.GetState** | `session_id` | Get page state (URL, title, scroll) |
+| **Browser_ListSessions** | — | List active browser sessions |
+| **Browser_CloseSession** | `session_id` | Close browser session |
+| **Browser_Diff** | `baseline_bytes`, `comparison_bytes`, `threshold?` | Compare two screenshots |
+| **Browser_Checkpoint** | `name`, `urls[]`, `base_url?`, `viewports?`, `themes?` | Multi-URL visual checkpoint |
+| **Browser_CompareCheckpoints** | `baseline_slug`, `comparison_slug`, `threshold?` | Compare checkpoint sets |
 
 ### Hidden (via ToolCall)
 
@@ -221,9 +223,9 @@ All callable via `ToolCall`. Provide DB-backed CRUD for projects, personas, and 
 
 | Tool | When to Use |
 |------|-------------|
-| **Proj.Projects.Create/Get/List** | Project CRUD |
-| **Proj.UserPersonas.Create/Get/Update/Delete/List** | Persona CRUD |
-| **Proj.UserStories.Create/Get/Update/Delete/List** | Story CRUD |
+| **Proj_Projects.Create/Get/List** | Project CRUD |
+| **Proj_UserPersonas.Create/Get/Update/Delete/List** | Persona CRUD |
+| **Proj_UserStories.Create/Get/Update/Delete/List** | Story CRUD |
 
 ---
 


### PR DESCRIPTION
Phase 0 / F5 — server-wide `.`→`_` tool naming (user amendment: some clients choke on dots). Mechanism: new `ToolNames` canonicalization seam at emission/dispatch (255 literals untouched by design — see INTEGRATION-NOTES.md in-branch; recommend ratifying as the amended spec).

**Review (2026-08-31 — `TOBOR-REVIEW.md` at trl-infra root): APPROVE W/ NOTES.**
- All spec behavior verified: underscore-only emission (list_tools/Catalog), dotted alias dispatch both sides, resolve_alias/1 activated, legacy dotted jsonb dual-probed, no double-folding, docs swept, 136-line test file.
- Notes: write-path canonicalization omitted (new configs still store dotted keys — DB never converges; add write-time fold); `src/npl_mcp/launcher.py:1031` still emits dotted (defer to I1 monorepo sweep?); `dotted/1` blanket heuristic lossy if a future canonical name contains a real underscore; add ToolCall/ToolSearch dotted-discovery tests.

Rebase risk low. **Best merge candidate of Phase 0** — after write-path fold + the two notes.