### PR TITLE
feat(mcp): org-addressed custom MCP URLs (/org/:org_slug/custom/:slug/mcp)

### DIFF
--- a/backend/db/changelog/081-org-slug-uniqueness.yaml
+++ b/backend/db/changelog/081-org-slug-uniqueness.yaml
@@ -1,0 +1,58 @@
+# Slug-URL work (feat/slug-urls): organizations.slug is the primary segment of
+# the canonical custom-MCP URL (/org/<org_slug>/custom/<slug>/mcp), so it must
+# be clean and unique. The app-DB table was created with `slug citext NOT NULL
+# UNIQUE` (009), and pm_core — the authoritative org store post-cutover — has
+# the same (vendor 006-organizations.yaml), so this changeset is a safety net:
+# it normalizes slugs (slugify; collisions resolved with -2/-3 suffixes) and
+# adds a named unique index. Idempotent by construction (already-clean rows are
+# skipped, IF NOT EXISTS index) and designed to be runnable post-merge.
+# The unit-tested reference logic lives in
+# NoizuPromptLingua.Organizations.SlugBackfill (slugify + -2/-3 collision rule).
+databaseChangeLog:
+  - changeSet:
+      id: org-slug-normalize-and-unique-index
+      author: tobor-locker
+      changes:
+        - sql:
+            splitStatements: false
+            sql: |
+              DO $$
+              DECLARE
+                r record;
+                base text;
+                candidate text;
+                n int;
+              BEGIN
+                FOR r IN SELECT id, slug, name FROM organizations LOOP
+                  base := lower(regexp_replace(
+                    coalesce(nullif(btrim(coalesce(r.slug, '')), ''), r.name, r.id::text),
+                    '[^a-z0-9]+', '-', 'g'));
+                  base := btrim(base, '-');
+                  IF base IS NULL OR base = '' THEN
+                    base := 'org-' || left(r.id::text, 8);
+                  END IF;
+                  base := left(base, 64);
+                  candidate := base;
+                  n := 1;
+                  WHILE EXISTS (
+                    SELECT 1 FROM organizations o
+                    WHERE o.slug = candidate AND o.id <> r.id
+                  ) LOOP
+                    n := n + 1;
+                    candidate := base || '-' || n::text;
+                  END LOOP;
+                  IF candidate <> r.slug THEN
+                    UPDATE organizations
+                      SET slug = candidate, updated_at = now()
+                      WHERE id = r.id;
+                  END IF;
+                END LOOP;
+              END $$;
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_organizations_slug
+                ON organizations (slug);
+      rollback:
+        - sql:
+            # The named index only; normalized slugs are kept (data fix, not a
+            # schema fix — restoring whitespace would be restoring damage).
+            sql: |
+              DROP INDEX IF EXISTS idx_organizations_slug;

--- a/backend/db/changelog/db.changelog-master.yaml
+++ b/backend/db/changelog/db.changelog-master.yaml
@@ -244,3 +244,6 @@ databaseChangeLog:
   - include:
       file: 080-mcp-key-toolsets.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 081-org-slug-uniqueness.yaml
+      relativeToChangelogFile: true

--- a/backend/lib/noizu_prompt_lingua/entities/organizations.ex
+++ b/backend/lib/noizu_prompt_lingua/entities/organizations.ex
@@ -65,6 +65,20 @@ defmodule NoizuPromptLingua.Organizations do
     NoizuPromptLingua.PMCore.with_pm(fn -> Noizu.PM.Organizations.get_id_by_slug(slug) end)
   end
 
+  @doc """
+  Slug for an org id (pm_core), or nil. Inverse of `get_id_by_slug/1`; used to
+  build canonical org-addressed URLs (e.g. the custom-MCP gateway's 301 of the
+  legacy `/custom/:slug/mcp` path to `/org/:org_slug/custom/:slug/mcp`).
+  """
+  def get_slug_by_id(id) do
+    NoizuPromptLingua.PMCore.with_pm(fn ->
+      case Noizu.PM.Organizations.get_organization(id) do
+        %{slug: slug} -> slug
+        _ -> nil
+      end
+    end)
+  end
+
   def update_organization(id, attrs) do
     case NoizuPromptLingua.Repo.get(Schema, id) do
       nil ->

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -130,6 +130,16 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   end
 
   @doc """
+  Resolve a scope by (organization_id, slug) — the org-addressed URL form
+  `/org/:org_slug/custom/:slug/mcp`. Slug matching is normalized case-insensitively,
+  as in `get_by_slug/1`. Returns nil when the slug exists but belongs to a
+  different org (or no org), so a slug can never be served outside its owner.
+  """
+  def get_by_org_and_slug(org_id, slug) when is_binary(slug) do
+    Repo.get_by(MCPCustomScope, organization_id: org_id, slug: normalize_slug(slug))
+  end
+
+  @doc """
   Get-or-create the global `tobor` all-in-one scope. Idempotent. Used as the
   unauthenticated setup fallback; signed-in accounts get `ensure_account_default/1`.
   """

--- a/backend/lib/noizu_prompt_lingua/organizations/slug_backfill.ex
+++ b/backend/lib/noizu_prompt_lingua/organizations/slug_backfill.ex
@@ -1,0 +1,119 @@
+defmodule NoizuPromptLingua.Organizations.SlugBackfill do
+  @moduledoc """
+  Org-slug normalization + collision-safe backfill for the slug-URL work
+  (`081-org-slug-uniqueness` Liquibase changeset / Ecto twin).
+
+  `organizations.slug` is the primary segment of the canonical custom-MCP URL
+  (`/org/<org_slug>/custom/<slug>/mcp`), so it must be clean and unique. The
+  SQL changeset does the same normalization inline; these pure functions are
+  the unit-tested reference implementation.
+
+  Note pm_core — the authoritative org store post-cutover — already enforces
+  `slug citext NOT NULL UNIQUE` (vendor 006-organizations.yaml). This module
+  targets the legacy app-DB table, where the inline UNIQUE constraint exists
+  but slugs may still be unnormalized (whitespace, mixed separators).
+  """
+
+  @max_length 64
+
+  @doc """
+  Slugify a slug/name: lowercase, every run of non-`[a-z0-9]` collapsed to a
+  single `-`, edges trimmed, capped at #{@max_length}. Blank or fully
+  non-alphanumeric input yields nil.
+  """
+  def slugify(nil), do: nil
+
+  def slugify(value) when is_binary(value) do
+    value
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+    |> String.slice(0, @max_length)
+    |> String.trim_trailing("-")
+    |> case do
+      "" -> nil
+      slug -> slug
+    end
+  end
+
+  def slugify(_), do: nil
+
+  @doc """
+  Plan final slugs for `rows` (`%{id, slug, name}` maps). Deterministic:
+  rows claim candidates in input order, first claim wins; a candidate already
+  taken gets a `-2`, `-3`, … suffix. Each row's candidate is
+  `slugify(slug) || slugify(name) || "org-" <> first-8-of-id`.
+
+  Returns `%{id => final_slug}` covering every row.
+  """
+  def plan(rows) when is_list(rows) do
+    {_taken, planned} =
+      Enum.reduce(rows, {MapSet.new(), %{}}, fn row, {taken, planned} ->
+        final = claim(candidate(row), taken, 1)
+        {MapSet.put(taken, final), Map.put(planned, row.id, final)}
+      end)
+
+    planned
+  end
+
+  @doc """
+  The subset of the plan that differs from the row's current slug:
+  `[{id, from_slug, to_slug}]` — exactly the updates `run/0` applies.
+  """
+  def changes(rows) when is_list(rows) do
+    planned = plan(rows)
+
+    Enum.flat_map(rows, fn %{id: id, slug: from} ->
+      to = Map.fetch!(planned, id)
+      if from != to, do: [{id, from, to}], else: []
+    end)
+  end
+
+  @doc """
+  Apply the plan to the app-DB organizations table inside one transaction.
+  Returns `{:ok, updated_count}`. Rows already normalized are left untouched,
+  so re-running converges (idempotent).
+  """
+  def run do
+    import Ecto.Query, only: [from: 2]
+
+    alias NoizuPromptLingua.Repo
+    alias NoizuPromptLingua.Schema.Organizations.Organization
+
+    rows = Repo.all(from(o in Organization, select: %{id: o.id, slug: o.slug, name: o.name}))
+    updates = changes(rows)
+
+    {:ok, _} =
+      Repo.transaction(fn ->
+        Enum.each(updates, fn {id, _from, to} ->
+          Repo.get!(Organization, id)
+          |> Ecto.Changeset.change(slug: to)
+          |> Repo.update!()
+        end)
+      end)
+
+    {:ok, length(updates)}
+  end
+
+  defp candidate(%{slug: slug, name: name, id: id}) do
+    slugify(slug) || slugify(name) || "org-" <> String.slice(to_string(id), 0, 8)
+  end
+
+  defp claim(candidate, taken, 1) do
+    if MapSet.member?(taken, candidate) do
+      claim(candidate, taken, 2)
+    else
+      candidate
+    end
+  end
+
+  defp claim(base, taken, n) do
+    candidate = "#{base}-#{n}"
+
+    if MapSet.member?(taken, candidate) do
+      claim(base, taken, n + 1)
+    else
+      candidate
+    end
+  end
+end

--- a/backend/lib/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_controller.ex
@@ -2,40 +2,107 @@ defmodule NoizuPromptLinguaWeb.CustomMCPGatewayController do
   use NoizuPromptLinguaWeb, :controller
 
   alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.Organizations
+  alias NoizuPromptLingua.Schema.MCPCustomScope
 
-  def handle(conn, %{"slug" => slug}) do
-    case MCPCustomScopes.get_by_slug(slug) do
-      nil ->
-        conn
-        |> put_status(:not_found)
-        |> json(%{error: "Custom MCP scope not found"})
+  @doc """
+  Org-addressed (canonical) entry: /org/<org_slug>/custom/<slug>/mcp.
 
-      _scope ->
-        path = "/custom/#{slug}/mcp"
-        resource = "https://#{conn.host}#{path}"
-
-        # This endpoint audience-binds to its own URL, so its 401 challenge must
-        # advertise its own RFC 9728 document -- the root one declares
-        # `<host>/mcp`, and a client honouring that would come back with a token
-        # bound to the wrong resource.
-        opts =
-          NoizuPromptLinguaWeb.MCPConfig.plug_opts(
-            NoizuPromptLingua.MCP.Custom,
-            [expected_audience: resource],
-            resource_metadata:
-              NoizuPromptLinguaWeb.MCPConfig.resource_metadata_url_for_path(conn.host, path)
-          )
-          |> Keyword.put(:context, {__MODULE__, :mcp_context})
-          |> Noizu.MCP.Transport.StreamableHTTP.Plug.init()
-
-        conn
-        |> Plug.Conn.assign(:custom_scope_slug, slug)
-        |> Map.put(:path_info, [])
-        |> Noizu.MCP.Transport.StreamableHTTP.Plug.call(opts)
+  Resolves the org by slug (UUID-or-slug resolver with the Redis-backed slug
+  cache), then resolves the scope by (org_id, slug) so a slug can never be
+  served outside its owning org.
+  """
+  def handle_org(conn, %{"org_slug" => org_slug, "slug" => slug}) do
+    with {:ok, org_id} <- Organizations.resolve_org_id(org_slug),
+         %MCPCustomScope{} = scope <-
+           MCPCustomScopes.get_by_org_and_slug(org_id, slug) do
+      serve(conn, scope, "/org/#{org_slug}/custom/#{scope.slug}/mcp", org_id)
+    else
+      _ ->
+        not_found(conn)
     end
   end
 
+  @doc """
+  Legacy entry: /custom/<slug>/mcp. Permanent alias, never breaks:
+
+  - Browser GET/HEAD of an org-bound scope 301s to its canonical
+    /org/<org_slug>/custom/<slug>/mcp URL.
+  - Everything else (MCP clients POST JSON-RPC and cannot be relied on to
+    re-issue a redirect) is served in place, exactly as before.
+  """
+  def handle(conn, %{"slug" => slug}) do
+    case MCPCustomScopes.get_by_slug(slug) do
+      nil ->
+        not_found(conn)
+
+      scope ->
+        if redirect?(conn, scope) do
+          redirect_legacy(conn, scope)
+        else
+          serve(conn, scope, "/custom/#{scope.slug}/mcp", nil)
+        end
+    end
+  end
+
+  defp redirect?(%{method: method}, scope) do
+    method in ["GET", "HEAD"] and scope.organization_id != nil
+  end
+
+  defp redirect_legacy(conn, scope) do
+    case Organizations.get_slug_by_id(scope.organization_id) do
+      nil ->
+        # Org row is gone/unreachable — keep the alias resolving in place.
+        serve(conn, scope, "/custom/#{scope.slug}/mcp", nil)
+
+      org_slug ->
+        location =
+          "/org/#{org_slug}/custom/#{scope.slug}/mcp" <>
+            if(conn.query_string == "", do: "", else: "?" <> conn.query_string)
+
+        conn
+        |> put_status(:moved_permanently)
+        |> put_resp_header("location", location)
+        |> json(%{redirect: location})
+      end
+  end
+
+  defp not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{error: "Custom MCP scope not found"})
+  end
+
+  defp serve(conn, scope, path, org_id) do
+    resource = "https://#{conn.host}#{path}"
+
+    # This endpoint audience-binds to its own URL, so its 401 challenge must
+    # advertise its own RFC 9728 document -- the root one declares
+    # `<host>/mcp`, and a client honouring that would come back with a token
+    # bound to the wrong resource.
+    opts =
+      NoizuPromptLinguaWeb.MCPConfig.plug_opts(
+        NoizuPromptLingua.MCP.Custom,
+        [expected_audience: resource],
+        resource_metadata:
+          NoizuPromptLinguaWeb.MCPConfig.resource_metadata_url_for_path(conn.host, path)
+      )
+      |> Keyword.put(:context, {__MODULE__, :mcp_context})
+      |> Noizu.MCP.Transport.StreamableHTTP.Plug.init()
+
+    conn
+    |> Plug.Conn.assign(:custom_scope_slug, scope.slug)
+    |> Plug.Conn.assign(:custom_scope_org_id, org_id)
+    |> Map.put(:path_info, [])
+    |> Noizu.MCP.Transport.StreamableHTTP.Plug.call(opts)
+  end
+
   def mcp_context(conn) do
-    %{custom_scope_slug: conn.assigns[:custom_scope_slug]}
+    base = %{custom_scope_slug: conn.assigns[:custom_scope_slug]}
+
+    case conn.assigns[:custom_scope_org_id] do
+      nil -> base
+      org_id -> Map.put(base, :custom_scope_org_id, org_id)
+    end
   end
 end

--- a/backend/lib/noizu_prompt_lingua_web/router.ex
+++ b/backend/lib/noizu_prompt_lingua_web/router.ex
@@ -352,6 +352,15 @@ defmodule NoizuPromptLinguaWeb.Router do
     match :*, "/custom/:slug/mcp", CustomMCPGatewayController, :handle
   end
 
+  # Org-addressed custom MCP gateway — the canonical URL shape:
+  # <host>/org/<org_slug>/custom/<slug>/mcp. The org segment scopes the slug
+  # lookup (the scope must belong to that org). The legacy <host>/custom/<slug>/mcp
+  # path above remains a permanent alias: it 301s browser GETs of org-bound
+  # scopes to this canonical form and serves everything else in place.
+  scope "/", NoizuPromptLinguaWeb do
+    match :*, "/org/:org_slug/custom/:slug/mcp", CustomMCPGatewayController, :handle_org
+  end
+
   scope "/mcp" do
     forward "/",
             Noizu.MCP.Transport.StreamableHTTP.Plug,

--- a/backend/priv/repo/migrations/20260831010000_org_slug_uniqueness.exs
+++ b/backend/priv/repo/migrations/20260831010000_org_slug_uniqueness.exs
@@ -1,0 +1,57 @@
+defmodule NoizuPromptLingua.Repo.Migrations.OrgSlugUniqueness do
+  use Ecto.Migration
+
+  @moduledoc """
+  Org-slug normalization + named unique index (Liquibase 081-org-slug-uniqueness
+  twin). Ecto mirrors are the prod-apply path (Helm gates Liquibase off), so
+  this must be independently safe: already-clean rows are skipped and the index
+  is IF NOT EXISTS. Collision rule (suffix -2, -3, …) matches the unit-tested
+  NoizuPromptLingua.Organizations.SlugBackfill reference implementation.
+  """
+
+  @normalize ~S"""
+  DO $$
+  DECLARE
+    r record;
+    base text;
+    candidate text;
+    n int;
+  BEGIN
+    FOR r IN SELECT id, slug, name FROM organizations LOOP
+      base := lower(regexp_replace(
+        coalesce(nullif(btrim(coalesce(r.slug, '')), ''), r.name, r.id::text),
+        '[^a-z0-9]+', '-', 'g'));
+      base := btrim(base, '-');
+      IF base IS NULL OR base = '' THEN
+        base := 'org-' || left(r.id::text, 8);
+      END IF;
+      base := left(base, 64);
+      candidate := base;
+      n := 1;
+      WHILE EXISTS (
+        SELECT 1 FROM organizations o
+        WHERE o.slug = candidate AND o.id <> r.id
+      ) LOOP
+        n := n + 1;
+        candidate := base || '-' || n::text;
+      END LOOP;
+      IF candidate <> r.slug THEN
+        UPDATE organizations
+          SET slug = candidate, updated_at = now()
+          WHERE id = r.id;
+      END IF;
+    END LOOP;
+  END $$;
+  """
+
+  def up do
+    execute(@normalize)
+    execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_organizations_slug ON organizations (slug)")
+  end
+
+  def down do
+    # The named index only; normalized slugs are kept (data fix, not a schema
+    # fix — restoring whitespace would be restoring damage).
+    execute("DROP INDEX IF EXISTS idx_organizations_slug")
+  end
+end

--- a/backend/test/noizu_prompt_lingua/organizations/slug_backfill_test.exs
+++ b/backend/test/noizu_prompt_lingua/organizations/slug_backfill_test.exs
@@ -1,0 +1,92 @@
+defmodule NoizuPromptLingua.Organizations.SlugBackfillTest do
+  @moduledoc """
+  Pure-function coverage for the org-slug backfill reference logic (Liquibase
+  081 twin): slugify normalization, the -2/-3 collision rule, and the
+  plan/changes split. No DB — the SQL changeset is verified separately by its
+  idempotent-by-construction shape.
+  """
+  use ExUnit.Case, async: true
+
+  alias NoizuPromptLingua.Organizations.SlugBackfill
+
+  describe "slugify/1" do
+    test "lowercases and collapses non-alphanumeric runs to single dashes" do
+      assert SlugBackfill.slugify("Acme Corp!") == "acme-corp"
+      assert SlugBackfill.slugify("  --Foo__Bar  ") == "foo-bar"
+      assert SlugBackfill.slugify("Café Org") == "caf-org"
+    end
+
+    test "blank or non-alphanumeric input yields nil" do
+      assert SlugBackfill.slugify(nil) == nil
+      assert SlugBackfill.slugify("") == nil
+      assert SlugBackfill.slugify("   ") == nil
+      assert SlugBackfill.slugify("---___") == nil
+    end
+
+    test "caps at 64 characters and does not end on a dash" do
+      long = String.duplicate("a", 60) <> "-" <> String.duplicate("b", 10)
+      slug = SlugBackfill.slugify(long)
+      assert byte_size(slug) == 64
+      refute String.ends_with?(slug, "-")
+    end
+  end
+
+  describe "plan/1" do
+    test "first row wins a candidate; later collisions take -2 then -3" do
+      rows = [
+        %{id: "a", slug: "acme", name: "Acme"},
+        %{id: "b", slug: "acme corp", name: "Acme Corp"},
+        %{id: "c", slug: "ACME-CORP!", name: "Acme Three"}
+      ]
+
+      assert SlugBackfill.plan(rows) == %{
+               "a" => "acme",
+               "b" => "acme-corp",
+               "c" => "acme-corp-2"
+             }
+    end
+
+    test "already-clean slugs pass through unchanged" do
+      rows = [%{id: "a", slug: "acme", name: "Acme"}, %{id: "b", slug: "other", name: "Other"}]
+      assert SlugBackfill.plan(rows) == %{"a" => "acme", "b" => "other"}
+    end
+
+    test "falls back to the name, then to org-<id8>" do
+      rows = [
+        %{id: "11111111-2222-3333-4444-555555555555", slug: "  --  ", name: "Fallback Name"},
+        %{id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", slug: nil, name: "!!!"}
+      ]
+
+      assert SlugBackfill.plan(rows) == %{
+               "11111111-2222-3333-4444-555555555555" => "fallback-name",
+               "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" => "org-aaaaaaaa"
+             }
+    end
+
+    test "suffixed candidates are themselves collision-checked" do
+      rows = [
+        %{id: "a", slug: "acme", name: "Acme"},
+        %{id: "b", slug: "acme", name: "Acme 2"},
+        %{id: "c", slug: "acme-2", name: "Acme 3"}
+      ]
+
+      assert SlugBackfill.plan(rows) == %{"a" => "acme", "b" => "acme-2", "c" => "acme-2-2"}
+    end
+  end
+
+  describe "changes/1" do
+    test "reports only rows whose final slug differs, as {id, from, to}" do
+      rows = [
+        %{id: "a", slug: "acme", name: "Acme"},
+        %{id: "b", slug: "Acme Corp", name: "Acme Corp"}
+      ]
+
+      assert [{_id, "Acme Corp", "acme-corp"}] = SlugBackfill.changes(rows)
+    end
+
+    test "empty when everything is already clean" do
+      rows = [%{id: "a", slug: "acme", name: "Acme"}]
+      assert SlugBackfill.changes(rows) == []
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_slug_urls_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_slug_urls_test.exs
@@ -1,0 +1,165 @@
+defmodule NoizuPromptLinguaWeb.CustomMCPGatewaySlugUrlsTest do
+  @moduledoc """
+  Slug-URL work (feat/slug-urls): the canonical org-addressed custom-MCP URL
+  (`/org/:org_slug/custom/:slug/mcp`) plus the legacy alias contract —
+  `/custom/:slug/mcp` never breaks: browser GETs of org-bound scopes 301 to the
+  canonical form, everything else (MCP clients POST JSON-RPC) is served in
+  place exactly as before.
+
+  Unauthenticated requests that reach the MCP plug deterministically get its
+  401 challenge, which is used here as the "served in place" marker — the
+  gateway resolved the scope and handed off, versus 404 (not found / wrong org)
+  and 301 (redirected).
+  """
+  use NoizuPromptLinguaWeb.ConnCase
+
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLinguaWeb.Router
+
+  setup do
+    # Slug uniqueness must hold across runs: the org slug -> UUID map is
+    # cached in Redis and the sandbox does not roll Redis back (same hazard as
+    # org_slug_length_test). unique_integer is not ExUnit-seed derived.
+    uniq = System.unique_integer([:positive])
+    %{uniq: uniq, org_a: nil, org_b: nil}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Router shape
+  # ---------------------------------------------------------------------------
+
+  test "router exposes the canonical org-addressed path and the legacy alias" do
+    paths = MapSet.new(Router.__routes__(), & &1.path)
+
+    assert MapSet.member?(paths, "/org/:org_slug/custom/:slug/mcp")
+    assert MapSet.member?(paths, "/custom/:slug/mcp")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Legacy alias: /custom/:slug/mcp
+  # ---------------------------------------------------------------------------
+
+  test "GET of a legacy org-bound scope 301s to the canonical org URL, query preserved", %{
+    conn: conn,
+    uniq: uniq
+  } do
+    {org, scope} = org_with_scope("w1a", uniq)
+
+    conn = get(conn, "/custom/#{scope.slug}/mcp?x=1")
+
+    assert conn.status == 301
+
+    assert Plug.Conn.get_resp_header(conn, "location") == [
+             "/org/#{org.slug}/custom/#{scope.slug}/mcp?x=1"
+           ]
+  end
+
+  test "POST of a legacy org-bound scope is served in place, never redirected", %{
+    conn: conn,
+    uniq: uniq
+  } do
+    {_org, scope} = org_with_scope("w1b", uniq)
+
+    conn = post(conn, "/custom/#{scope.slug}/mcp")
+
+    # MCP clients cannot be relied on to re-issue a redirect — the alias must
+    # keep serving. 401 = gateway resolved the scope and handed to the plug.
+    assert conn.status == 401
+    assert Plug.Conn.get_resp_header(conn, "location") == []
+  end
+
+  test "GET of a legacy org-less (global) scope is served in place, not redirected", %{
+    conn: conn,
+    uniq: uniq
+  } do
+    _scope = create_scope("w1g-#{uniq}", nil)
+
+    conn = get(conn, "/custom/w1g-#{uniq}/mcp")
+
+    assert conn.status == 401
+    assert Plug.Conn.get_resp_header(conn, "location") == []
+  end
+
+  test "unknown legacy slug is a 404", %{conn: conn} do
+    conn = get(conn, "/custom/w1-never-created/mcp")
+    assert conn.status == 404
+  end
+
+  # ---------------------------------------------------------------------------
+  # Canonical: /org/:org_slug/custom/:slug/mcp
+  # ---------------------------------------------------------------------------
+
+  test "org-addressed URL resolves by (org slug, slug)", %{conn: conn, uniq: uniq} do
+    {_org, scope} = org_with_scope("w1c", uniq)
+
+    conn = post(conn, "/org/#{org_slug("w1c", uniq)}/custom/#{scope.slug}/mcp")
+
+    assert conn.status == 401
+  end
+
+  test "a scope is never served under a different org's URL", %{conn: conn, uniq: uniq} do
+    {org_a, scope} = org_with_scope("w1d", uniq)
+    _org_b = create_org(org_b_slug(uniq))
+
+    conn = post(conn, "/org/#{org_b_slug(uniq)}/custom/#{scope.slug}/mcp")
+
+    assert conn.status == 404
+    # And the owner's org still resolves — the 404 is scoping, not absence.
+    assert MCPCustomScopes.get_by_org_and_slug(org_a.id, scope.slug) != nil
+  end
+
+  test "unknown org slug is a 404", %{conn: conn, uniq: uniq} do
+    scope = create_scope("w1e-#{uniq}", nil)
+
+    conn = post(conn, "/org/w1-no-such-org-#{uniq}/custom/#{scope.slug}/mcp")
+    assert conn.status == 404
+  end
+
+  test "known org but wrong slug is a 404", %{conn: conn, uniq: uniq} do
+    {_org, _scope} = org_with_scope("w1f", uniq)
+
+    conn = post(conn, "/org/#{org_slug("w1f", uniq)}/custom/w1-wrong-slug/mcp")
+    assert conn.status == 404
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp org_slug(prefix, uniq), do: "#{prefix}-org-#{uniq}"
+
+  defp pm_repo_live? do
+    match?({:module, _}, Code.ensure_loaded(Noizu.PM.Repo)) and
+      is_pid(Process.whereis(Noizu.PM.Repo))
+  end
+
+  defp create_org(slug) do
+    {:ok, org} =
+      %Noizu.PM.Schema.Organizations.Organization{}
+      |> Ecto.Changeset.change(%{slug: slug, name: "W1 Org #{slug}"})
+      |> Noizu.PM.Repo.insert()
+
+    org
+  end
+
+  defp create_scope(slug, org_id) do
+    attrs =
+      %{"slug" => slug, "name" => "W1 Scope #{slug}", "config" => %{"groups" => %{}}}
+      |> then(fn a -> if org_id, do: Map.put(a, "organization_id", org_id), else: a end)
+
+    {:ok, scope} = MCPCustomScopes.create(attrs)
+    scope
+  end
+
+  defp org_with_scope(prefix, uniq) do
+    unless pm_repo_live?() do
+      raise "pm repo not live — run @tag :pm_live tests only when Noizu.PM.Repo is started"
+    end
+
+    org = create_org(org_slug(prefix, uniq))
+    scope = create_scope("#{prefix}-scope-#{uniq}", org.id)
+    {org, scope}
+  end
+
+  defp org_b_slug(uniq), do: "w1d-b-org-#{uniq}"
+end


### PR DESCRIPTION
Wave item of the tobor.locker overhaul (TOBOR-PLAN.md). Early WIP — opened as draft for visibility; spec-compliance review pending. Phase-0 deps and the contract rulings in `TOBOR-REVIEW.md` (trl-infra root) apply. Merge order: after Phase 0 per plan.