### PR TITLE
feat(mcp): scope clone endpoint + per-endpoint Setup MCP popunder (W3)

### DIFF
--- a/backend/lib/noizu_prompt_lingua_web/controllers/admin_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/admin_controller.ex
@@ -1229,6 +1229,28 @@ defmodule NoizuPromptLinguaWeb.AdminController do
     conn |> put_status(:bad_request) |> json(%{error: "scope required"})
   end
 
+  @doc """
+  Clone a custom scope into a new endpoint (config copied verbatim, original
+  untouched). Mirrors `clone_mcp_key`. `scope` attrs may override `name`,
+  `slug`, `description`, `kind`. `/copy` is kept as a legacy alias route.
+  """
+  def clone_mcp_custom_scope(conn, %{"slug" => slug} = params) do
+    attrs = Map.get(params, "scope") || %{}
+
+    case MCPCustomScopes.copy(slug, attrs) do
+      {:ok, scope} ->
+        conn
+        |> put_status(:created)
+        |> json(%{scope: MCPCustomScopes.scope_json(scope, mcp_host(conn))})
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "Scope not found"})
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{errors: format_errors(cs)})
+    end
+  end
+
   def update_mcp_custom_scope(conn, %{"slug" => slug, "scope" => attrs} = params) do
     # `confirm` may arrive at the top level or inside the scope map; thread the
     # acting admin so a confirmed disable records who authorized it.

--- a/backend/lib/noizu_prompt_lingua_web/router.ex
+++ b/backend/lib/noizu_prompt_lingua_web/router.ex
@@ -508,6 +508,10 @@ defmodule NoizuPromptLinguaWeb.Router do
     get "/mcp-custom-scopes/:slug", AdminController, :show_mcp_custom_scope
     patch "/mcp-custom-scopes/:slug", AdminController, :update_mcp_custom_scope
     delete "/mcp-custom-scopes/:slug", AdminController, :delete_mcp_custom_scope
+    post "/mcp-custom-scopes/:slug/clone", AdminController, :clone_mcp_custom_scope
+    # Legacy alias — the action was originally named copy; kept resolving so any
+    # external callers with copy in their scripts keep working.
+    post "/mcp-custom-scopes/:slug/copy", AdminController, :clone_mcp_custom_scope
 
     # mcp_overview review flow — list generated overviews, approve/reject/edit
     # (editing the Markdown implies approval). UI is a follow-up.

--- a/backend/test/noizu_prompt_lingua_web/controllers/mcp_custom_scope_controller_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/mcp_custom_scope_controller_test.exs
@@ -61,4 +61,47 @@ defmodule NoizuPromptLinguaWeb.MCPCustomScopeControllerTest do
 
     assert denied["error"] =~ "cannot be deleted"
   end
+
+  test "admin can clone a custom scope (config copied, original untouched)", %{conn: conn} do
+    post(conn, "/api/v1/admin/mcp-custom-scopes", %{
+      scope: %{
+        slug: "clone-src",
+        name: "Clone Source",
+        description: "before clone",
+        config: %{groups: %{sessions: %{tools: %{"Session.Create" => %{disabled: true}}}}}
+      }
+    })
+    |> json_response(201)
+
+    clone =
+      post(conn, "/api/v1/admin/mcp-custom-scopes/clone-src/clone", %{
+        scope: %{slug: "clone-dst", name: "Clone Dst"}
+      })
+      |> json_response(201)
+
+    assert clone["scope"]["slug"] == "clone-dst"
+    assert clone["scope"]["name"] == "Clone Dst"
+    # description/kind/config fall back to the source
+    assert clone["scope"]["description"] == "before clone"
+    assert clone["scope"]["source_template_slug"] == "clone-src"
+    assert clone["scope"]["config"]["groups"]["sessions"]["tools"]["Session.Create"]["disabled"] ==
+             true
+
+    # the source scope is untouched
+    orig = conn |> get("/api/v1/admin/mcp-custom-scopes/clone-src") |> json_response(200)
+    assert orig["scope"]["name"] == "Clone Source"
+    assert orig["scope"]["slug"] == "clone-src"
+
+    # legacy /copy alias route resolves to the same action
+    alias_copy =
+      post(conn, "/api/v1/admin/mcp-custom-scopes/clone-src/copy", %{
+        scope: %{slug: "clone-alias"}
+      })
+      |> json_response(201)
+
+    assert alias_copy["scope"]["slug"] == "clone-alias"
+
+    missing = post(conn, "/api/v1/admin/mcp-custom-scopes/nope/clone") |> json_response(404)
+    assert missing["error"] =~ "not found"
+  end
 end

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -10,6 +10,7 @@ import {
   type McpCustomScopeConfig,
   type McpCustomTool,
 } from '@/lib/api';
+import McpEndpointSetupPopunder from '@/components/mcp-endpoint-setup-popunder';
 
 type ScopeForm = {
   originalSlug?: string;
@@ -51,6 +52,19 @@ function formFromScope(scope: McpCustomScope): ScopeForm {
   };
 }
 
+/**
+ * STUB — canonical URL builder is the backend `NoizuPromptLingua.MCP.Urls`
+ * (TOBOR-CONTRACTS §2, F2 branch). Until that merges, prefer the scope's own
+ * backend-provided URL and otherwise build the canonical
+ * `/org/:org_slug/custom/:slug/mcp` shape with the org segment unresolved.
+ */
+function stubScopeUrl(scope?: McpCustomScope | null): string {
+  if (!scope) return 'https://tobor.locker/org/:org_slug/custom/:slug/mcp';
+  return (
+    scope.url || `https://tobor.locker/org/:org_slug/custom/${encodeURIComponent(scope.slug)}/mcp`
+  );
+}
+
 function included(config: McpCustomScopeConfig, groupId: string) {
   return !!config.groups[groupId] && config.groups[groupId].disabled !== true;
 }
@@ -90,6 +104,7 @@ export default function AdminMcpCustomScopesPage() {
   const [form, setForm] = useState<ScopeForm>(blankForm());
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [setupOpen, setSetupOpen] = useState(false);
 
   const selectedScope = useMemo(
     () => scopes.find((s) => s.slug === form.originalSlug) ?? null,
@@ -216,25 +231,22 @@ export default function AdminMcpCustomScopesPage() {
     }
   }
 
-  async function duplicate() {
+  async function clone() {
     if (!form.originalSlug) {
-      toast.error('Save the endpoint before copying it');
+      toast.error('Save the endpoint before cloning it');
       return;
     }
     setSaving(true);
     try {
-      const res = await api.adminCreateMcpCustomScope({
-        slug: slugify(`${form.slug}-copy`),
-        name: `${form.name} copy`,
-        description: form.description.trim(),
-        kind: form.kind === 'all_in_one' ? 'custom' : form.kind || 'custom',
-        config: form.config,
+      const res = await api.adminCloneMcpCustomScope(form.originalSlug, {
+        slug: slugify(`${form.slug}-clone`),
+        name: `${form.name} clone`,
       });
       setScopes((prev) => [res.scope, ...prev.filter((s) => s.id !== res.scope.id)]);
       setForm(formFromScope(res.scope));
-      toast.success('Copied to a new endpoint');
+      toast.success('Cloned to a new endpoint');
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Copy failed');
+      toast.error(err instanceof Error ? err.message : 'Clone failed');
     } finally {
       setSaving(false);
     }
@@ -260,7 +272,7 @@ export default function AdminMcpCustomScopesPage() {
           Users and organizations are always given a <strong>Tobor Locker</strong>
           endpoint cloned from the global template at{' '}
           <span className="font-mono">/custom/tobor/mcp</span>. Edit standard
-          templates here; people can copy and edit their own instances from
+          templates here; people can clone and edit their own instances from
           MCP client setup. <Link href="/app/admin">Back to Admin</Link>
         </p>
 
@@ -307,8 +319,13 @@ export default function AdminMcpCustomScopesPage() {
                     </button>
                   )}
                   {form.originalSlug && (
-                    <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={duplicate} disabled={saving}>
-                      Copy endpoint
+                    <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={clone} disabled={saving}>
+                      Clone endpoint
+                    </button>
+                  )}
+                  {form.originalSlug && (
+                    <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={() => setSetupOpen(true)}>
+                      Setup MCP
                     </button>
                   )}
                 </div>
@@ -453,6 +470,15 @@ export default function AdminMcpCustomScopesPage() {
               </div>
             </form>
           </div>
+        )}
+
+        {selectedScope && (
+          <McpEndpointSetupPopunder
+            open={setupOpen}
+            onClose={() => setSetupOpen(false)}
+            scope={selectedScope}
+            mcpUrl={stubScopeUrl(selectedScope)}
+          />
         )}
       </main>
     </div>

--- a/frontend/src/components/mcp-endpoint-setup-popunder.tsx
+++ b/frontend/src/components/mcp-endpoint-setup-popunder.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { toast } from 'sonner';
+import { TabbedPopunder } from '@/components/kit';
+import { DEFAULT_MCP_AUTH_ENV_VAR } from '@/lib/mcp-setup';
+import type { McpCustomScope } from '@/lib/api';
+
+/**
+ * Per-endpoint "Setup MCP" popunder (W3).
+ *
+ * Tab per CLI agent (Claude CLI / Grok / Codex / OpenCode) plus a generic
+ * curl/manual tab; each renders a copy-paste JSON config block + CLI one-liner
+ * for registering the endpoint. Extends the snippet patterns in
+ * `components/mcp-setup-panel.tsx` (same `claude mcp add` / `codex mcp add` /
+ * `grok mcp add` command shapes and `tobor-<slug>` registration names).
+ *
+ * The MCP URL arrives as a plain prop — the canonical builder is the backend
+ * `NoizuPromptLingua.MCP.Urls` (TOBOR-CONTRACTS §2, F2). Until that merges,
+ * callers stub the value with the canonical shape
+ * `https://tobor.locker/org/:org_slug/custom/:slug/mcp`.
+ */
+
+type TabId = 'claude-cli' | 'grok' | 'codex' | 'opencode' | 'generic';
+
+interface McpEndpointSetupPopunderProps {
+  open: boolean;
+  onClose: () => void;
+  /** Scope being set up (slug names the registered server). */
+  scope: Pick<McpCustomScope, 'slug' | 'name'> | null;
+  /** Resolved endpoint URL (canonical shape per TOBOR-CONTRACTS §2). */
+  mcpUrl: string;
+  /** Env var the bearer token is exported under (see lib/mcp-setup). */
+  authEnvName?: string;
+}
+
+function serverName(slug: string) {
+  return `tobor-${slug.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
+function snippet(label: string, text: string) {
+  return <SnippetBlock key={label} label={label} text={text} />;
+}
+
+function SnippetBlock({ label, text }: { label: string; text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      toast.success('Copied to clipboard');
+    } catch {
+      toast.error('Copy failed — select and copy manually');
+    }
+  }
+
+  return (
+    <div style={{ position: 'relative', marginBottom: 14 }}>
+      <button
+        type="button"
+        onClick={copy}
+        style={{
+          ...btnSm,
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          zIndex: 1,
+          ...(copied
+            ? { background: 'var(--green-dim)', color: 'var(--green)', borderColor: 'var(--green)' }
+            : {}),
+        }}
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+      <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)', marginBottom: 6 }}>
+        {label}
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: 16,
+          paddingRight: 80,
+          background: 'var(--bg-3)',
+          borderRadius: 'var(--radius-sm)',
+          fontFamily: 'monospace',
+          fontSize: 12,
+          lineHeight: 1.7,
+          color: 'var(--text-1)',
+          overflowX: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all',
+        }}
+      >
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+export default function McpEndpointSetupPopunder({
+  open,
+  onClose,
+  scope,
+  mcpUrl,
+  authEnvName = DEFAULT_MCP_AUTH_ENV_VAR,
+}: McpEndpointSetupPopunderProps) {
+  if (!scope) return null;
+
+  const name = serverName(scope.slug);
+  const header = `Authorization: Bearer $${authEnvName}`;
+
+  const tabs: { id: TabId; label: string; render: () => ReactNode }[] = [
+    {
+      id: 'claude-cli',
+      label: 'Claude CLI',
+      render: () => (
+        <>
+          {snippet(
+            'CLI one-liner',
+            `claude mcp add --transport http ${name} ${mcpUrl} --header "${header}"`,
+          )}
+          {snippet(
+            '~/.claude.json (or project .mcp.json)',
+            JSON.stringify(
+              {
+                mcpServers: {
+                  [name]: {
+                    type: 'http',
+                    url: mcpUrl,
+                    headers: { Authorization: `Bearer \${${authEnvName}}` },
+                  },
+                },
+              },
+              null,
+              2,
+            ),
+          )}
+        </>
+      ),
+    },
+    {
+      id: 'grok',
+      label: 'Grok',
+      render: () => (
+        <>
+          {snippet(
+            'CLI one-liner',
+            `grok mcp add --transport http ${name} ${mcpUrl} --header "${header}"`,
+          )}
+          {snippet(
+            '~/.grok/config.toml',
+            `[mcp_servers.${name}]
+url = "${mcpUrl}"
+[mcp_servers.${name}.headers]
+Authorization = "Bearer \${${authEnvName}}"`,
+          )}
+        </>
+      ),
+    },
+    {
+      id: 'codex',
+      label: 'Codex',
+      render: () => (
+        <>
+          {snippet(
+            'CLI one-liner',
+            `codex mcp add ${name} --url ${mcpUrl} --bearer-token-env-var ${authEnvName}`,
+          )}
+          {snippet(
+            '~/.codex/config.toml',
+            `[mcp_servers.${name}]
+url = "${mcpUrl}"
+bearer_token_env_var = "${authEnvName}"`,
+          )}
+        </>
+      ),
+    },
+    {
+      id: 'opencode',
+      label: 'OpenCode',
+      render: () => (
+        <>
+          {snippet(
+            'CLI one-liner',
+            `opencode mcp add -t remote ${name} ${mcpUrl} --header "${header}"`,
+          )}
+          {snippet(
+            'opencode.json',
+            JSON.stringify(
+              {
+                mcp: {
+                  [name]: {
+                    type: 'remote',
+                    url: mcpUrl,
+                    headers: { Authorization: `Bearer \${${authEnvName}}` },
+                    enabled: true,
+                  },
+                },
+              },
+              null,
+              2,
+            ),
+          )}
+        </>
+      ),
+    },
+    {
+      id: 'generic',
+      label: 'Generic / curl',
+      render: () => (
+        <>
+          {snippet('MCP endpoint URL', mcpUrl)}
+          {snippet(
+            'Smoke test (initialize handshake)',
+            `export ${authEnvName}=<your-token>
+curl -s ${mcpUrl} \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer $${authEnvName}" \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"manual","version":"0"}}}'`,
+          )}
+          <p style={{ margin: 0, fontSize: 11, lineHeight: 1.5, color: 'var(--text-2)' }}>
+            Any MCP-compatible client that speaks streamable HTTP can register{' '}
+            <span className="font-mono">{mcpUrl}</span> with a{' '}
+            <span className="font-mono">Authorization: Bearer</span> header — or use the OAuth
+            connector flow (DCR + PKCE) with no token paste at all.
+          </p>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <TabbedPopunder
+      open={open}
+      onClose={onClose}
+      title={`Setup MCP — ${scope.name}`}
+      tabs={tabs}
+      initialTabId="claude-cli"
+    />
+  );
+}
+
+const btnSm = {
+  padding: '4px 10px',
+  fontSize: 11,
+  borderRadius: 4,
+  border: '1px solid var(--border)',
+  background: 'var(--bg-2)',
+  color: 'var(--text-1)',
+  cursor: 'pointer',
+  fontFamily: 'var(--font)',
+};

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2009,6 +2009,16 @@ export const api = {
     });
   },
 
+  adminCloneMcpCustomScope(slug: string, patch?: Partial<McpCustomScopeInput>) {
+    return request<{ scope: McpCustomScope }>(
+      `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(slug)}/clone`,
+      {
+        method: "POST",
+        body: JSON.stringify({ scope: patch ?? {} }),
+      },
+    );
+  },
+
   adminUpdateMcpCustomScope(slug: string, patch: Partial<McpCustomScopeInput>) {
     return request<{ scope: McpCustomScope }>(`/api/v1/admin/mcp-custom-scopes/${slug}`, {
       method: "PATCH",


### PR DESCRIPTION
Wave item of the tobor.locker overhaul (TOBOR-PLAN.md). Early WIP — opened as draft for visibility; spec-compliance review pending. Phase-0 deps and the contract rulings in `TOBOR-REVIEW.md` (trl-infra root) apply. Merge order: after Phase 0 per plan.