### PR TITLE
feat(oauth): consent tool manifest + per-client toolset_config narrowing (W8)

### DIFF
--- a/INTEGRATION-NOTES.md
+++ b/INTEGRATION-NOTES.md
@@ -1,0 +1,83 @@
+# W8 oauth-consent-manifest — INTEGRATION NOTES
+
+Branch: `feat/oauth-consent-manifest` (worktree `staging/npl-w8-oauth`).
+Base: `50d7361b0`. Contracts: `staging/TOBOR-CONTRACTS.md` §2/§5.
+
+## What shipped
+
+| File | Change |
+|---|---|
+| `backend/lib/noizu_prompt_lingua/oauth/consent_manifest.ex` | NEW — `sections/0` (manifest for the consent screen: one section per `tobor` default-package group + expanded tool names) and `narrowing/2` (checkbox params → KeyToolsets-shape `toolset_config`; only BLOCKED entries stored). |
+| `backend/lib/noizu_prompt_lingua/mcp/oauth_toolsets.ex` | NEW — per-OAuth-client list filtering. `config_for/1` resolves the client from `ctx.assigns.auth_claims["client_id"]`; `apply_hidden/3` mirrors `KeyToolsets.apply_hidden/3` (flag resolution delegated verbatim to `KeyToolsets.state_from_config/3`). |
+| `backend/lib/noizu_prompt_lingua/schema/oauth_client.ex` | `toolset_config :map` field (default `%{}`) + cast. |
+| `backend/priv/repo/migrations/20260831010000_oauth_client_toolsets.exs` | `ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS toolset_config JSONB NOT NULL DEFAULT '{}'::jsonb` (twin of 20260831000000_mcp_key_toolsets). |
+| `backend/test/support/oauth_test_schema.ex` | Column added to test DDL (+ `ADD COLUMN IF NOT EXISTS` for pre-existing test DBs). |
+| `backend/lib/noizu_prompt_lingua/oauth/clients.ex` | `update_toolset_config/2` — normalize-on-write via `MCPApiKeys.normalize_toolset/1`; empty narrowing stores `%{}` (= ungated/legacy). |
+| `backend/lib/noizu_prompt_lingua_web/controllers/oauth_controller.ex` | `render_consent/5` renders the manifest (sections + per-tool toggles, pre-checked; required core groups locked); `consent/2` approve path calls `capture_narrowing/2` before issuing the code (failure logs, never blocks consent). |
+| `backend/lib/noizu_prompt_lingua/mcp/server.ex` | `list_tools/3` chains `OAuthToolsets.apply_hidden/3` after the existing KeyToolsets filter. |
+
+Tests: `backend/test/noizu_prompt_lingua/oauth/consent_manifest_test.exs`,
+`backend/test/noizu_prompt_lingua/oauth/client_toolsets_test.exs`,
+`backend/test/noizu_prompt_lingua_web/controllers/oauth_consent_test.exs`.
+
+## SINGLE WIRING POINT for F2 (post-merge)
+
+**Execution gating.** W8 captures + persists `oauth_clients.toolset_config` and
+enforces it for DISCOVERY (`list_tools`, local filter). EXECUTION enforcement is
+F2's job. The single wiring point post-F2-merge:
+
+1. `EffectiveToolset.resolve/4` cascade must add the client tier for OAuth
+   tokens. Today the client is resolved in
+   `NoizuPromptLingua.MCP.OAuthToolsets.config_for/1` — replace its body with:
+
+   ```elixir
+   EffectiveToolset.resolve(scope, %{
+     id: client.id, kind: :oauth_client, toolset_config: client.toolset_config
+   }, user_ref)
+   ```
+
+   (client map shape per TOBOR-CONTRACTS.md §2 `@type client`. The JWT already
+   carries `client_id` in `auth_claims`, minted by
+   `NoizuPromptLingua.OAuth.TokenService.mint_tokens/1`; user id is
+   `auth_claims["sub"]`.)
+
+2. Then swap `NoizuPromptLingua.MCP.Server.list_tools/3`'s
+   `OAuthToolsets.apply_hidden/3` call for the `EffectiveToolset`-resolved
+   visible/enabled map and delete `oauth_toolsets.ex`
+   (flag semantics are identical: absent = enabled + visible).
+
+Note: `KeyToolsets.config_for/1` resolves `auth_claims["api_key_id"]`; for a
+token-exchange token carrying BOTH, `list_tools` currently applies key config
+then client config (both must allow listing) — F2's unified resolve should
+preserve that intersection.
+
+## Compat assessment (standing-consent / silent re-auth)
+
+- `authorize/2`'s silent path (`finish_authorize/5`) is untouched — a standing
+  grant issues the code without ever rendering the manifest. Verified by test
+  ("existing grant re-authorizes silently").
+- Existing client rows: column default `'{}'::jsonb` → `%{}` →
+  `OAuthToolsets.config_for/1` returns `nil` → `list_tools` filter is an
+  identity no-op. Verified by test.
+- `Grants.approve!/4`, `TokenService`, DCR, token/revoke endpoints: unchanged.
+- Consent POST: purely additive (`capture_narrowing/2` before `Grants.approve!/4`);
+  a `prompt=consent` re-approval overwrites the narrowing with the new decision
+  (latest-consent-wins) — no behavioral change for grants that skip consent.
+- Consent HTML: manifest block + `.consent-*` CSS classes are additive;
+  `html_page/2` is shared with the elevation pages but the new classes/rules
+  don't alter their markup.
+- `sanitize_params/1` and the session resume flow are unchanged (manifest state
+  is rebuilt server-side on POST, not carried through the session).
+
+## Deliberate exclusions
+
+- Root-plane tools (Discovery / NPL) are absent from the manifest — they are
+  ungated by design (`KeyToolsets.ungated_category?/1`); consent never promises
+  a block it can't enforce.
+- Required core groups (`MCPServers.required_ids/0` — sessions, organizations)
+  render locked; the normalizer would force-enable them anyway (all_in_one
+  typed-confirm semantics, not wired for consent).
+- Tool names are stored verbatim from `spec.definition.name` (dotted until F5
+  lands; self-consistent between manifest and filter). After F5, re-consent
+  refreshes stored names to canonical underscore form.
+- Execution gating for `disabled` entries intentionally deferred to F2 (above).

--- a/backend/lib/noizu_prompt_lingua/mcp/oauth_toolsets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/oauth_toolsets.ex
@@ -1,0 +1,96 @@
+defmodule NoizuPromptLingua.MCP.OAuthToolsets do
+  @moduledoc """
+  W8: per-OAuth-client MCP toolset filtering for the gateway.
+
+  Reads the `toolset_config` narrowing captured at consent time
+  (`oauth_clients.toolset_config`, shape-identical to `mcp_api_keys.toolset_config`;
+  see `NoizuPromptLingua.MCP.OAuth.ConsentManifest`) and applies the SAME
+  `disabled`/`hidden` semantics as `NoizuPromptLingua.MCP.KeyToolsets`
+  (delegated — the two share flag resolution verbatim):
+
+    * `disabled: true` — blocks EXECUTION (enforced by ToolGuard/EffectiveToolset
+      post-F2-merge; see INTEGRATION-NOTES.md) and drops the tool from listings.
+    * `hidden: true` — blocks LISTING/DISCOVERY only.
+
+  The client is resolved server-side from `ctx.assigns.auth_claims["client_id"]`
+  (minted into the MCP JWT at `TokenService.mint_tokens/1`). Tokens with no
+  client_id, unknown/revoked clients, and clients with `%{}`/nil config are
+  UNGATED — existing standing-consent grants behave exactly as before.
+
+  ## F2 swap point
+
+  This module is deliberately thin so it can be replaced by
+  `NoizuPromptLingua.MCP.EffectiveToolset` after the F2 branch merges:
+
+      EffectiveToolset.resolve(scope, %{
+        id: client.id, kind: :oauth_client, toolset_config: client.toolset_config
+      }, user_ref)
+
+  Until then `apply_hidden/3` implements the local filter with the identical
+  flag semantics (absent = enabled + visible).
+  """
+
+  require Logger
+
+  alias NoizuPromptLingua.MCP.KeyToolsets
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.OAuthClient
+
+  @doc """
+  The calling OAuth client's toolset config (normalized), or `nil` when the
+  request carries no client_id (API-key / system principal), the client is
+  unknown or revoked, or the client has no stored narrowing.
+  """
+  def config_for(ctx) do
+    with client_id when is_binary(client_id) <- oauth_client_id(ctx),
+         %OAuthClient{status: "active"} = client <- Repo.get_by(OAuthClient, client_id: client_id),
+         config when is_map(config) <- client.toolset_config,
+         true <- config != %{} do
+      KeyToolsets.normalize(config)
+    else
+      _ -> nil
+    end
+  rescue
+    e ->
+      Logger.warning("[OAuthToolsets] config resolution failed: #{Exception.message(e)}")
+      nil
+  end
+
+  @doc "OAuth client_id from the MCP JWT claims in ctx.assigns."
+  def oauth_client_id(ctx) do
+    claims = get_in(ctx, [Access.key(:assigns, %{}), Access.key(:auth_claims, %{})]) || %{}
+    claims["client_id"]
+  end
+
+  # Flag resolution is shared verbatim with API keys (same config shape).
+  defdelegate state_from_config(config, group_id, tool_name), to: KeyToolsets
+
+  @doc """
+  Apply per-client `hidden`/`disabled` listing rules to expanded tool specs,
+  mirroring `KeyToolsets.apply_hidden/3`. `group_id` is the owning MCP group
+  when the caller knows it; pass `nil` to resolve per spec via
+  `MCPServers.group_id_for_tool_module/1`. No-op (specs unchanged) when the
+  calling client carries no narrowing.
+  """
+  def apply_hidden(specs, ctx, group_id) when is_list(specs) do
+    config = config_for(ctx)
+
+    if config == nil do
+      specs
+    else
+      Enum.reject(specs, fn spec ->
+        KeyToolsets.ungated_category?(KeyToolsets.tool_category(spec)) or ungated?(spec, config, group_id)
+      end)
+    end
+  end
+
+  def apply_hidden(specs, _ctx, _group_id), do: specs
+
+  defp ungated?(spec, config, group_id) do
+    name = spec.definition.name
+    gid = group_id || MCPServers.group_id_for_tool_module(spec.module)
+    flags = state_from_config(config, gid, name)
+    flags.hidden == true or flags.disabled == true
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/mcp/server.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/server.ex
@@ -40,7 +40,8 @@ defmodule NoizuPromptLingua.MCP.Server do
   @doc """
   Shared `handle_list_tools` implementation: expand the server's tool set
   (registered tools, or `catalog_specs/1` for dynamic servers), drop tools the
-  calling API key has hidden/disabled, drop static hidden tools, paginate.
+  calling API key has hidden/disabled, drop tools the calling OAuth client's
+  consent narrowing has hidden/disabled, drop static hidden tools, paginate.
   """
   def list_tools(server, cursor, ctx) do
     specs =
@@ -52,6 +53,7 @@ defmodule NoizuPromptLingua.MCP.Server do
 
     specs
     |> NoizuPromptLingua.MCP.KeyToolsets.apply_hidden(ctx, nil)
+    |> NoizuPromptLingua.MCP.OAuthToolsets.apply_hidden(ctx, nil)
     |> Enum.reject(& &1.hidden)
     |> Enum.map(& &1.definition)
     |> Pagination.paginate(cursor)

--- a/backend/lib/noizu_prompt_lingua/oauth/clients.ex
+++ b/backend/lib/noizu_prompt_lingua/oauth/clients.ex
@@ -134,6 +134,27 @@ defmodule NoizuPromptLingua.OAuth.Clients do
 
   def authenticate_client(_, _), do: {:error, :invalid_client}
 
+  @doc """
+  W8: persist the consent screen's toolset narrowing on the client
+  (`oauth_clients.toolset_config`, KeyToolsets shape — only blocked entries
+  stored). Normalized on write via the shared API-key normalizer; an empty
+  narrowing stores `%{}` (= no narrowing = legacy ungated behavior).
+  """
+  def update_toolset_config(%OAuthClient{} = client, config) do
+    normalized = NoizuPromptLingua.MCPApiKeys.normalize_toolset(config || %{})
+
+    # A narrowing with no entries collapses to the bare empty config so the
+    # row stays byte-identical to legacy clients (config_for/1 treats %{} as nil).
+    normalized =
+      if Map.get(normalized, "groups", %{}) == %{}, do: %{}, else: normalized
+
+    client
+    |> OAuthClient.changeset(%{toolset_config: normalized})
+    |> Repo.update()
+  end
+
+  def update_toolset_config(_, _), do: {:error, :invalid_client}
+
   def create_first_party!(attrs) do
     client_id = attrs[:client_id] || "fp_" <> random_id(8)
 

--- a/backend/lib/noizu_prompt_lingua/oauth/consent_manifest.ex
+++ b/backend/lib/noizu_prompt_lingua/oauth/consent_manifest.ex
@@ -1,0 +1,120 @@
+defmodule NoizuPromptLingua.OAuth.ConsentManifest do
+  @moduledoc """
+  W8: the tool manifest shown on the OAuth consent screen and the parser that
+  turns the user's allow/block choices into a per-client `toolset_config`.
+
+  Manifest = one section per group in the global `tobor` default package
+  (`MCPCustomScopes.default_package_groups/0`), each listing the tool names the
+  gateway serves for that group. Root-plane tools (Discovery / NPL) are NOT in
+  the manifest — they cannot be group-gated (see `KeyToolsets`), so consent
+  never promises a block it cannot enforce.
+
+  Narrowing semantics (§2 EffectiveToolset / KeyToolsets shape — absent =
+  allowed, only BLOCKED entries stored):
+
+      %{"groups" => %{"<group_id>" => %{
+           "disabled" => true,
+           "tools" => %{"<Tool.Name>" => %{"disabled" => true}}}}}
+
+  Required core groups (`MCPServers.required_ids/0`) are always allowed — the
+  consent UI renders them locked, mirroring the all_in_one typed-confirm rule.
+  """
+
+  alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.{MCPCustomScopes, MCPServers}
+
+  @type section :: %{
+          required(:group) => String.t(),
+          required(:label) => String.t(),
+          required(:required) => boolean(),
+          required(:tools) => [String.t()]
+        }
+
+  @doc """
+  Sections (groups) + per-tool entries the consent screen renders. Resilient:
+  a group whose tools cannot be expanded renders with an empty tool list
+  rather than failing the consent flow.
+  """
+  @spec sections() :: [section()]
+  def sections do
+    required = MCPServers.required_ids()
+
+    MCPCustomScopes.default_package_groups()
+    |> Enum.map(fn group_id ->
+      %{
+        group: group_id,
+        label: label(group_id),
+        required: group_id in required,
+        tools: tool_names(group_id)
+      }
+    end)
+  end
+
+  @doc """
+  Build the `toolset_config` narrowing from consent POST params.
+
+  Form encoding: unchecked boxes are simply absent from the params
+  (`allow_group[<gid>]` / `allow_tool[<gid>][<tool>]` checkboxes, all rendered
+  pre-checked). A group left unchecked → whole group `disabled`; an
+  individual tool left unchecked → that tool `disabled`. A fully-allowed
+  request yields `%{"groups" => %{}}` (= no narrowing = legacy behavior).
+  """
+  @spec narrowing([section()], map()) :: map()
+  def narrowing(sections, params) when is_map(params) do
+    allowed_groups = param_map(params["allow_group"])
+    allowed_tools = param_map(params["allow_tool"])
+
+    groups =
+      Enum.reduce(sections, %{}, fn %{group: group_id, tools: tools}, acc ->
+        cond do
+          group_id in MCPServers.required_ids() ->
+            acc
+
+          Map.get(allowed_groups, group_id) != "on" ->
+            Map.put(acc, group_id, %{"disabled" => true})
+
+          true ->
+            group_tools = param_map(Map.get(allowed_tools, group_id))
+            blocked = Enum.reject(tools, &(Map.get(group_tools, &1) == "on"))
+
+            case blocked do
+              [] -> acc
+              blocked -> Map.put(acc, group_id, %{"tools" => Map.new(blocked, &{&1, %{"disabled" => true}})})
+            end
+        end
+      end)
+
+    %{"groups" => groups}
+  end
+
+  def narrowing(_sections, _params), do: %{"groups" => %{}}
+
+  # Phoenix nests checkbox params as string-keyed maps; tolerate absence.
+  defp param_map(value) when is_map(value), do: value
+  defp param_map(_), do: %{}
+
+  defp label(group_id) do
+    MCPServers.all()
+    |> Enum.find(&(&1.id == group_id))
+    |> case do
+      %{label: label} -> label
+      _ -> group_id
+    end
+  end
+
+  defp tool_names(group_id) do
+    case MCPServers.server_module(group_id) do
+      nil ->
+        []
+
+      module ->
+        module.__mcp__(:tools)
+        |> Tools.expand()
+        |> Enum.map(& &1.definition.name)
+        |> Enum.sort()
+        |> Enum.uniq()
+    end
+  rescue
+    _ -> []
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/schema/oauth_client.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/oauth_client.ex
@@ -14,6 +14,13 @@ defmodule NoizuPromptLingua.Schema.OAuthClient do
     field :is_first_party, :boolean, default: false
     field :status, :string, default: "active"
     field :metadata, :map, default: %{}
+
+    # W8: per-client MCP toolset narrowing captured at consent time.
+    # Shape-identical to `mcp_api_keys.toolset_config` (see
+    # `NoizuPromptLingua.MCP.KeyToolsets`): only BLOCKED entries are stored
+    # (`disabled`/`hidden` flags; absent = allowed). `%{}` (column default)
+    # = no narrowing = legacy behavior (everything allowed).
+    field :toolset_config, :map, default: %{}
     timestamps(type: :utc_datetime_usec)
   end
 
@@ -29,7 +36,8 @@ defmodule NoizuPromptLingua.Schema.OAuthClient do
       :scope,
       :is_first_party,
       :status,
-      :metadata
+      :metadata,
+      :toolset_config
     ])
     |> validate_required([:client_id, :client_name, :redirect_uris])
     |> validate_inclusion(:status, ["active", "revoked"])

--- a/backend/lib/noizu_prompt_lingua_web/controllers/oauth_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/oauth_controller.ex
@@ -14,6 +14,7 @@ defmodule NoizuPromptLinguaWeb.OAuthController do
   alias NoizuPromptLingua.OAuth.{
     AuthorizationServer,
     Clients,
+    ConsentManifest,
     Elevation,
     Grants,
     Pkce,
@@ -98,6 +99,11 @@ defmodule NoizuPromptLinguaWeb.OAuthController do
             send_resp(conn, 400, "missing code_challenge")
 
           true ->
+            # W8: persist the consent screen's toolset narrowing (allow/block
+            # per section + tool) on the client before issuing the code.
+            # Failure is logged, never blocks consent.
+            capture_narrowing(client, params)
+
             grant = Grants.approve!(user.id, client.client_id, resource, scope)
 
             code =
@@ -352,6 +358,7 @@ defmodule NoizuPromptLinguaWeb.OAuthController do
           <dt>Resource</dt><dd><code>#{html_escape(resource)}</code></dd>
           <dt>Scopes</dt><dd><code>#{html_escape(params["scope"] || "mcp")}</code></dd>
         </dl>
+        #{consent_manifest_html(ConsentManifest.sections())}
         <form method="post" action="/oauth/consent">
           <input type="hidden" name="client_id" value="#{html_escape(client.client_id)}" />
           <input type="hidden" name="redirect_uri" value="#{html_escape(params["redirect_uri"])}" />
@@ -369,6 +376,71 @@ defmodule NoizuPromptLinguaWeb.OAuthController do
     |> put_session(:oauth_pending, pending)
     |> put_resp_content_type("text/html")
     |> send_resp(200, html)
+  end
+
+  # ── W8: consent tool manifest ─────────────────────────────────────────────
+
+  # Requested manifest: one section (group) per row of the tobor default
+  # package, per-tool allow toggles pre-checked to the client's request.
+  # The user narrows by unchecking; required core groups render locked.
+  defp consent_manifest_html(sections) do
+    rows =
+      Enum.map_join(sections, "\n", fn %{group: gid, label: label, required: required?, tools: tools} ->
+        """
+        <fieldset class="consent-section">
+          <legend>
+            <input type="checkbox" name="allow_group[#{html_escape(gid)}]" value="on" checked
+                   onclick="consentToggleGroup(this, '#{html_escape(gid)}')"
+                   #{if required?, do: "disabled"} />
+            #{html_escape(label)}#{if required?, do: " <span class=\"consent-note\">(required)</span>"}
+          </legend>
+          #{consent_tools_html(gid, tools)}
+        </fieldset>
+        """
+      end)
+
+    """
+    <p><strong>Requested tool access</strong> <span class="consent-note">(uncheck anything you want to withhold)</span></p>
+    #{rows}
+    <script>
+      function consentToggleGroup(cb, gid) {
+        document.querySelectorAll('input[data-group="' + gid + '"]').forEach(function (t) {
+          t.checked = cb.checked;
+          t.disabled = !cb.checked;
+        });
+      }
+    </script>
+    """
+  end
+
+  defp consent_tools_html(_gid, []), do: ""
+
+  defp consent_tools_html(gid, tools) do
+    Enum.map_join(tools, "\n", fn name ->
+      """
+      <label class="consent-tool">
+        <input type="checkbox" name="allow_tool[#{html_escape(gid)}][#{html_escape(name)}]" value="on" checked data-group="#{html_escape(gid)}" />
+        <code>#{html_escape(name)}</code>
+      </label>
+      """
+    end)
+  end
+
+  # Latest consent decision wins: rebuild the manifest server-side and persist
+  # whatever the submitted checkboxes imply (only blocked entries are stored).
+  defp capture_narrowing(client, params) do
+    narrowing = ConsentManifest.narrowing(ConsentManifest.sections(), params)
+
+    case Clients.update_toolset_config(client, narrowing) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        require Logger
+        Logger.warning("[OAuth] toolset narrowing not persisted for #{client.client_id}: #{inspect(reason)}")
+
+        :ok
+    end
   end
 
   defp validate_authorize_params(params) do
@@ -514,6 +586,10 @@ defmodule NoizuPromptLinguaWeb.OAuthController do
         dt { font-weight: 600; margin-top: 0.75rem; }
         dd { margin: 0.25rem 0 0; }
         button { cursor: pointer; }
+        .consent-section { margin: 0.9rem 0; border: 1px solid #e4e4e7; border-radius: 8px; padding: 0.5rem 0.75rem; }
+        .consent-section legend { font-weight: 600; padding: 0 0.35rem; }
+        .consent-tool { display: block; margin: 0.15rem 0; }
+        .consent-note { color: #71717a; font-size: 0.85rem; font-weight: 400; }
       </style>
     </head>
     <body>

--- a/backend/priv/repo/migrations/20260831010000_oauth_client_toolsets.exs
+++ b/backend/priv/repo/migrations/20260831010000_oauth_client_toolsets.exs
@@ -1,0 +1,23 @@
+defmodule NoizuPromptLingua.Repo.Migrations.OAuthClientToolsets do
+  use Ecto.Migration
+
+  @moduledoc """
+  W8: per-OAuth-client MCP toolset narrowing (`oauth_clients.toolset_config`),
+  captured by the consent screen. Shape-identical to `mcp_api_keys.toolset_config`
+  (Ecto migration 20260831000000 twin); only blocked entries are stored.
+
+  `IF NOT EXISTS` keeps this safe if a prod Liquibase changeset (074-series
+  oauth tables live in the chart, not this repo) later adds the same column.
+  """
+
+  def up do
+    execute("""
+    ALTER TABLE oauth_clients
+      ADD COLUMN IF NOT EXISTS toolset_config JSONB NOT NULL DEFAULT '{}'::jsonb
+    """)
+  end
+
+  def down do
+    execute("ALTER TABLE oauth_clients DROP COLUMN IF EXISTS toolset_config")
+  end
+end

--- a/backend/test/noizu_prompt_lingua/oauth/client_toolsets_test.exs
+++ b/backend/test/noizu_prompt_lingua/oauth/client_toolsets_test.exs
@@ -1,0 +1,145 @@
+defmodule NoizuPromptLingua.OAuth.ClientToolsetsTest do
+  use NoizuPromptLingua.DataCase, async: false
+
+  alias NoizuPromptLingua.MCP.OAuthToolsets
+  alias NoizuPromptLingua.OAuth.{Clients, ConsentManifest}
+
+  @sections [
+    %{group: "chat", label: "Chat", required: false, tools: ["Chat_Send", "Chat_List"]},
+    %{group: "sessions", label: "Sessions", required: true, tools: ["Session_Create"]}
+  ]
+
+  # Narrowing: block the whole chat group except nothing, block Chat_List... —
+  # concrete: chat group allowed but Chat_List blocked; tickets-like second
+  # optional group absent from @sections, so no group-level block.
+  defp narrowing do
+    ConsentManifest.narrowing(@sections, %{
+      "allow_group" => %{"chat" => "on", "sessions" => "on"},
+      "allow_tool" => %{"chat" => %{"Chat_Send" => "on"}}
+    })
+  end
+
+  defp ctx(client_id) do
+    %{assigns: %{auth_claims: %{"client_id" => client_id}}}
+  end
+
+  defp specs do
+    [
+      %{definition: %{name: "Chat_Send", meta: %{}}, module: NoizuPromptLingua.MCP.Sessions, hidden: false},
+      %{definition: %{name: "Chat_List", meta: %{}}, module: NoizuPromptLingua.MCP.Sessions, hidden: false},
+      %{definition: %{name: "Session_Create", meta: %{}}, module: NoizuPromptLingua.MCP.Sessions, hidden: false}
+    ]
+  end
+
+  setup do
+    NoizuPromptLingua.OAuthTestSchema.ensure!()
+
+    uniq = System.unique_integer([:positive])
+
+    {:ok, reg} =
+      Clients.register(%{
+        "client_name" => "consent-cli-#{uniq}",
+        "redirect_uris" => ["http://127.0.0.1:9876/callback"],
+        "token_endpoint_auth_method" => "none"
+      })
+
+    client = Clients.get_active(reg["client_id"])
+    %{client: client}
+  end
+
+  describe "legacy grants (no stored toolset_config)" do
+    test "fresh client has empty config and is ungated", %{client: client} do
+      assert client.toolset_config == %{}
+      assert OAuthToolsets.config_for(ctx(client.client_id)) == nil
+    end
+
+    test "list filtering is an identity no-op for legacy clients", %{client: client} do
+      assert OAuthToolsets.apply_hidden(specs(), ctx(client.client_id), "chat") == specs()
+    end
+
+    test "empty narrowing persists as %{} (stays ungated)", %{client: client} do
+      assert {:ok, updated} = Clients.update_toolset_config(client, %{"groups" => %{}})
+      assert updated.toolset_config == %{}
+      assert OAuthToolsets.config_for(ctx(client.client_id)) == nil
+    end
+
+    test "ctx without client_id (api-key / system principal) is ungated" do
+      assert OAuthToolsets.config_for(%{assigns: %{auth_claims: %{"api_key_id" => "k"}}}) == nil
+      assert OAuthToolsets.config_for(%{assigns: %{}}) == nil
+    end
+
+    test "unknown client_id is ungated" do
+      assert OAuthToolsets.config_for(ctx("dcr_does_not_exist")) == nil
+    end
+  end
+
+  describe "consent narrowing persistence" do
+    test "update_toolset_config stores the narrowing", %{client: client} do
+      assert {:ok, updated} = Clients.update_toolset_config(client, narrowing())
+
+      assert updated.toolset_config["groups"]["chat"]["tools"] == %{
+               "Chat_List" => %{"disabled" => true}
+             }
+
+      reloaded = Clients.get_active(client.client_id)
+      assert reloaded.toolset_config["groups"]["chat"]["tools"]["Chat_List"] == %{"disabled" => true}
+    end
+
+    test "flags resolve with KeyToolsets semantics (tool beats absent; absent = allowed)", %{
+      client: client
+    } do
+      {:ok, _} = Clients.update_toolset_config(client, narrowing())
+
+      assert %{disabled: true, hidden: false} =
+               OAuthToolsets.state_from_config(
+                 Clients.get_active(client.client_id).toolset_config,
+                 "chat",
+                 "Chat_List"
+               )
+
+      assert %{disabled: false, hidden: false} =
+               OAuthToolsets.state_from_config(
+                 Clients.get_active(client.client_id).toolset_config,
+                 "chat",
+                 "Chat_Send"
+               )
+
+      # Required group never narrowed.
+      assert %{disabled: false, hidden: false} =
+               OAuthToolsets.state_from_config(
+                 Clients.get_active(client.client_id).toolset_config,
+                 "sessions",
+                 "Session_Create"
+               )
+    end
+
+    test "list filtering drops consent-blocked tools only", %{client: client} do
+      {:ok, _} = Clients.update_toolset_config(client, narrowing())
+
+      filtered = OAuthToolsets.apply_hidden(specs(), ctx(client.client_id), "chat")
+      names = Enum.map(filtered, & &1.definition.name)
+
+      assert names == ["Chat_Send", "Session_Create"]
+    end
+
+    test "nil group_id falls back to per-spec group resolution (ungated when unknown)", %{
+      client: client
+    } do
+      {:ok, _} = Clients.update_toolset_config(client, narrowing())
+
+      # Group nil + unknown module resolves to nil group → flags default open.
+      assert OAuthToolsets.apply_hidden(specs(), ctx(client.client_id), nil) == specs()
+    end
+
+    test "revoked client is ungated (config not honored)", %{client: client} do
+      {:ok, _} = Clients.update_toolset_config(client, narrowing())
+      {:ok, _} = Clients.revoke_client(client.client_id)
+
+      assert OAuthToolsets.config_for(ctx(client.client_id)) == nil
+    end
+
+    test "update_toolset_config rejects non-client input" do
+      assert {:error, :invalid_client} = Clients.update_toolset_config("nope", %{})
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua/oauth/consent_manifest_test.exs
+++ b/backend/test/noizu_prompt_lingua/oauth/consent_manifest_test.exs
@@ -1,0 +1,85 @@
+defmodule NoizuPromptLingua.OAuth.ConsentManifestTest do
+  use NoizuPromptLingua.DataCase, async: false
+
+  alias NoizuPromptLingua.OAuth.ConsentManifest
+
+  @sections [
+    %{group: "chat", label: "Chat", required: false, tools: ["Chat_Send", "Chat_List"]},
+    %{group: "sessions", label: "Sessions", required: true, tools: ["Session_Create"]},
+    %{group: "tickets", label: "Tickets", required: false, tools: []}
+  ]
+
+  describe "narrowing/2" do
+    test "fully-allowed request yields empty narrowing (legacy behavior)" do
+      params = %{
+        "allow_group" => %{"chat" => "on", "sessions" => "on", "tickets" => "on"},
+        "allow_tool" => %{"chat" => %{"Chat_Send" => "on", "Chat_List" => "on"}}
+      }
+
+      assert ConsentManifest.narrowing(@sections, params) == %{"groups" => %{}}
+    end
+
+    test "missing params entirely (no checkboxes submitted) narrows every optional group" do
+      narrowing = ConsentManifest.narrowing(@sections, %{})
+
+      assert narrowing["groups"]["chat"] == %{"disabled" => true}
+      assert narrowing["groups"]["tickets"] == %{"disabled" => true}
+      # Required groups are never narrowed.
+      refute Map.has_key?(narrowing["groups"], "sessions")
+    end
+
+    test "unchecked tool narrows only that tool" do
+      params = %{
+        "allow_group" => %{"chat" => "on"},
+        "allow_tool" => %{"chat" => %{"Chat_Send" => "on"}}
+      }
+
+      assert ConsentManifest.narrowing(@sections, params) == %{
+               "groups" => %{
+                 "chat" => %{"tools" => %{"Chat_List" => %{"disabled" => true}}},
+                 "tickets" => %{"disabled" => true}
+               }
+             }
+    end
+
+    test "group unchecked wins even if some tools remain checked" do
+      params = %{
+        "allow_tool" => %{"chat" => %{"Chat_Send" => "on"}}
+      }
+
+      assert ConsentManifest.narrowing(@sections, params)["groups"]["chat"] == %{"disabled" => true}
+    end
+
+    test "tolerates non-map params (absent nesting)" do
+      params = %{"allow_group" => nil, "allow_tool" => "garbage"}
+
+      assert %{"groups" => groups} = ConsentManifest.narrowing(@sections, params)
+      assert groups["chat"] == %{"disabled" => true}
+    end
+  end
+
+  describe "sections/0" do
+    test "one section per tobor default-package group with required keys" do
+      sections = ConsentManifest.sections()
+
+      expected_groups = MapSet.new(NoizuPromptLingua.MCPCustomScopes.default_package_groups())
+
+      assert length(sections) > 0
+      assert MapSet.new(sections, & &1.group) == expected_groups
+
+      for section <- sections do
+        assert is_binary(section.group)
+        assert is_binary(section.label)
+        assert is_boolean(section.required)
+        assert is_list(section.tools)
+        assert Enum.all?(section.tools, &is_binary/1)
+      end
+
+      required = MapSet.new(NoizuPromptLingua.MCPServers.required_ids())
+
+      for section <- sections do
+        assert section.required == MapSet.member?(required, section.group)
+      end
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua_web/controllers/oauth_consent_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/oauth_consent_test.exs
@@ -1,0 +1,186 @@
+defmodule NoizuPromptLinguaWeb.OAuthConsentTest do
+  use NoizuPromptLinguaWeb.ConnCase, async: false
+
+  alias NoizuPromptLingua.OAuth.{Clients, ConsentManifest, Grants}
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.Users.User
+
+  @redirect_uri "http://127.0.0.1:9876/callback"
+  @resource "https://tobor.locker/mcp"
+
+  setup do
+    NoizuPromptLingua.OAuthTestSchema.ensure!()
+
+    uniq = System.unique_integer([:positive])
+
+    user =
+      %User{
+        id: Ecto.UUID.generate(),
+        email: "consent-#{uniq}@example.com",
+        user_name: "consent#{uniq}",
+        handle: "consent#{uniq}",
+        status: :active,
+        verified: true,
+        flagged: false
+      }
+      |> Repo.insert!()
+
+    {:ok, reg} =
+      Clients.register(%{
+        "client_name" => "consent-web-cli-#{uniq}",
+        "redirect_uris" => [@redirect_uri],
+        "token_endpoint_auth_method" => "none"
+      })
+
+    client = Clients.get_active(reg["client_id"])
+
+    verifier = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false)
+    challenge = :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+
+    conn =
+      build_conn()
+      |> put_req_header("x-forwarded-for", "10.7.#{rem(uniq, 250)}.#{rem(uniq, 251)}")
+
+    %{
+      user: user,
+      client: client,
+      conn: conn,
+      challenge: challenge,
+      verifier: verifier,
+      uniq: uniq
+    }
+  end
+
+  defp authorize_params(client, challenge) do
+    %{
+      "response_type" => "code",
+      "client_id" => client.client_id,
+      "redirect_uri" => @redirect_uri,
+      "code_challenge" => challenge,
+      "code_challenge_method" => "S256",
+      "state" => "st-123"
+    }
+  end
+
+  defp signed_in(conn, user), do: Plug.Test.init_test_session(conn, %{"oauth_user_id" => user.id})
+
+  describe "standing consent (legacy grants)" do
+    test "existing grant re-authorizes silently — no consent manifest, no toolset change", %{
+      conn: conn,
+      user: user,
+      client: client,
+      challenge: challenge
+    } do
+      _grant = Grants.approve!(user.id, client.client_id, @resource, "mcp")
+
+      conn =
+        conn
+        |> signed_in(user)
+        |> get("/oauth/authorize", authorize_params(client, challenge))
+
+      assert conn.status == 302
+      assert conn.resp_body =~ @redirect_uri
+      assert conn.resp_body =~ "code="
+
+      # Silent path: redirect body only, manifest never rendered.
+      refute conn.resp_body =~ "allow_group"
+      refute conn.resp_body =~ "consent-section"
+
+      # Legacy grant never touches the client's toolset_config.
+      assert Clients.get_active(client.client_id).toolset_config == %{}
+    end
+  end
+
+  describe "fresh consent renders the tool manifest" do
+    test "authorize shows sections + per-tool toggles pre-checked", %{
+      conn: conn,
+      user: user,
+      client: client,
+      challenge: challenge
+    } do
+      conn =
+        conn
+        |> signed_in(user)
+        |> get("/oauth/authorize", authorize_params(client, challenge))
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Requested tool access"
+      assert conn.resp_body =~ "allow_group["
+      assert conn.resp_body =~ "allow_tool["
+      # Toggles render pre-checked to the client's request.
+      assert conn.resp_body =~ "checked data-group"
+      assert conn.resp_body =~ "value=\"on\" checked"
+    end
+  end
+
+  describe "consent POST persists narrowing" do
+    test "blocked group/tool lands in toolset_config, code still issued", %{
+      conn: conn,
+      user: user,
+      client: client,
+      challenge: challenge
+    } do
+      sections = ConsentManifest.sections()
+
+      # Allow the chat group with only its first tool; omit every other group
+      # checkbox (unchecked = blocked). Required groups excluded by design.
+      chat = Enum.find(sections, &(&1.group == "chat"))
+      [allowed_tool | blocked_tools] = chat.tools
+
+      form =
+        authorize_params(client, challenge)
+        |> Map.drop(["response_type", "code_challenge_method"])
+        |> Map.merge(%{
+          "decision" => "approve",
+          "allow_group" => %{"chat" => "on"},
+          "allow_tool" => %{"chat" => %{allowed_tool => "on"}}
+        })
+
+      conn =
+        conn
+        |> signed_in(user)
+        |> post("/oauth/consent", form)
+
+      assert conn.status == 302
+      assert conn.resp_body =~ "code="
+
+      config = Clients.get_active(client.client_id).toolset_config
+      groups = config["groups"]
+
+      # Allowed tool absent from the narrowing; blocked tools flagged.
+      refute Map.has_key?(groups["chat"]["tools"] || %{}, allowed_tool)
+
+      for blocked <- blocked_tools do
+        assert groups["chat"]["tools"][blocked] == %{"disabled" => true}
+      end
+
+      # Omitted optional groups are blocked at group level.
+      for %{group: gid, required: false} <- sections, gid != "chat" do
+        assert groups[gid]["disabled"] == true
+        assert groups[gid]["tools"] == %{}
+      end
+
+      # Required groups never narrowed.
+      for %{group: gid, required: true} <- sections do
+        refute Map.has_key?(groups, gid)
+      end
+    end
+
+    test "deny decision persists nothing", %{
+      conn: conn,
+      user: user,
+      client: client,
+      challenge: challenge
+    } do
+      form =
+        authorize_params(client, challenge)
+        |> Map.drop(["response_type", "code_challenge_method"])
+        |> Map.merge(%{"decision" => "deny", "allow_group" => %{"chat" => "on"}})
+
+      conn = conn |> signed_in(user) |> post("/oauth/consent", form)
+
+      assert conn.status == 302
+      assert Clients.get_active(client.client_id).toolset_config == %{}
+    end
+  end
+end

--- a/backend/test/support/oauth_test_schema.ex
+++ b/backend/test/support/oauth_test_schema.ex
@@ -17,10 +17,16 @@ defmodule NoizuPromptLingua.OAuthTestSchema do
       is_first_party boolean NOT NULL DEFAULT false,
       status varchar(16) NOT NULL DEFAULT 'active',
       metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      toolset_config jsonb NOT NULL DEFAULT '{}'::jsonb,
       inserted_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     )
     """)
+
+    # Pre-existing test DBs (table created before W8) get the column added.
+    Repo.query!(
+      "ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS toolset_config JSONB NOT NULL DEFAULT '{}'::jsonb"
+    )
 
     Repo.query!(
       "CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_clients_client_id ON oauth_clients (client_id)"


### PR DESCRIPTION
Wave item of the tobor.locker overhaul (TOBOR-PLAN.md). Early WIP — opened as draft for visibility; spec-compliance review pending. Phase-0 deps and the contract rulings in `TOBOR-REVIEW.md` (trl-infra root) apply. Merge order: after Phase 0 per plan.