### PR TITLE
feat(W9): tool name+description overrides editor for scope config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "regen": "rm -rf .cache && npm run generate-css",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
-    "test:contracts": "node --import tsx --test src/components/app-shell.contract.test.ts src/lib/pm/trp-board-embed.test.ts",
+    "test:contracts": "node --import tsx --test src/components/app-shell.contract.test.ts src/lib/pm/trp-board-embed.test.ts src/lib/tool-overrides.test.ts",
     "test:e2e:authentik": "cypress run --browser chrome --config-file cypress.authentik.config.ts --spec 'cypress/e2e/auth/login-authentik.cy.ts'"
   },
   "dependencies": {

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { toast } from 'sonner';
 import {
@@ -10,6 +10,14 @@ import {
   type McpCustomScopeConfig,
   type McpCustomTool,
 } from '@/lib/api';
+import { ToolOverrideFields } from '@/components/kit/tool-overrides-editor';
+import {
+  applyOverridePatch,
+  canonicalToolName,
+  hasOverrides,
+  overrideEntry,
+  type ToolOverrideEntry,
+} from '@/lib/tool-overrides';
 
 type ScopeForm = {
   originalSlug?: string;
@@ -90,6 +98,7 @@ export default function AdminMcpCustomScopesPage() {
   const [form, setForm] = useState<ScopeForm>(blankForm());
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [overridesOpen, setOverridesOpen] = useState<Record<string, boolean>>({});
 
   const selectedScope = useMemo(
     () => scopes.find((s) => s.slug === form.originalSlug) ?? null,
@@ -165,6 +174,15 @@ export default function AdminMcpCustomScopesPage() {
       group.tools[toolName] = { ...(group.tools[toolName] ?? {}), hidden: !value };
       draft.groups[groupId] = group;
     });
+  }
+
+  // W9 — name/description/arg-description overrides. Entries key by canonical
+  // underscore tool name (contract §4/§7); toggle fields are preserved.
+  function setToolOverrides(groupId: string, toolName: string, entry: ToolOverrideEntry) {
+    setForm((current) => ({
+      ...current,
+      config: applyOverridePatch(current.config, groupId, toolName, entry),
+    }));
   }
 
   async function save(e: React.FormEvent) {
@@ -404,34 +422,85 @@ export default function AdminMcpCustomScopesPage() {
                                 <th>Category</th>
                                 <th>Enabled</th>
                                 <th>Visible</th>
+                                <th>Overrides</th>
                               </tr>
                             </thead>
                             <tbody>
-                              {group.tools.map((tool) => (
-                                <tr key={tool.name}>
-                                  <td>
-                                    <div className="font-mono">{tool.name}</div>
-                                    <span className="sg-field__hint">{tool.description}</span>
-                                  </td>
-                                  <td>{tool.category}</td>
-                                  <td>
-                                    <input
-                                      type="checkbox"
-                                      checked={toolEnabled(form.config, group.id, tool.name)}
-                                      onChange={(e) => setToolEnabled(group.id, tool.name, e.target.checked)}
-                                      aria-label={`${tool.name} enabled`}
-                                    />
-                                  </td>
-                                  <td>
-                                    <input
-                                      type="checkbox"
-                                      checked={toolVisible(form.config, group.id, tool)}
-                                      onChange={(e) => setToolVisible(group.id, tool.name, e.target.checked)}
-                                      aria-label={`${tool.name} visible`}
-                                    />
-                                  </td>
-                                </tr>
-                              ))}
+                              {group.tools.map((tool) => {
+                                const toolKey = canonicalToolName(tool.name);
+                                const openKey = `${group.id}/${toolKey}`;
+                                const overridesShown = overridesOpen[openKey] ?? false;
+                                const overridden = hasOverrides(form.config, group.id, toolKey);
+                                return (
+                                  <Fragment key={tool.name}>
+                                    <tr>
+                                      <td>
+                                        <div className="font-mono">
+                                          {tool.name}
+                                          {overridden && (
+                                            <span
+                                              title="Has name/description overrides"
+                                              style={{
+                                                marginLeft: 6,
+                                                fontSize: 9,
+                                                padding: '1px 5px',
+                                                borderRadius: 8,
+                                                background: 'var(--accent, #333)',
+                                                color: '#fff',
+                                                verticalAlign: 'middle',
+                                              }}
+                                            >
+                                              edited
+                                            </span>
+                                          )}
+                                        </div>
+                                        <span className="sg-field__hint">{tool.description}</span>
+                                      </td>
+                                      <td>{tool.category}</td>
+                                      <td>
+                                        <input
+                                          type="checkbox"
+                                          checked={toolEnabled(form.config, group.id, tool.name)}
+                                          onChange={(e) => setToolEnabled(group.id, tool.name, e.target.checked)}
+                                          aria-label={`${tool.name} enabled`}
+                                        />
+                                      </td>
+                                      <td>
+                                        <input
+                                          type="checkbox"
+                                          checked={toolVisible(form.config, group.id, tool)}
+                                          onChange={(e) => setToolVisible(group.id, tool.name, e.target.checked)}
+                                          aria-label={`${tool.name} visible`}
+                                        />
+                                      </td>
+                                      <td>
+                                        <button
+                                          type="button"
+                                          className="sg-btn sg-btn--outline sg-btn--sm"
+                                          aria-expanded={overridesShown}
+                                          onClick={() =>
+                                            setOverridesOpen((cur) => ({ ...cur, [openKey]: !overridesShown }))
+                                          }
+                                        >
+                                          {overridesShown ? 'Hide' : 'Edit'}
+                                        </button>
+                                      </td>
+                                    </tr>
+                                    {overridesShown && (
+                                      <tr>
+                                        <td colSpan={5} style={{ background: 'var(--bg-3, #fafafa)' }}>
+                                          <ToolOverrideFields
+                                            idPrefix={`scope-${group.id}-${toolKey}`}
+                                            tool={tool}
+                                            entry={overrideEntry(form.config, group.id, toolKey)}
+                                            onChange={(next) => setToolOverrides(group.id, tool.name, next)}
+                                          />
+                                        </td>
+                                      </tr>
+                                    )}
+                                  </Fragment>
+                                );
+                              })}
                             </tbody>
                           </table>
                         </div>

--- a/frontend/src/components/kit/tool-overrides-editor.tsx
+++ b/frontend/src/components/kit/tool-overrides-editor.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+/**
+ * W9 — name + description override editor (TOBOR-CONTRACTS.md §7).
+ *
+ * `ToolOverridesEditor` renders the ToolTogglesGrid-style grouping (one
+ * section per tool group, one row per tool) with per-tool editors for
+ * `name_override`, `description_override`, and `arg_overrides`
+ * (arg name → description). Pure controlled component: the host owns the
+ * scope config and persistence (the scope-update API), same pattern as the
+ * mcp-custom-scopes page edits.
+ *
+ * Entries are keyed by canonical underscore tool name (§4) via
+ * `canonicalToolName` from `@/lib/tool-overrides`.
+ */
+import { useState } from 'react';
+import type { McpCustomScopeConfig } from '@/lib/api';
+import {
+  applyOverridePatch,
+  canonicalToolName,
+  hasOverrides,
+  overrideEntry,
+  type ToolOverrideEntry,
+} from '@/lib/tool-overrides';
+
+export interface ToolOverridesTool {
+  /** Catalog name — dotted legacy or canonical underscore; entries key canonically. */
+  name: string;
+  description: string;
+  parameters?: { name: string; description: string; type?: string; required?: boolean }[];
+}
+
+export interface ToolOverridesGroup {
+  /** Group id — matches scope config `groups` keys. */
+  group: string;
+  label?: string;
+  tools: ToolOverridesTool[];
+}
+
+interface ToolOverridesEditorProps {
+  groups: ToolOverridesGroup[];
+  /** Full scope config; only W9 override fields are read/written. */
+  value: McpCustomScopeConfig;
+  /** Emits the full next config (pure controlled). */
+  onChange: (next: McpCustomScopeConfig) => void;
+  readOnly?: boolean;
+}
+
+/**
+ * Single-tool override fields. Also exported for embedding in table rows /
+ * sidebars (used by the mcp-custom-scopes page's per-tool expander).
+ */
+export function ToolOverrideFields({
+  tool,
+  entry,
+  onChange,
+  readOnly = false,
+  idPrefix,
+}: {
+  tool: ToolOverridesTool;
+  entry: ToolOverrideEntry;
+  onChange: (next: ToolOverrideEntry) => void;
+  readOnly?: boolean;
+  idPrefix: string;
+}) {
+  const [newArg, setNewArg] = useState('');
+  const knownArgs = tool.parameters ?? [];
+  const extraArgs = Object.keys(entry.arg_overrides ?? {}).filter(
+    (arg) => !knownArgs.some((p) => p.name === arg),
+  );
+  const argRows = [
+    ...knownArgs.map((p) => ({ name: p.name, fallback: p.description })),
+    ...extraArgs.map((name) => ({ name, fallback: '' })),
+  ];
+
+  function patchArg(arg: string, value: string) {
+    const args = { ...(entry.arg_overrides ?? {}) };
+    if (value.trim() === '') delete args[arg];
+    else args[arg] = value;
+    onChange({ ...entry, arg_overrides: args });
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-label={`Overrides for ${tool.name}`}>
+      <div>
+        <label htmlFor={`${idPrefix}-name`} style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>
+          Name override
+        </label>
+        <input
+          id={`${idPrefix}-name`}
+          value={entry.name_override ?? ''}
+          placeholder={canonicalToolName(tool.name)}
+          readOnly={readOnly}
+          onChange={(e) => onChange({ ...entry, name_override: e.target.value })}
+          style={{ width: '100%', fontFamily: 'monospace', fontSize: 12 }}
+        />
+      </div>
+      <div>
+        <label
+          htmlFor={`${idPrefix}-desc`}
+          style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}
+        >
+          Description override
+        </label>
+        <textarea
+          id={`${idPrefix}-desc`}
+          value={entry.description_override ?? ''}
+          placeholder={tool.description}
+          readOnly={readOnly}
+          rows={2}
+          onChange={(e) => onChange({ ...entry, description_override: e.target.value })}
+          style={{ width: '100%', fontSize: 12 }}
+        />
+      </div>
+      {argRows.length > 0 && (
+        <div>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>
+            Argument description overrides
+          </span>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 4 }}>
+            {argRows.map((arg) => (
+              <div key={arg.name} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span
+                  className="font-mono"
+                  style={{ flex: '0 0 140px', fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                  title={arg.name}
+                >
+                  {arg.name}
+                </span>
+                <input
+                  aria-label={`Description override for ${tool.name} argument ${arg.name}`}
+                  value={entry.arg_overrides?.[arg.name] ?? ''}
+                  placeholder={arg.fallback || 'argument description'}
+                  readOnly={readOnly}
+                  onChange={(e) => patchArg(arg.name, e.target.value)}
+                  style={{ flex: 1, fontSize: 12 }}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {!readOnly && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            aria-label="New argument name"
+            value={newArg}
+            placeholder="add argument by name"
+            onChange={(e) => setNewArg(e.target.value)}
+            style={{ flex: '0 0 180px', fontFamily: 'monospace', fontSize: 12 }}
+          />
+          <button
+            type="button"
+            className="sg-btn sg-btn--outline sg-btn--sm"
+            disabled={!newArg.trim() || argRows.some((r) => r.name === newArg.trim())}
+            onClick={() => {
+              const name = newArg.trim();
+              if (!name) return;
+              patchArg(name, entry.arg_overrides?.[name] ?? '');
+              setNewArg('');
+            }}
+          >
+            Add argument
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ToolOverridesEditor({
+  groups,
+  value,
+  onChange,
+  readOnly = false,
+}: ToolOverridesEditorProps) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+
+  function patchTool(groupId: string, tool: ToolOverridesTool, entry: ToolOverrideEntry) {
+    onChange(applyOverridePatch(value, groupId, tool.name, entry));
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }} role="group" aria-label="Tool overrides">
+      {groups.map((group) => (
+        <section
+          key={group.group}
+          aria-label={`Tool group ${group.group}`}
+          style={{
+            borderRadius: 6,
+            border: '1px solid var(--border)',
+            background: 'var(--bg-3)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '8px 12px',
+              borderBottom: '1px solid var(--border)',
+              background: 'var(--bg-2)',
+              fontSize: 12,
+              fontWeight: 600,
+              color: 'var(--text-0)',
+            }}
+          >
+            {group.label ?? group.group}
+            <span style={{ fontWeight: 400, fontSize: 10, color: 'var(--text-3)', marginLeft: 6 }}>
+              {group.tools.filter((t) => hasOverrides(value, group.group, canonicalToolName(t.name))).length}/
+              {group.tools.length} overridden
+            </span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {group.tools.map((tool) => {
+              const toolKey = canonicalToolName(tool.name);
+              const expanded = open[`${group.group}/${toolKey}`] ?? false;
+              const overridden = hasOverrides(value, group.group, toolKey);
+              return (
+                <div
+                  key={tool.name}
+                  style={{ borderBottom: '1px solid var(--border)' }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '6px 12px',
+                      background: 'var(--bg-2)',
+                    }}
+                  >
+                    <span
+                      title={tool.name}
+                      className="font-mono"
+                      style={{
+                        flex: 1,
+                        fontSize: 11,
+                        color: 'var(--text-0)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {tool.name}
+                      {overridden && (
+                        <span
+                          title="Has overrides"
+                          style={{
+                            marginLeft: 6,
+                            fontSize: 9,
+                            padding: '1px 5px',
+                            borderRadius: 8,
+                            background: 'var(--accent)',
+                            color: 'var(--bg-1)',
+                            verticalAlign: 'middle',
+                          }}
+                        >
+                          edited
+                        </span>
+                      )}
+                    </span>
+                    <button
+                      type="button"
+                      className="sg-btn sg-btn--outline sg-btn--sm"
+                      aria-expanded={expanded}
+                      onClick={() =>
+                        setOpen((cur) => ({
+                          ...cur,
+                          [`${group.group}/${toolKey}`]: !expanded,
+                        }))
+                      }
+                    >
+                      {expanded ? 'Hide' : 'Overrides'}
+                    </button>
+                  </div>
+                  {expanded && (
+                    <div style={{ padding: '8px 12px 12px' }}>
+                      <ToolOverrideFields
+                        idPrefix={`toe-${group.group}-${toolKey}`}
+                        tool={tool}
+                        entry={overrideEntry(value, group.group, toolKey)}
+                        onChange={(next) => patchTool(group.group, tool, next)}
+                        readOnly={readOnly}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -341,7 +341,14 @@ export interface McpCustomScopeConfig {
   groups: Record<string, {
     disabled?: boolean;
     hidden?: boolean;
-    tools?: Record<string, { disabled?: boolean; hidden?: boolean }>;
+    tools?: Record<string, {
+      disabled?: boolean;
+      hidden?: boolean;
+      // W9 name/description overrides (keyed by canonical underscore tool name)
+      name_override?: string;
+      description_override?: string;
+      arg_overrides?: Record<string, string>;
+    }>;
   }>;
 }
 

--- a/frontend/src/lib/tool-overrides.test.ts
+++ b/frontend/src/lib/tool-overrides.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure tests for W9 tool-override config helpers. No React, no DOM, no test
+ * runner required — run with the project's existing tsx:
+ *
+ *   npx tsx src/lib/tool-overrides.test.ts
+ *
+ * Covers TOBOR-CONTRACTS.md §7: name_override / description_override /
+ * arg_overrides entries in scope config jsonb, keyed by canonical underscore
+ * tool name (§4), with toggle fields (disabled/hidden) preserved and empty
+ * values pruned.
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  applyOverridePatch,
+  canonicalToolName,
+  hasOverrides,
+  overrideEntry,
+} from './tool-overrides';
+import type { McpCustomScopeConfig } from './api';
+
+const base = (): McpCustomScopeConfig => ({
+  groups: {
+    sessions: {
+      tools: {
+        Session_Create: { disabled: true },
+        'Session.List': { hidden: true }, // legacy dotted-key entry
+      },
+    },
+  },
+});
+
+test('canonicalToolName normalizes dotted names', () => {
+  assert.equal(canonicalToolName('Session.Create'), 'Session_Create');
+  assert.equal(canonicalToolName('ToolCall'), 'ToolCall');
+});
+
+test('applyOverridePatch keys by canonical name and preserves toggles', () => {
+  const next = applyOverridePatch(base(), 'sessions', 'Session_Create', {
+    name_override: 'CreateSession',
+  });
+  const entry = next.groups.sessions.tools?.Session_Create;
+  assert.equal(entry?.disabled, true, 'existing disabled flag must survive');
+  assert.equal(entry?.name_override, 'CreateSession');
+  // untouched legacy dotted entry stays put
+  assert.ok(next.groups.sessions.tools?.['Session.List']);
+});
+
+test('applyOverridePatch migrates legacy dotted-key entry', () => {
+  const next = applyOverridePatch(base(), 'sessions', 'Session.List', {
+    description_override: 'List sessions (custom blurb)',
+  });
+  const tools = next.groups.sessions.tools ?? {};
+  assert.equal(tools['Session.List'], undefined, 'dotted key must be migrated away');
+  assert.equal(tools.Session_List?.hidden, true, 'hidden flag carried to canonical key');
+  assert.equal(tools.Session_List?.description_override, 'List sessions (custom blurb)');
+});
+
+test('empty string overrides prune to nothing', () => {
+  let cfg = applyOverridePatch(base(), 'sessions', 'Ticket_Create', {
+    name_override: '   ',
+    description_override: '',
+    arg_overrides: { title: '  ' },
+  });
+  assert.equal(cfg.groups.sessions.tools?.Ticket_Create, undefined);
+
+  cfg = applyOverridePatch(cfg, 'sessions', 'Ticket_Create', {
+    name_override: 'X',
+    description_override: undefined,
+    arg_overrides: undefined,
+  });
+  assert.equal(cfg.groups.sessions.tools?.Ticket_Create?.name_override, 'X');
+
+  // clearing (explicit empty values, as the editor emits) removes the entry
+  cfg = applyOverridePatch(cfg, 'sessions', 'Ticket_Create', {
+    name_override: '',
+    description_override: '',
+    arg_overrides: {},
+  });
+  assert.equal(cfg.groups.sessions.tools?.Ticket_Create, undefined);
+});
+
+test('arg_overrides keeps non-empty args and drops blank ones', () => {
+  const cfg = applyOverridePatch(base(), 'sessions', 'Session_Create', {
+    arg_overrides: { title: 'Session title', body: '' },
+  });
+  const args = cfg.groups.sessions.tools?.Session_Create?.arg_overrides;
+  assert.deepEqual(args, { title: 'Session title' });
+});
+
+test('toggle-only entry survives a clear-overrides patch', () => {
+  const cfg = applyOverridePatch(base(), 'sessions', 'Session_Create', {});
+  const entry = cfg.groups.sessions.tools?.Session_Create;
+  assert.deepEqual(entry, { disabled: true }, 'disabled toggle must not be wiped');
+});
+
+test('overrideEntry + hasOverrides round-trip', () => {
+  let cfg = base();
+  assert.equal(hasOverrides(cfg, 'sessions', 'Session_Create'), false);
+  cfg = applyOverridePatch(cfg, 'sessions', 'Session_Create', {
+    name_override: 'CreateSession',
+    arg_overrides: { title: 't' },
+  });
+  const entry = overrideEntry(cfg, 'sessions', 'Session_Create');
+  assert.equal(entry.name_override, 'CreateSession');
+  assert.deepEqual(entry.arg_overrides, { title: 't' });
+  assert.equal(hasOverrides(cfg, 'sessions', 'Session_Create'), true);
+  assert.equal(hasOverrides(cfg, 'sessions', 'Session.List'), false);
+});
+
+test('source config is never mutated', () => {
+  const cfg = base();
+  applyOverridePatch(cfg, 'sessions', 'Session_Create', { name_override: 'Z' });
+  assert.equal(cfg.groups.sessions.tools?.Session_Create?.name_override, undefined);
+  assert.deepEqual(Object.keys(cfg.groups), ['sessions']);
+});

--- a/frontend/src/lib/tool-overrides.ts
+++ b/frontend/src/lib/tool-overrides.ts
@@ -1,0 +1,131 @@
+/**
+ * Tool name/description override helpers (W9 — name+desc-overrides editor).
+ *
+ * Per-tool override entries live inside the scope config jsonb, keyed by
+ * **canonical underscore tool name** (TOBOR-CONTRACTS.md §4/§7):
+ *
+ *   config.groups[groupId].tools[toolName] = {
+ *     disabled?, hidden?,                       // existing toggle fields
+ *     name_override?, description_override?,    // W9
+ *     arg_overrides?: { [argName]: string },    // W9 arg-description overrides
+ *   }
+ *
+ * These helpers only ever touch the W9 override fields — `disabled`/`hidden`
+ * set by the toggle grids are preserved untouched. Empty values are pruned so
+ * the jsonb never accumulates blank-string junk; entries that end up carrying
+ * no state at all are removed entirely.
+ */
+import type { McpCustomScopeConfig } from './api';
+
+/** Canonical underscore tool name (`Session.Create` → `Session_Create`). */
+export function canonicalToolName(name: string): string {
+  return name.replace(/\./g, '_');
+}
+
+/** W9 override fields carried on a per-tool config entry. */
+export interface ToolOverrideEntry {
+  name_override?: string;
+  description_override?: string;
+  arg_overrides?: Record<string, string>;
+}
+
+type ScopeToolEntry = NonNullable<
+  NonNullable<NonNullable<McpCustomScopeConfig['groups']>[string]>['tools']
+>[string];
+
+/** Read the override fields for a tool (already key-normalized by the caller or not). */
+export function overrideEntry(
+  config: McpCustomScopeConfig,
+  groupId: string,
+  toolKey: string,
+): ToolOverrideEntry {
+  const tool = config.groups?.[groupId]?.tools?.[toolKey] as ScopeToolEntry | undefined;
+  if (!tool) return {};
+  return {
+    name_override: tool.name_override,
+    description_override: tool.description_override,
+    arg_overrides: tool.arg_overrides ? { ...tool.arg_overrides } : undefined,
+  };
+}
+
+function pruneEntry(entry: ScopeToolEntry): ScopeToolEntry | undefined {
+  const next: ScopeToolEntry = { ...entry };
+  if (typeof next.name_override === 'string') {
+    if (next.name_override.trim() === '') delete next.name_override;
+  }
+  if (typeof next.description_override === 'string') {
+    if (next.description_override.trim() === '') delete next.description_override;
+  }
+  if (next.arg_overrides) {
+    const args = Object.fromEntries(
+      Object.entries(next.arg_overrides).filter(([, v]) => typeof v === 'string' && v.trim() !== ''),
+    );
+    if (Object.keys(args).length === 0) delete next.arg_overrides;
+    else next.arg_overrides = args;
+  }
+  const hasOverride =
+    next.name_override !== undefined ||
+    next.description_override !== undefined ||
+    next.arg_overrides !== undefined;
+  if (!hasOverride && next.disabled === undefined && next.hidden === undefined) return undefined;
+  return next;
+}
+
+function cloneConfig(config: McpCustomScopeConfig): McpCustomScopeConfig {
+  return {
+    groups: Object.fromEntries(
+      Object.entries(config.groups ?? {}).map(([groupId, group]) => [
+        groupId,
+        { ...group, tools: { ...(group.tools ?? {}) } },
+      ]),
+    ),
+  };
+}
+
+/**
+ * Patch the W9 override fields for one tool. `patch` replaces the full
+ * override entry (pass `{}` to clear). Toggle fields (`disabled`/`hidden`)
+ * are preserved. Keys the entry under `canonicalToolName(toolName)`.
+ * Returns a new config; the input is never mutated.
+ */
+export function applyOverridePatch(
+  config: McpCustomScopeConfig,
+  groupId: string,
+  toolName: string,
+  patch: ToolOverrideEntry,
+): McpCustomScopeConfig {
+  const draft = cloneConfig(config);
+  const group = draft.groups[groupId] ?? { tools: {} };
+  group.tools = group.tools ?? {};
+  const toolKey = canonicalToolName(toolName);
+  // A legacy dotted-key entry may carry earlier state — migrate it (the
+  // canonical-key entry, if also present, wins).
+  const legacy =
+    toolKey !== toolName ? (group.tools[toolName] as ScopeToolEntry | undefined) : undefined;
+  const canonical = group.tools[toolKey] as ScopeToolEntry | undefined;
+  const prior: ScopeToolEntry = { ...(legacy ?? {}), ...(canonical ?? {}) };
+  const merged: ScopeToolEntry = {
+    ...prior,
+    ...(patch.name_override !== undefined ? { name_override: patch.name_override } : {}),
+    ...(patch.description_override !== undefined
+      ? { description_override: patch.description_override }
+      : {}),
+    ...(patch.arg_overrides !== undefined ? { arg_overrides: { ...patch.arg_overrides } } : {}),
+  };
+  const pruned = pruneEntry(merged);
+  delete group.tools[toolKey];
+  if (toolKey !== toolName) delete group.tools[toolName];
+  if (pruned) group.tools[toolKey] = pruned;
+  draft.groups[groupId] = group;
+  return draft;
+}
+
+/** True when a tool entry carries any W9 override content (for UI badges). */
+export function hasOverrides(config: McpCustomScopeConfig, groupId: string, toolKey: string): boolean {
+  const entry = overrideEntry(config, groupId, toolKey);
+  return (
+    !!entry.name_override?.trim() ||
+    !!entry.description_override?.trim() ||
+    !!entry.arg_overrides && Object.values(entry.arg_overrides).some((v) => v.trim() !== '')
+  );
+}


### PR DESCRIPTION
Wave item of the tobor.locker overhaul (TOBOR-PLAN.md). Early WIP — opened as draft for visibility; spec-compliance review pending. Phase-0 deps and the contract rulings in `TOBOR-REVIEW.md` (trl-infra root) apply. Merge order: after Phase 0 per plan.