### PR TITLE
chore: sync main → develop (pubsub composite group, slug addressing, tsc fix)

### DIFF
--- a/helm/npl-mcp/values.yaml
+++ b/helm/npl-mcp/values.yaml
@@ -17,7 +17,7 @@ pmCore:
 backend:
   image:
     repository: ops.noizu.com/npl-mcp/server
-    tag: "sha-50d7361"
+    tag: "sha-83406a5"
     pullPolicy: IfNotPresent
   port: 4040
   # Authentik OIDC redirect flow (SSOController). issuer must NOT have a trailing
@@ -96,7 +96,7 @@ liquibase:
 frontend:
   image:
     repository: ops.noizu.com/npl-mcp/frontend
-    tag: "sha-50d7361"
+    tag: "sha-83406a5"
     pullPolicy: IfNotPresent
   port: 3000
   resources:


### PR DESCRIPTION
## Sync main → develop

Carries commits present on `main` but missing from `develop`:

```
f693719d0 ci: deploy sha-83406a5 [skip ci]
```

Note: this delta is the CI deploy-tag commit only (sha-83406a5); the substantive work (pubsub composite group, slug addressing, tsc fix, etc.) is already on develop via PRs #10/#11 + 50d7361b0.

Co-Authored-By: Loom <loom@therobotlives.com>
