### PR TITLE
fix(mcp): F3 — inert malformed anchors, wire window enforcement, prune + set_at

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
@@ -175,17 +175,23 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
     name_override = flag(entries, "name_override")
     description_override = flag(entries, "description_override")
 
-    {window_visible, expires_at} =
+    merged =
       entries
       |> Enum.reverse()
       |> Enum.reduce(%{}, fn {group, tool}, acc -> acc |> Map.merge(group) |> Map.merge(tool) end)
-      |> Window.evaluate(at)
+
+    {window_visible, expires_at} = Window.evaluate(merged, at)
+
+    # F3 enforcement wiring: a LIVE enable_for_hours window LIFTS BOTH static
+    # flags (disabled + hidden) while active; expired windows are no-ops
+    # (evaluate degrades to {true, nil} and lifting? to false).
+    lifted? = Window.lifting?(merged, at)
 
     base_visible = hidden != true
 
     %{
-      enabled: disabled != true,
-      visible: if(is_boolean(window_visible), do: base_visible and window_visible, else: base_visible),
+      enabled: lifted? or disabled != true,
+      visible: lifted? or (base_visible and window_visible),
       name_override: string_or_nil(name_override),
       description_override: string_or_nil(description_override),
       expires_at: expires_at

--- a/backend/lib/noizu_prompt_lingua/mcp/window.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/window.ex
@@ -11,12 +11,14 @@ defmodule NoizuPromptLingua.MCP.Window do
   never both. Absent fields mean "no window" (tool visibility is governed by the
   static `hidden`/`disabled` flags per the inverted default-visible semantics).
 
-  Anchoring: `enable_for_hours` needs a start instant; it is stamped at
-  normalize time (when the scope config is written) as `enabled_at` (UTC
-  ISO8601), following the same stamp-on-write precedent as
-  `disabled_confirmed_at` in `NoizuPromptLingua.MCPCustomScopes`. An entry with
-  `enable_for_hours` but no `enabled_at` (hand-edited jsonb) evaluates as an
-  inert window — write-side normalization re-anchors it.
+  Anchoring: `enable_for_hours` needs a start instant. Every write that
+  normalizes a window entry stamps `set_at` (UTC ISO8601, `DateTime.utc_now()`)
+  and the window anchors to it — so re-setting or extending an
+  `enable_for_hours` window resets its anchor (contract §3 as ratified).
+  Legacy entries anchored via `enabled_at` (the pre-set_at field) still
+  evaluate: `set_at` is preferred, `enabled_at` is the fallback. Hand-edited
+  jsonb with a malformed anchor is INERT — normalization re-anchors it and
+  evaluation treats the window as a no-op; it never raises.
 
   Naive-vs-UTC: naive datetime inputs (strings without an offset,
   `NaiveDateTime` structs) are interpreted as **UTC** — the repo-wide split
@@ -35,11 +37,22 @@ defmodule NoizuPromptLingua.MCP.Window do
     * `enable_for_hours` elapsed → `{true, nil}` (window inert; the entry's
       static flags govern again — windows expire out, they never permanently
       flip state).
+
+  A LIVE `enable_for_hours` window additionally LIFTS both static flags
+  (disabled + hidden) while active — enforcement wiring is in
+  `EffectiveToolset.build_state/2` via `lifting?/2`. Expired windows are
+  no-ops for the lift too.
   """
 
   @until_field "hide_until"
   @hours_field "enable_for_hours"
   @anchor_field "enabled_at"
+  @set_at_field "set_at"
+
+  # Windows whose effect ended more than this long ago are dropped on write —
+  # expired-but-recent windows are kept (they are inert at evaluation, but the
+  # audit trail is fresh).
+  @prune_after_days 7
 
   @type window :: %{
           hide_until: DateTime.t() | nil,
@@ -47,7 +60,8 @@ defmodule NoizuPromptLingua.MCP.Window do
         }
 
   @doc "Field names as stored in scope-config jsonb."
-  def fields, do: %{until: @until_field, hours: @hours_field, anchor: @anchor_field}
+  def fields,
+    do: %{until: @until_field, hours: @hours_field, anchor: @set_at_field, legacy_anchor: @anchor_field}
 
   ## ------------------------------------------------------------------
   ## Parsing / validation
@@ -103,25 +117,36 @@ defmodule NoizuPromptLingua.MCP.Window do
   Normalize an entry's window fields onto `base` (the normalized tool config
   being built by `MCPCustomScopes.normalize_tool_config/1`).
 
-    * valid `hide_until` → stored as ISO8601 UTC string.
-    * valid `enable_for_hours` → stored as integer, with `enabled_at` anchored
-      to the existing anchor (re-parsed) or stamped `DateTime.utc_now()`.
-    * invalid values (unparseable datetime, zero/negative/non-integer hours,
+    * valid `hide_until` → stored as ISO8601 UTC string — unless the window
+      expired more than #{@prune_after_days} days ago, in which case it is
+      pruned (retention: expired windows are not kept forever).
+    * valid `enable_for_hours` → stored as integer with a fresh `set_at`
+      anchor (stamped now) — every write re-anchors, so re-setting/extending
+      resets the window.
+    * `set_at` is stamped on every write that keeps a window.
+    * invalid values (unparseable datetime — including a malformed anchor,
+      which must be INERT, never a raise — zero/negative/non-integer hours,
       mutually-exclusive pair) are dropped — same silent-drop policy as the
       boolean flag normalizers; strict rejection happens at the changeset.
   """
   def normalize_entry(base, config) when is_map(base) and is_map(config) do
+    now = DateTime.utc_now()
+
     case parse(config) do
       {:ok, %{hide_until: %DateTime{} = until}} ->
-        Map.put(base, @until_field, DateTime.to_iso8601(until))
+        if prune?(until, now) do
+          base
+        else
+          base
+          |> Map.put(@until_field, DateTime.to_iso8601(until))
+          |> Map.put(@set_at_field, DateTime.to_iso8601(now))
+        end
 
       {:ok, %{enable_for_hours: hours}} when is_integer(hours) ->
-        anchor = parse_until(raw(config, @anchor_field)) |> elem(1)
-        anchor = anchor || DateTime.utc_now()
-
+        # Fresh anchor every write (set_at = now): re-set/extend resets.
         base
         |> Map.put(@hours_field, hours)
-        |> Map.put(@anchor_field, DateTime.to_iso8601(anchor))
+        |> Map.put(@set_at_field, DateTime.to_iso8601(now))
 
       _ ->
         base
@@ -156,9 +181,9 @@ defmodule NoizuPromptLingua.MCP.Window do
         {not hidden?, if(hidden?, do: until, else: nil)}
 
       {:ok, %{enable_for_hours: hours}} when is_integer(hours) ->
-        case parse_until(raw(entry, @anchor_field)) do
-          {:ok, %DateTime{} = enabled_at} ->
-            expires = DateTime.add(enabled_at, hours * 3600, :second)
+        case anchor(entry) do
+          {:ok, %DateTime{} = anchored_at} ->
+            expires = DateTime.add(anchored_at, hours * 3600, :second)
 
             if DateTime.compare(at, expires) == :lt do
               {true, expires}
@@ -168,7 +193,8 @@ defmodule NoizuPromptLingua.MCP.Window do
             end
 
           _ ->
-            # Unanchored window is inert — cannot have elapsed, cannot govern.
+            # Unanchored (or malformed-anchor) window is inert — cannot have
+            # elapsed, cannot govern. Never raises on hand-edited jsonb.
             {true, nil}
         end
 
@@ -184,6 +210,33 @@ defmodule NoizuPromptLingua.MCP.Window do
 
   def evaluate(_, _), do: {true, nil}
 
+  @doc "Lift check at now (convenience)."
+  def lifting?(entry), do: lifting?(entry, DateTime.utc_now())
+
+  @doc """
+  True when the entry carries a LIVE `enable_for_hours` window at `at` —
+  while active it LIFTS BOTH static flags (`disabled` and `hidden`); elapsed,
+  unanchored, malformed, or absent windows are no-ops (`false`).
+  """
+  def lifting?(entry, %DateTime{} = at) when is_map(entry) do
+    case parse(entry) do
+      {:ok, %{enable_for_hours: hours}} when is_integer(hours) ->
+        case anchor(entry) do
+          {:ok, %DateTime{} = anchored_at} ->
+            expires = DateTime.add(anchored_at, hours * 3600, :second)
+            DateTime.compare(at, expires) == :lt
+
+          _ ->
+            false
+        end
+
+      _ ->
+        false
+    end
+  end
+
+  def lifting?(_, _), do: false
+
   ## ------------------------------------------------------------------
   ## Internals
   ## ------------------------------------------------------------------
@@ -191,6 +244,19 @@ defmodule NoizuPromptLingua.MCP.Window do
   defp raw(entry, key) when is_binary(key) do
     Map.get(entry, key) || Map.get(entry, String.to_atom(key))
   end
+
+  # Window anchor: `set_at` (stamped on every write) with legacy `enabled_at`
+  # as fallback. A malformed value falls through to the fallback and then to
+  # the inert no-op — never a raise.
+  defp anchor(entry) do
+    case parse_until(raw(entry, @set_at_field)) do
+      {:ok, %DateTime{} = dt} -> {:ok, dt}
+      _ -> parse_until(raw(entry, @anchor_field))
+    end
+  end
+
+  defp prune?(expiry, now),
+    do: DateTime.compare(expiry, DateTime.add(now, -@prune_after_days * 86_400, :second)) == :lt
 
   defp parse_until(nil), do: {:ok, nil}
 

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -1197,7 +1197,7 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
     "name_override",
     "description_override",
     "arg_overrides"
-    # window keys (hide_until / enable_for_hours / enabled_at) are owned and
+    # window keys (hide_until / enable_for_hours / set_at) are owned and
     # normalized by MCP.Window.normalize_entry — not carried verbatim.
   ]
 

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
@@ -268,6 +268,111 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
       assert state.visible
       assert is_nil(state.expires_at)
     end
+
+    test "live enable window LIFTS disabled (enforcement wiring)" do
+      at = DateTime.utc_now()
+      anchor = DateTime.add(at, -3600, :second)
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{
+                "tools" => %{
+                  @tool => %{"disabled" => true, "enable_for_hours" => 24, "enabled_at" => DateTime.to_iso8601(anchor)}
+                }
+              }
+            })
+        }, nil, at)
+
+      assert state.enabled
+      assert %DateTime{} = state.expires_at
+    end
+
+    test "live enable window LIFTS hidden (enforcement wiring)" do
+      at = DateTime.utc_now()
+      anchor = DateTime.add(at, -3600, :second)
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{
+                "tools" => %{
+                  @tool => %{"hidden" => true, "enable_for_hours" => 24, "enabled_at" => DateTime.to_iso8601(anchor)}
+                }
+              }
+            })
+        }, nil, at)
+
+      assert state.visible
+      assert state.enabled
+    end
+
+    test "expired enable window does NOT lift disabled (no-op after expiry)" do
+      at = DateTime.utc_now()
+      anchor = DateTime.add(at, -48 * 3600, :second)
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{
+                "tools" => %{
+                  @tool => %{"disabled" => true, "enable_for_hours" => 24, "enabled_at" => DateTime.to_iso8601(anchor)}
+                }
+              }
+            })
+        }, nil, at)
+
+      refute state.enabled
+      assert is_nil(state.expires_at)
+    end
+
+    test "hide_until suppresses listing but does not disable execution" do
+      at = DateTime.utc_now()
+
+      state =
+        EffectiveToolset.state(@group, @tool, %{
+          "config" =>
+            scope_config(%{
+              @group => %{
+                "tools" => %{
+                  @tool => %{"disabled" => false, "hide_until" => DateTime.add(at, 3600, :second) |> DateTime.to_iso8601()}
+                }
+              }
+            })
+        }, nil, at)
+
+      refute state.visible
+      assert state.enabled
+    end
+
+    test "KeyToolsets.state/3 honors the window lift (ToolGuard path)" do
+      at = DateTime.utc_now()
+      anchor = DateTime.add(at, -3600, :second)
+      slug = "win-lift"
+
+      create_scope(
+        slug,
+        scope_config(%{
+          @group => %{
+            "tools" => %{
+              @tool => %{"disabled" => true, "enable_for_hours" => 24, "enabled_at" => DateTime.to_iso8601(anchor)}
+            }
+          }
+        })
+      )
+
+      ctx = %Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: %{custom_scope_slug: slug, auth_claims: %{}}
+      }
+
+      flags = KeyToolsets.state(@group, @tool, ctx)
+      refute flags.disabled
+      refute flags.hidden
+    end
   end
 
   # ── hidden vs disabled semantics ────────────────────────────────────────────

--- a/backend/test/noizu_prompt_lingua/mcp/window_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/window_test.exs
@@ -185,31 +185,127 @@ defmodule NoizuPromptLingua.MCP.WindowTest do
       refute Map.has_key?(normalized, "enable_for_hours")
     end
 
-    test "stamps enabled_at when anchoring enable_for_hours" do
+    test "stamps set_at when anchoring enable_for_hours" do
       normalized = Window.normalize_entry(%{}, %{"enable_for_hours" => 24})
 
       assert normalized["enable_for_hours"] == 24
-      assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(normalized["enabled_at"])
+      refute Map.has_key?(normalized, "enabled_at")
+      assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(normalized["set_at"])
 
       # anchor is fresh (stamped now)
-      stamped = DateTime.from_iso8601(normalized["enabled_at"]) |> elem(1)
+      stamped = DateTime.from_iso8601(normalized["set_at"]) |> elem(1)
       assert DateTime.diff(DateTime.utc_now(), stamped) < 5
     end
 
-    test "keeps an existing anchor (re-normalize does not slide the window)" do
+    test "every write re-stamps set_at (re-set/extend resets the anchor)" do
       config = %{
         "enable_for_hours" => 24,
+        "set_at" => "2026-08-30T00:00:00Z",
         "enabled_at" => "2026-08-30T00:00:00Z"
       }
 
       normalized = Window.normalize_entry(%{}, config)
-      assert normalized["enabled_at"] == "2026-08-30T00:00:00Z"
+
+      # stale anchors are not carried; the anchor slides to the new write
+      refute normalized["set_at"] == "2026-08-30T00:00:00Z"
+      refute Map.has_key?(normalized, "enabled_at")
+      assert {:ok, stamped, _} = DateTime.from_iso8601(normalized["set_at"])
+      assert DateTime.diff(DateTime.utc_now(), stamped) < 5
+    end
+
+    test "regression: hand-edited malformed anchor is INERT (no raise), window re-anchors" do
+      # Before the fix this raised: elem/1 of the parse error tuple flowed
+      # into DateTime.to_iso8601/1.
+      normalized =
+        Window.normalize_entry(%{}, %{
+          "enable_for_hours" => 24,
+          "enabled_at" => "not-a-timestamp"
+        })
+
+      assert normalized["enable_for_hours"] == 24
+      assert is_binary(normalized["set_at"])
+
+      # ...and the same malformed jsonb evaluates as a live re-anchored window
+      assert {true, %DateTime{}} = Window.evaluate(normalized)
+
+      # non-string garbage anchors are inert on write too
+      normalized2 = Window.normalize_entry(%{}, %{"enable_for_hours" => 24, "enabled_at" => 42})
+      assert is_binary(normalized2["set_at"])
+    end
+
+    test "evaluate prefers set_at over legacy enabled_at" do
+      entry = %{
+        "enable_for_hours" => 24,
+        "set_at" => "2026-08-31T00:00:00Z",
+        "enabled_at" => "2026-08-01T00:00:00Z"
+      }
+
+      assert {true, ~U[2026-09-01 00:00:00Z]} = Window.evaluate(entry, @now)
+    end
+
+    test "hide_until writes also stamp set_at" do
+      normalized = Window.normalize_entry(%{}, %{"hide_until" => @future})
+      assert is_binary(normalized["set_at"])
     end
 
     test "drops invalid values silently (strict rejection lives on the changeset)" do
       assert Window.normalize_entry(%{}, %{"hide_until" => "someday"}) == %{}
       assert Window.normalize_entry(%{}, %{"enable_for_hours" => 0}) == %{}
       assert Window.normalize_entry(%{}, %{"hide_until" => @future, "enable_for_hours" => 24}) == %{}
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # lifting?/2 — enable_for_hours lifts BOTH static flags while live
+  # ------------------------------------------------------------------
+
+  describe "lifting?/2" do
+    test "live window lifts" do
+      entry = %{"enable_for_hours" => 24, "set_at" => "2026-08-31T00:00:00Z"}
+      assert Window.lifting?(entry, @now)
+    end
+
+    test "legacy enabled_at anchor still lifts" do
+      entry = %{"enable_for_hours" => 24, "enabled_at" => "2026-08-31T00:00:00Z"}
+      assert Window.lifting?(entry, @now)
+    end
+
+    test "elapsed window does not lift" do
+      entry = %{"enable_for_hours" => 24, "set_at" => "2026-08-29T00:00:00Z"}
+      refute Window.lifting?(entry, @now)
+    end
+
+    test "unanchored / malformed / hide_until entries never lift" do
+      refute Window.lifting?(%{"enable_for_hours" => 24}, @now)
+      refute Window.lifting?(%{"enable_for_hours" => 24, "set_at" => "garbage"}, @now)
+      refute Window.lifting?(%{"hide_until" => @future}, @now)
+      refute Window.lifting?(%{}, @now)
+      refute Window.lifting?(nil, @now)
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Retention — prune expired windows >7d old on write
+  # ------------------------------------------------------------------
+
+  describe "normalize_entry/2 retention prune" do
+    test "hide_until expired more than 7d ago is pruned" do
+      ancient = DateTime.add(@now, -8 * 86_400, :second)
+
+      assert Window.normalize_entry(%{}, %{"hide_until" => ancient}) == %{}
+    end
+
+    test "hide_until expired within 7d is kept (inert at evaluation)" do
+      recent = DateTime.add(@now, -3 * 86_400, :second)
+
+      normalized = Window.normalize_entry(%{}, %{"hide_until" => recent})
+      assert is_binary(normalized["hide_until"])
+      assert {true, nil} = Window.evaluate(normalized, DateTime.utc_now())
+    end
+
+    test "future hide_until is kept" do
+      normalized = Window.normalize_entry(%{}, %{"hide_until" => @future})
+      assert is_binary(normalized["hide_until"])
     end
   end
 
@@ -245,7 +341,24 @@ defmodule NoizuPromptLingua.MCP.WindowTest do
 
       tool = MCPCustomScopes.normalize_config(config, "custom")["groups"]["sessions"]["tools"]["Session_List"]
       assert tool["enable_for_hours"] == 48
-      assert is_binary(tool["enabled_at"])
+      assert is_binary(tool["set_at"])
+    end
+
+    test "regression: hand-edited malformed anchor in scope-config jsonb is inert on write" do
+      config = %{
+        "groups" => %{
+          "sessions" => %{
+            "tools" => %{"Session_List" => %{"enable_for_hours" => 48, "enabled_at" => "garbage"}}
+          }
+        }
+      }
+
+      # raised (DateTime.to_iso8601 on an error tuple) before the fix
+      tool =
+        MCPCustomScopes.normalize_config(config, "custom")["groups"]["sessions"]["tools"]["Session_List"]
+
+      assert tool["enable_for_hours"] == 48
+      assert {:ok, %DateTime{}, _} = DateTime.from_iso8601(tool["set_at"])
     end
 
     test "evaluates end-to-end after normalization round-trip" do


### PR DESCRIPTION
Follow-up to PR #15 (review findings in TOBOR-REVIEW.md):

- **Crash**: malformed `enabled_at` anchor no longer raises on config write — inert with re-anchor on write; regression tests with hand-edited jsonb.
- **Wiring**: `Window.lifting?/2` + `EffectiveToolset.build_state` lifts BOTH disabled+hidden while an enable window is live; flows through KeyToolsets → ToolGuard. hide_until suppresses listing only; expired = no-op.
- **Retention**: expired hide_until pruned >7d on write; set_at stamped on every write (re-set resets enable_for_hours anchor); legacy enabled_at evaluates as fallback.

Gates: 118 scoped tests green (window/effective_toolset/key_toolsets/tool_guard/custom scopes). Commit c1f5be722.

Co-Authored-By: Loom <loom@therobotlives.com>