### PR TITLE
fix(frontend): ui-kit a11y contract, shared tool-state types, id collisions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "regen": "rm -rf .cache && npm run generate-css",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
-    "test:contracts": "node --import tsx --test src/components/app-shell.contract.test.ts src/lib/pm/trp-board-embed.test.ts src/lib/mcp-setup.test.ts src/components/mcp-oauth-setup.contract.test.ts src/lib/tool-overrides.test.ts",
+    "test:contracts": "node --import tsx --test src/components/app-shell.contract.test.ts src/lib/pm/trp-board-embed.test.ts src/lib/mcp-setup.test.ts src/components/mcp-oauth-setup.contract.test.ts src/lib/tool-overrides.test.ts src/components/kit/acl-editor.contract.test.ts",
     "test:e2e:authentik": "cypress run --browser chrome --config-file cypress.authentik.config.ts --spec 'cypress/e2e/auth/login-authentik.cy.ts'"
   },
   "dependencies": {

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -19,7 +19,7 @@ import {
   TempWindowEditor,
   type ContextMenuItem,
   type AclState,
-  type ToolToggleGroup,
+  type ToolSection,
   type TempWindow,
 } from '@/components/kit';
 import {
@@ -473,39 +473,44 @@ function AdminMcpCustomScopesInner() {
   const selectedClient = clients.find((c) => c.id === selectedClientId) ?? null;
 
   /** Client toolset toggles derived from catalog × client toolset_config (absent = enabled + visible). */
-  const clientToggleGroups: ToolToggleGroup[] = useMemo(() => {
+  const clientToggleGroups: ToolSection[] = useMemo(() => {
     const cfg = clientPerms?.toolsetConfig ?? { groups: {} };
     return catalog.map((group) => ({
-      group: group.label,
+      name: group.label,
       tools: group.tools.map((tool) => {
         const override = cfg.groups[group.id]?.tools?.[tool.name] ?? {};
+        const hidden = override.hidden === undefined ? tool.hidden : override.hidden;
         return {
-          name: tool.name,
-          enabled: override.disabled !== true,
-          hidden: override.hidden === undefined ? tool.hidden : override.hidden,
+          tool: { kind: 'mcp_tool', id: tool.name },
+          state: {
+            enabled: override.disabled !== true,
+            visible: !hidden,
+          },
         };
       }),
     }));
   }, [catalog, clientPerms]);
 
-  function patchClientToggleGroups(next: ToolToggleGroup[]) {
+  function patchClientToggleGroups(next: ToolSection[]) {
     setClientPerms((current) => {
       if (!current) return current;
       const labelToId = new Map(catalog.map((g) => [g.label, g.id]));
       const groups: McpCustomScopeConfig['groups'] = {};
-      for (const tg of next) {
-        const groupId = labelToId.get(tg.group) ?? tg.group;
+      for (const section of next) {
+        const groupId = labelToId.get(section.name) ?? section.name;
         const catalogGroup = catalog.find((g) => g.id === groupId);
         const tools: Record<string, { disabled?: boolean; hidden?: boolean }> = {};
-        for (const entry of tg.tools) {
-          const catalogTool = catalogGroup?.tools.find((t) => t.name === entry.name);
+        for (const entry of section.tools) {
+          const name = entry.tool.id;
+          const catalogTool = catalogGroup?.tools.find((t) => t.name === name);
+          const hidden = !entry.state.visible;
           const tool: { disabled?: boolean; hidden?: boolean } = {};
-          if (!entry.enabled) tool.disabled = true;
+          if (!entry.state.enabled) tool.disabled = true;
           // Only persist hidden when it diverges from the catalog default
           // (inverted semantics: absent = visible).
-          if (catalogTool && entry.hidden !== catalogTool.hidden) tool.hidden = entry.hidden;
-          else if (!catalogTool && entry.hidden) tool.hidden = true;
-          tools[entry.name] = tool;
+          if (catalogTool && hidden !== catalogTool.hidden) tool.hidden = hidden;
+          else if (!catalogTool && hidden) tool.hidden = true;
+          tools[name] = tool;
         }
         groups[groupId] = { tools };
       }
@@ -807,7 +812,7 @@ function AdminMcpCustomScopesInner() {
               Per-client overrides layer on top of the scope config (absent = enabled + visible).
             </span>
             <ToolTogglesGrid
-              groups={clientToggleGroups}
+              sections={clientToggleGroups}
               onChange={patchClientToggleGroups}
             />
           </section>

--- a/frontend/src/components/kit/acl-editor.contract.test.ts
+++ b/frontend/src/components/kit/acl-editor.contract.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { AclRule } from '@/types/tool-state';
+import { denyFirst, parseRef, refLabel } from './acl-editor';
+
+function rule(id: string, effect: 'allow' | 'deny', kind: string, rid: string): AclRule {
+  return { id, effect, subject: { kind, id: rid }, resource: null, scope: 'read', priority: 0 };
+}
+
+test('denyFirst sorts deny rules before allow rules', () => {
+  const ordered = denyFirst([
+    rule('a', 'allow', 'client', 'c1'),
+    rule('b', 'deny', 'client', 'c2'),
+    rule('c', 'allow', 'user', 'u1'),
+    rule('d', 'deny', 'user', 'u2'),
+  ]);
+  assert.deepEqual(
+    ordered.map((r) => r.effect),
+    ['deny', 'deny', 'allow', 'allow'],
+  );
+});
+
+test('denyFirst is stable within an effect and does not mutate input', () => {
+  const input = [rule('a', 'allow', 'client', 'c1'), rule('b', 'deny', 'client', 'c2')];
+  const ordered = denyFirst(input);
+  assert.deepEqual(ordered.map((r) => r.id), ['b', 'a']);
+  assert.deepEqual(input.map((r) => r.id), ['a', 'b']);
+});
+
+test('parseRef parses kind:id and bare ids', () => {
+  assert.deepEqual(parseRef('client:key-1'), { kind: 'client', id: 'key-1' });
+  assert.deepEqual(parseRef(' key-1 '), { kind: 'any', id: 'key-1' });
+  assert.equal(parseRef(''), null);
+  assert.equal(parseRef('broken:'), null);
+});
+
+test('refLabel prefers the display label and falls back to kind:id', () => {
+  assert.equal(refLabel({ kind: 'client', id: 'k1', label: 'CI runner' }), 'CI runner (client:k1)');
+  assert.equal(refLabel({ kind: 'client', id: 'k1' }), 'client:k1');
+});

--- a/frontend/src/components/kit/acl-editor.tsx
+++ b/frontend/src/components/kit/acl-editor.tsx
@@ -1,49 +1,40 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { kitBtnSm, kitFieldLabel, kitInput } from './shared';
+import type { AclEffect, AclGroup, AclRule, AclState, EntityRef } from '@/types/tool-state';
 
-/**
- * ACL shapes bind against the F1 acl-core contract: subject and resource are
- * opaque ERP ref strings (`{:ref, Type, id}` serialized), effect is allow/deny,
- * scope is a free-form string supplied by the host. This component knows
- * nothing about backend code — the host owns persistence.
- */
+export type { AclEffect, AclGroup, AclRule, AclState };
 
-export type AclEffect = 'allow' | 'deny';
-
-export interface AclRule {
-  /** Client-side id (host-assigned or generated). */
-  id: string;
-  /** Opaque ERP ref string, e.g. subject user/org/group ref. */
-  subject: string;
-  /** Opaque ERP ref string for the protected entity. */
-  resource: string;
-  effect: AclEffect;
-  /** Permission scope label (e.g. "read", "write", "admin"). */
-  scope: string;
+/** Human label for a ref in aria-labels / chips: "label (kind:id)" or "kind:id". */
+export function refLabel(r: EntityRef): string {
+  const base = `${r.kind}:${r.id}`;
+  return r.label ? `${r.label} (${base})` : base;
 }
 
-export interface AclGroup {
-  id: string;
-  name: string;
-  /** Member subject refs (opaque ERP ref strings). */
-  members: string[];
+function sameRef(a: EntityRef, b: EntityRef): boolean {
+  return a.kind === b.kind && a.id === b.id;
 }
 
-export interface AclState {
-  rules: AclRule[];
-  groups: AclGroup[];
+/** Parse "kind:id" (or bare "id" → kind "any") into an EntityRef. */
+export function parseRef(input: string): EntityRef | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const sep = trimmed.indexOf(':');
+  if (sep === -1) return { kind: 'any', id: trimmed };
+  const kind = trimmed.slice(0, sep).trim();
+  const id = trimmed.slice(sep + 1).trim();
+  return kind && id ? { kind, id } : null;
 }
 
 interface ACLEditorProps {
   value: AclState;
   onChange: (next: AclState) => void;
   /** Suggested subject refs for datalist autocomplete. */
-  subjectSuggestions?: string[];
+  subjectSuggestions?: EntityRef[];
   /** Suggested resource refs for datalist autocomplete. */
-  resourceSuggestions?: string[];
+  resourceSuggestions?: EntityRef[];
   /** Allowed scope labels (free-form when omitted). */
   scopeOptions?: string[];
   readOnly?: boolean;
@@ -55,10 +46,22 @@ function localId() {
   return `acl-${Date.now()}-${seq}`;
 }
 
+/** Deny rules sort before allow rules for display (stable within effect). */
+export function denyFirst(rules: AclRule[]): AclRule[] {
+  return [...rules].sort(
+    (a, b) => (a.effect === 'deny' ? 0 : 1) - (b.effect === 'deny' ? 0 : 1),
+  );
+}
+
 /**
  * Grant/deny rule editor with named permission groups. Pure controlled
  * component: emits the full next state via onChange; never mutates props.
- * Accessible: labeled inputs, datalist suggestions, aria-labels on icon buttons.
+ * Binds the shared F4 tool-state contract (`AclState` from
+ * `@/types/tool-state`) — subjects/resources are F1 ERP refs (kind + id),
+ * not opaque strings. Rules render deny-before-allow regardless of stored
+ * order (deny wins under F1 evaluation).
+ * Accessible: labeled inputs, datalist suggestions, subject-named aria-labels
+ * on icon buttons.
  */
 export default function ACLEditor({
   value,
@@ -70,6 +73,10 @@ export default function ACLEditor({
 }: ACLEditorProps) {
   const { rules, groups } = value;
   const [newGroupMembers, setNewGroupMembers] = useState<Record<string, string>>({});
+  const uid = useId();
+  const subjectListId = `${uid}-subject-suggestions`;
+  const resourceListId = `${uid}-resource-suggestions`;
+  const kindListId = `${uid}-kind-suggestions`;
 
   function updateRules(next: AclRule[]) {
     onChange({ rules: next, groups });
@@ -82,13 +89,27 @@ export default function ACLEditor({
   function addRule() {
     updateRules([
       ...rules,
-      { id: localId(), subject: '', resource: '', effect: 'allow', scope: scopeOptions[0] ?? 'read' },
+      {
+        id: localId(),
+        subject: { kind: 'any', id: '' },
+        resource: null,
+        effect: 'deny',
+        scope: scopeOptions[0] ?? 'read',
+        priority: 0,
+      },
     ]);
   }
 
   function patchRule(id: string, patch: Partial<AclRule>) {
     updateRules(rules.map((r) => (r.id === id ? { ...r, ...patch } : r)));
   }
+
+  const kindSuggestions = [
+    ...new Set([
+      ...subjectSuggestions.map((s) => s.kind),
+      ...resourceSuggestions.map((s) => s.kind),
+    ]),
+  ];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -108,14 +129,14 @@ export default function ACLEditor({
           <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0 }}>No rules — access falls through to defaults.</p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {rules.map((rule, idx) => (
+            {denyFirst(rules).map((rule) => (
               <div
                 key={rule.id}
                 role="group"
-                aria-label={`Rule ${idx + 1}`}
+                aria-label={`${rule.effect} rule for ${refLabel(rule.subject)}`}
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: 'auto 1fr 1fr auto 1fr auto',
+                  gridTemplateColumns: 'auto 1fr 1fr 1fr 64px auto',
                   gap: 6,
                   alignItems: 'end',
                   padding: 8,
@@ -137,40 +158,78 @@ export default function ACLEditor({
                       fontWeight: 600,
                     }}
                   >
-                    <option value="allow">allow</option>
                     <option value="deny">deny</option>
+                    <option value="allow">allow</option>
                   </select>
                 </div>
                 <div>
                   <label htmlFor={`acl-subject-${rule.id}`} style={kitFieldLabel}>Subject ref</label>
-                  <input
-                    id={`acl-subject-${rule.id}`}
-                    list="acl-subject-suggestions"
-                    value={rule.subject}
-                    readOnly={readOnly}
-                    placeholder="user/org/group ref"
-                    onChange={(e) => patchRule(rule.id, { subject: e.target.value })}
-                    style={{ ...kitInput, width: '100%', fontFamily: 'monospace' }}
-                  />
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    <input
+                      id={`acl-subject-kind-${rule.id}`}
+                      list={kindListId}
+                      aria-label={`Subject kind for ${refLabel(rule.subject)}`}
+                      value={rule.subject.kind}
+                      readOnly={readOnly}
+                      placeholder="kind"
+                      onChange={(e) => patchRule(rule.id, { subject: { ...rule.subject, kind: e.target.value } })}
+                      style={{ ...kitInput, width: 84, fontFamily: 'monospace' }}
+                    />
+                    <input
+                      id={`acl-subject-${rule.id}`}
+                      list={subjectListId}
+                      aria-label={`Subject id for ${refLabel(rule.subject)}`}
+                      value={rule.subject.id}
+                      readOnly={readOnly}
+                      placeholder="subject id"
+                      onChange={(e) => patchRule(rule.id, { subject: { ...rule.subject, id: e.target.value } })}
+                      style={{ ...kitInput, width: '100%', fontFamily: 'monospace' }}
+                    />
+                  </div>
                 </div>
                 <div>
                   <label htmlFor={`acl-resource-${rule.id}`} style={kitFieldLabel}>Resource ref</label>
-                  <input
-                    id={`acl-resource-${rule.id}`}
-                    list="acl-resource-suggestions"
-                    value={rule.resource}
-                    readOnly={readOnly}
-                    placeholder="entity ref"
-                    onChange={(e) => patchRule(rule.id, { resource: e.target.value })}
-                    style={{ ...kitInput, width: '100%', fontFamily: 'monospace' }}
-                  />
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    <input
+                      id={`acl-resource-kind-${rule.id}`}
+                      list={kindListId}
+                      aria-label={`Resource kind${rule.resource ? ` for ${refLabel(rule.resource)}` : ''}`}
+                      value={rule.resource?.kind ?? ''}
+                      readOnly={readOnly}
+                      placeholder="kind"
+                      onChange={(e) =>
+                        patchRule(rule.id, {
+                          resource: e.target.value || rule.resource?.id
+                            ? { kind: e.target.value, id: rule.resource?.id ?? '' }
+                            : null,
+                        })
+                      }
+                      style={{ ...kitInput, width: 84, fontFamily: 'monospace' }}
+                    />
+                    <input
+                      id={`acl-resource-${rule.id}`}
+                      list={resourceListId}
+                      aria-label={`Resource id${rule.resource ? ` for ${refLabel(rule.resource)}` : ''}`}
+                      value={rule.resource?.id ?? ''}
+                      readOnly={readOnly}
+                      placeholder="entity id"
+                      onChange={(e) =>
+                        patchRule(rule.id, {
+                          resource: e.target.value || rule.resource?.kind
+                            ? { kind: rule.resource?.kind ?? '', id: e.target.value }
+                            : null,
+                        })
+                      }
+                      style={{ ...kitInput, width: '100%', fontFamily: 'monospace' }}
+                    />
+                  </div>
                 </div>
                 <div>
                   <label htmlFor={`acl-scope-${rule.id}`} style={kitFieldLabel}>Scope</label>
                   {scopeOptions.length > 0 ? (
                     <select
                       id={`acl-scope-${rule.id}`}
-                      value={rule.scope}
+                      value={rule.scope ?? ''}
                       disabled={readOnly}
                       onChange={(e) => patchRule(rule.id, { scope: e.target.value })}
                       style={{ ...kitInput, width: '100%' }}
@@ -182,12 +241,25 @@ export default function ACLEditor({
                   ) : (
                     <input
                       id={`acl-scope-${rule.id}`}
-                      value={rule.scope}
+                      value={rule.scope ?? ''}
                       readOnly={readOnly}
                       onChange={(e) => patchRule(rule.id, { scope: e.target.value })}
                       style={{ ...kitInput, width: '100%' }}
                     />
                   )}
+                </div>
+                <div>
+                  <label htmlFor={`acl-priority-${rule.id}`} style={kitFieldLabel}>Prio</label>
+                  <input
+                    id={`acl-priority-${rule.id}`}
+                    type="number"
+                    step={1}
+                    value={rule.priority}
+                    readOnly={readOnly}
+                    aria-label={`Priority for ${rule.effect} rule on ${refLabel(rule.subject)}`}
+                    onChange={(e) => patchRule(rule.id, { priority: Math.floor(Number(e.target.value)) || 0 })}
+                    style={{ ...kitInput, width: '100%' }}
+                  />
                 </div>
                 <span style={{ fontSize: 10, color: 'var(--text-3)', paddingBottom: 6 }}>
                   {rule.effect === 'deny' ? 'blocks' : 'grants'} access
@@ -197,7 +269,7 @@ export default function ACLEditor({
                     type="button"
                     onClick={() => updateRules(rules.filter((r) => r.id !== rule.id))}
                     style={{ ...kitBtnSm, border: 0, background: 'transparent', color: 'var(--red, #ef4444)', paddingBottom: 4 }}
-                    aria-label={`Delete rule ${idx + 1}`}
+                    aria-label={`Delete ${rule.effect} rule for ${refLabel(rule.subject)}`}
                   >
                     <TrashIcon style={{ width: 14, height: 14 }} aria-hidden="true" />
                   </button>
@@ -208,11 +280,18 @@ export default function ACLEditor({
             ))}
           </div>
         )}
-        <datalist id="acl-subject-suggestions">
-          {subjectSuggestions.map((s) => <option key={s} value={s} />)}
+        <datalist id={subjectListId}>
+          {subjectSuggestions.map((s) => (
+            <option key={`${s.kind}:${s.id}`} value={s.id}>{s.label ?? `${s.kind}:${s.id}`}</option>
+          ))}
         </datalist>
-        <datalist id="acl-resource-suggestions">
-          {resourceSuggestions.map((s) => <option key={s} value={s} />)}
+        <datalist id={resourceListId}>
+          {resourceSuggestions.map((s) => (
+            <option key={`${s.kind}:${s.id}`} value={s.id}>{s.label ?? `${s.kind}:${s.id}`}</option>
+          ))}
+        </datalist>
+        <datalist id={kindListId}>
+          {kindSuggestions.map((k) => <option key={k} value={k} />)}
         </datalist>
       </section>
 
@@ -236,7 +315,7 @@ export default function ACLEditor({
           <p style={{ fontSize: 11, color: 'var(--text-3)', margin: 0 }}>No groups defined.</p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {groups.map((group, gIdx) => (
+            {groups.map((group) => (
               <div
                 key={group.id}
                 style={{
@@ -274,9 +353,9 @@ export default function ACLEditor({
                   {group.members.length === 0 ? (
                     <span style={{ fontSize: 11, color: 'var(--text-3)' }}>No members.</span>
                   ) : (
-                    group.members.map((m, mIdx) => (
+                    group.members.map((m) => (
                       <span
-                        key={m}
+                        key={`${m.kind}:${m.id}`}
                         style={{
                           display: 'inline-flex',
                           alignItems: 'center',
@@ -290,16 +369,16 @@ export default function ACLEditor({
                           color: 'var(--text-1)',
                         }}
                       >
-                        {m}
+                        {m.label ?? `${m.kind}:${m.id}`}
                         {!readOnly ? (
                           <button
                             type="button"
-                            aria-label={`Remove member ${m} from group ${group.name}`}
+                            aria-label={`Remove member ${refLabel(m)} from group ${group.name}`}
                             onClick={() =>
                               updateGroups(
                                 groups.map((g) =>
                                   g.id === group.id
-                                    ? { ...g, members: g.members.filter((_, i) => i !== mIdx) }
+                                    ? { ...g, members: g.members.filter((x) => !sameRef(x, m)) }
                                     : g,
                                 ),
                               )
@@ -317,17 +396,17 @@ export default function ACLEditor({
                   <div style={{ display: 'flex', gap: 6 }}>
                     <input
                       value={newGroupMembers[group.id] ?? ''}
-                      placeholder="add member ref…"
+                      placeholder="add member as kind:id…"
                       aria-label={`Add member to group ${group.name}`}
                       onChange={(e) => setNewGroupMembers((prev) => ({ ...prev, [group.id]: e.target.value }))}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') {
                           e.preventDefault();
-                          const member = (newGroupMembers[group.id] ?? '').trim();
+                          const member = parseRef(newGroupMembers[group.id] ?? '');
                           if (!member) return;
                           updateGroups(
                             groups.map((g) =>
-                              g.id === group.id && !g.members.includes(member)
+                              g.id === group.id && !g.members.some((x) => sameRef(x, member))
                                 ? { ...g, members: [...g.members, member] }
                                 : g,
                             ),
@@ -340,11 +419,11 @@ export default function ACLEditor({
                     <button
                       type="button"
                       onClick={() => {
-                        const member = (newGroupMembers[group.id] ?? '').trim();
+                        const member = parseRef(newGroupMembers[group.id] ?? '');
                         if (!member) return;
                         updateGroups(
                           groups.map((g) =>
-                            g.id === group.id && !g.members.includes(member)
+                            g.id === group.id && !g.members.some((x) => sameRef(x, member))
                               ? { ...g, members: [...g.members, member] }
                               : g,
                           ),

--- a/frontend/src/components/kit/context-menu.tsx
+++ b/frontend/src/components/kit/context-menu.tsx
@@ -40,11 +40,21 @@ interface ContextMenuProps {
   menuLabel?: string;
 }
 
+function nextEnabled(items: ContextMenuItem[], from: number, dir: 1 | -1): number {
+  for (let i = 0; i < items.length; i++) {
+    const idx = (from + dir * i + dir + items.length) % items.length;
+    if (!items[idx].disabled) return idx;
+  }
+  return from;
+}
+
 /**
  * Right-click context menu. Wrap any content; the menu opens at the cursor,
  * supports icons, destructive styling, disabled items, separators, shortcuts,
- * and one level of submenu. Keyboard: arrows navigate, Enter/Space activate,
- * Right opens a submenu, Esc / click-outside dismisses.
+ * and one level of submenu. Keyboard (WAI-ARIA menu pattern): arrows navigate,
+ * Home/End jump to first/last item, Enter/Space activate, Enter/ArrowRight
+ * opens a submenu (ArrowLeft/Esc closes it), Tab dismisses, Esc / click /
+ * scroll outside dismiss and focus returns to the trigger.
  */
 export default function ContextMenu({
   items,
@@ -57,17 +67,31 @@ export default function ContextMenu({
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const [activeIdx, setActiveIdx] = useState(-1);
   const [openSubmenuIdx, setOpenSubmenuIdx] = useState<number | null>(null);
+  const [activeSubIdx, setActiveSubIdx] = useState(-1);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
   const menuId = useId();
 
   const isOpen = pos !== null;
 
-  const close = useCallback(() => {
-    setPos(null);
-    setActiveIdx(-1);
-    setOpenSubmenuIdx(null);
-    onClose?.();
-  }, [onClose]);
+  const close = useCallback(
+    (opts: { restoreFocus?: boolean } = {}) => {
+      const wasOpen = pos !== null;
+      setPos(null);
+      setActiveIdx(-1);
+      setOpenSubmenuIdx(null);
+      setActiveSubIdx(-1);
+      if (wasOpen) {
+        if (opts.restoreFocus !== false) {
+          const t = triggerRef.current;
+          if (t && t.isConnected) t.focus({ preventScroll: true });
+        }
+        triggerRef.current = null;
+        onClose?.();
+      }
+    },
+    [pos, onClose],
+  );
 
   // Clamp the open menu inside the viewport.
   useEffect(() => {
@@ -81,20 +105,23 @@ export default function ContextMenu({
     }
   }, [isOpen]);
 
-  // Dismiss on outside click / scroll / Esc handled in keydown below.
+  // Dismiss on outside click, scroll, or resize. Esc is handled in keydown.
   useEffect(() => {
     if (!isOpen) return;
     function onPointerDown(e: PointerEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) close();
     }
-    function onScrollOrBlur() {
+    function onScrollOrResize() {
       close();
     }
     window.addEventListener('pointerdown', onPointerDown, true);
-    window.addEventListener('resize', onScrollOrBlur);
+    // capture: scroll events don't bubble; capture still sees them.
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
     return () => {
       window.removeEventListener('pointerdown', onPointerDown, true);
-      window.removeEventListener('resize', onScrollOrBlur);
+      window.removeEventListener('scroll', onScrollOrResize, true);
+      window.removeEventListener('resize', onScrollOrResize);
     };
   }, [isOpen, close]);
 
@@ -103,10 +130,18 @@ export default function ContextMenu({
     if (isOpen) menuRef.current?.focus();
   }, [isOpen]);
 
-  function openAt(x: number, y: number) {
+  function openAt(x: number, y: number, trigger: HTMLElement | null) {
+    triggerRef.current = trigger;
     setPos({ x, y });
     setActiveIdx(firstEnabledIndex(items));
     setOpenSubmenuIdx(null);
+    setActiveSubIdx(-1);
+  }
+
+  function openSubmenu(idx: number) {
+    const subs = items[idx]?.submenu ?? [];
+    setOpenSubmenuIdx(idx);
+    setActiveSubIdx(subs.findIndex((s) => !s.disabled));
   }
 
   function activate(item: ContextMenuItem) {
@@ -117,50 +152,104 @@ export default function ContextMenu({
 
   function onKeyDown(e: ReactKeyboardEvent) {
     if (!isOpen) return;
-    const flat = items;
+    const submenuOpen = openSubmenuIdx !== null && openSubmenuIdx === activeIdx;
+    const subs = submenuOpen ? (items[openSubmenuIdx]?.submenu ?? []) : [];
+
+    if (e.key === 'Tab') {
+      // Close and let focus move on with the default tab order.
+      close({ restoreFocus: false });
+      return;
+    }
     if (e.key === 'Escape') {
       e.preventDefault();
-      close();
+      if (submenuOpen) {
+        // First Esc closes the submenu, second closes the menu.
+        setOpenSubmenuIdx(null);
+        setActiveSubIdx(-1);
+      } else {
+        close();
+      }
+      return;
+    }
+    if (e.key === 'Home' || e.key === 'End') {
+      e.preventDefault();
+      if (submenuOpen) {
+        const candidates = subs.map((s, i) => ({ s, i })).filter(({ s }) => !s.disabled);
+        setActiveSubIdx(candidates.length ? (e.key === 'Home' ? candidates[0].i : candidates[candidates.length - 1].i) : -1);
+      } else {
+        setActiveIdx(e.key === 'Home' ? firstEnabledIndex(items) : lastEnabledIndex(items));
+        setOpenSubmenuIdx(null);
+        setActiveSubIdx(-1);
+      }
       return;
     }
     if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
       e.preventDefault();
       const dir = e.key === 'ArrowDown' ? 1 : -1;
-      let idx = activeIdx;
-      for (let i = 0; i < flat.length; i++) {
-        idx = (idx + dir + flat.length) % flat.length;
-        if (!flat[idx].disabled) break;
+      if (submenuOpen) {
+        setActiveSubIdx((cur) => {
+          let idx = cur;
+          for (let i = 0; i < subs.length; i++) {
+            idx = (idx + dir + subs.length) % subs.length;
+            if (!subs[idx].disabled) break;
+          }
+          return idx;
+        });
+      } else {
+        setActiveIdx((cur) => nextEnabled(items, cur, dir));
+        setOpenSubmenuIdx(null);
+        setActiveSubIdx(-1);
       }
-      setActiveIdx(idx);
-      setOpenSubmenuIdx(null);
       return;
     }
     if (e.key === 'ArrowRight') {
-      const item = flat[activeIdx];
-      if (item?.submenu?.length) {
-        e.preventDefault();
-        setOpenSubmenuIdx(activeIdx);
+      e.preventDefault();
+      if (submenuOpen) {
+        const sub = subs[activeSubIdx];
+        if (sub) activate(sub);
+      } else {
+        const item = items[activeIdx];
+        if (item?.submenu?.length) openSubmenu(activeIdx);
       }
       return;
     }
-    if (e.key === 'ArrowLeft' && openSubmenuIdx !== null) {
-      e.preventDefault();
-      setOpenSubmenuIdx(null);
+    if (e.key === 'ArrowLeft') {
+      if (submenuOpen) {
+        e.preventDefault();
+        setOpenSubmenuIdx(null);
+        setActiveSubIdx(-1);
+      }
       return;
     }
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      const item = flat[activeIdx];
-      if (item) activate(item);
+      if (submenuOpen) {
+        const sub = subs[activeSubIdx];
+        if (sub) activate(sub);
+        return;
+      }
+      const item = items[activeIdx];
+      if (!item) return;
+      if (item.submenu?.length) openSubmenu(activeIdx);
+      else activate(item);
     }
   }
+
+  const activeDescendant =
+    activeIdx >= 0
+      ? submenuOpenId(menuId, activeIdx, openSubmenuIdx === activeIdx ? activeSubIdx : null)
+      : undefined;
 
   return (
     <div
       onContextMenu={(e) => {
         if (disabled) return;
         e.preventDefault();
-        openAt(e.clientX, e.clientY);
+        const trigger =
+          document.activeElement instanceof HTMLElement && document.activeElement !== document.body
+            ? document.activeElement
+            : (e.target as HTMLElement);
+        openAt(e.clientX, e.clientY, trigger);
       }}
     >
       {children}
@@ -170,6 +259,7 @@ export default function ContextMenu({
           id={menuId}
           role="menu"
           aria-label={menuLabel}
+          aria-activedescendant={activeDescendant}
           tabIndex={-1}
           onKeyDown={onKeyDown}
           style={{
@@ -188,6 +278,7 @@ export default function ContextMenu({
               <button
                 type="button"
                 role="menuitem"
+                id={submenuOpenId(menuId, idx, null)}
                 aria-disabled={item.disabled || undefined}
                 aria-haspopup={item.submenu?.length ? 'menu' : undefined}
                 aria-expanded={item.submenu?.length ? openSubmenuIdx === idx : undefined}
@@ -200,6 +291,7 @@ export default function ContextMenu({
                 onMouseEnter={() => {
                   setActiveIdx(idx);
                   setOpenSubmenuIdx(item.submenu?.length ? idx : null);
+                  setActiveSubIdx(-1);
                 }}
                 onClick={() => activate(item)}
               >
@@ -224,13 +316,20 @@ export default function ContextMenu({
                     zIndex: 1001,
                   }}
                 >
-                  {item.submenu.map((sub) => (
+                  {item.submenu.map((sub, sIdx) => (
                     <button
                       key={sub.id}
                       type="button"
                       role="menuitem"
+                      id={submenuOpenId(menuId, idx, sIdx)}
                       aria-disabled={sub.disabled || undefined}
-                      style={kitMenuItem({ destructive: sub.destructive, disabled: sub.disabled })}
+                      style={{
+                        ...kitMenuItem({ destructive: sub.destructive, disabled: sub.disabled }),
+                        ...(activeSubIdx === sIdx && !sub.disabled
+                          ? { background: 'var(--accent-dim, var(--bg-3))' }
+                          : {}),
+                      }}
+                      onMouseEnter={() => setActiveSubIdx(sIdx)}
                       onClick={() => activate(sub)}
                     >
                       {sub.icon ? <span aria-hidden="true" style={{ display: 'inline-flex', width: 16 }}>{sub.icon}</span> : null}
@@ -247,7 +346,18 @@ export default function ContextMenu({
   );
 }
 
+function submenuOpenId(menuId: string, idx: number, subIdx: number | null): string {
+  return subIdx === null ? `${menuId}-item-${idx}` : `${menuId}-item-${idx}-${subIdx}`;
+}
+
 function firstEnabledIndex(items: ContextMenuItem[]): number {
   const idx = items.findIndex((i) => !i.disabled);
   return idx === -1 ? 0 : idx;
+}
+
+function lastEnabledIndex(items: ContextMenuItem[]): number {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (!items[i].disabled) return i;
+  }
+  return items.length - 1;
 }

--- a/frontend/src/components/kit/index.ts
+++ b/frontend/src/components/kit/index.ts
@@ -12,10 +12,21 @@ export { default as SlideOverSidebar } from './slideover-sidebar';
 export type { SlideOverTab } from './slideover-sidebar';
 
 export { default as ACLEditor } from './acl-editor';
-export type { AclEffect, AclRule, AclGroup, AclState } from './acl-editor';
 
 export { default as ToolTogglesGrid } from './tool-toggles-grid';
-export type { ToolToggleEntry, ToolToggleGroup } from './tool-toggles-grid';
+
+// Shared tool-state contract (F1/F2 binding) — canonical types live in
+// @/types/tool-state; re-exported here so kit consumers have one import site.
+export type {
+  AclEffect,
+  AclGroup,
+  AclRule,
+  AclState,
+  EffectiveToolState,
+  EntityRef,
+  ToolEntry,
+  ToolSection,
+} from '@/types/tool-state';
 
 export { default as TempWindowEditor } from './temp-window-editor';
 export type { TempWindow } from './temp-window-editor';

--- a/frontend/src/components/kit/temp-window-editor.tsx
+++ b/frontend/src/components/kit/temp-window-editor.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import { useId } from 'react';
 import { kitBtnSm, kitFieldLabel, kitInput } from './shared';
+
+/** Upper bound for `enable_for_hours` (30 days). */
+export const MAX_ENABLE_HOURS = 720;
 
 export interface TempWindow {
   /** ISO 8601 datetime; tool stays hidden until this instant (F3 field). */
@@ -32,14 +36,16 @@ function modeOf(v: TempWindow): Mode {
  */
 export default function TempWindowEditor({ value, onChange, readOnly = false }: TempWindowEditorProps) {
   const mode = modeOf(value);
+  const uid = useId();
+  const hideUntilId = `${uid}-hide-until`;
+  const enableHoursId = `${uid}-enable-hours`;
 
   function setMode(next: Mode) {
     if (next === 'none') {
       onChange({ hide_until: null, enable_for_hours: null });
     } else if (next === 'hide_until') {
-      // Default to 24h out, expressed in the user's local input format.
-      const d = new Date(Date.now() + 24 * 3600 * 1000);
-      onChange({ hide_until: toLocalInput(d), enable_for_hours: null });
+      // Default to 24h out — always ISO 8601 UTC, never a naive local string.
+      onChange({ hide_until: new Date(Date.now() + 24 * 3600 * 1000).toISOString(), enable_for_hours: null });
     } else {
       onChange({ hide_until: null, enable_for_hours: 24 });
     }
@@ -93,9 +99,9 @@ export default function TempWindowEditor({ value, onChange, readOnly = false }: 
 
       {mode === 'hide_until' ? (
         <div>
-          <label htmlFor="temp-window-hide-until" style={kitFieldLabel}>Hidden until</label>
+          <label htmlFor={hideUntilId} style={kitFieldLabel}>Hidden until</label>
           <input
-            id="temp-window-hide-until"
+            id={hideUntilId}
             type="datetime-local"
             value={value.hide_until ? toLocalInput(new Date(value.hide_until)) : ''}
             onChange={(e) => onChange({ ...value, hide_until: e.target.value ? new Date(e.target.value).toISOString() : null })}
@@ -118,16 +124,19 @@ export default function TempWindowEditor({ value, onChange, readOnly = false }: 
 
       {mode === 'enable_for' ? (
         <div>
-          <label htmlFor="temp-window-enable-hours" style={kitFieldLabel}>Enabled for (hours)</label>
+          <label htmlFor={enableHoursId} style={kitFieldLabel}>Enabled for (hours)</label>
           <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
             <input
-              id="temp-window-enable-hours"
+              id={enableHoursId}
               type="number"
               min={1}
+              max={MAX_ENABLE_HOURS}
               step={1}
               value={value.enable_for_hours ?? ''}
               onChange={(e) => {
-                const n = e.target.value === '' ? null : Math.max(1, Math.floor(Number(e.target.value)));
+                const n = e.target.value === ''
+                  ? null
+                  : Math.min(MAX_ENABLE_HOURS, Math.max(1, Math.floor(Number(e.target.value))));
                 onChange({ ...value, enable_for_hours: Number.isNaN(n as number) ? null : n });
               }}
               style={{ ...kitInput, width: 90 }}

--- a/frontend/src/components/kit/tool-toggles-grid.tsx
+++ b/frontend/src/components/kit/tool-toggles-grid.tsx
@@ -1,61 +1,58 @@
 'use client';
 
-export interface ToolToggleEntry {
-  name: string;
-  enabled: boolean;
-  hidden: boolean;
-}
-
-export interface ToolToggleGroup {
-  group: string;
-  tools: ToolToggleEntry[];
-}
+import type { EffectiveToolState, ToolSection } from '@/types/tool-state';
 
 interface ToolTogglesGridProps {
-  groups: ToolToggleGroup[];
+  sections: ToolSection[];
   /** Emits the full next state (pure controlled component). */
-  onChange: (next: ToolToggleGroup[]) => void;
+  onChange: (next: ToolSection[]) => void;
   readOnly?: boolean;
 }
 
 /**
- * Grid of grouped tool entries with per-tool enabled/hidden toggles and
+ * Grid of grouped tool entries with per-tool enabled/visible toggles and
  * group-level toggles that cascade to every child tool. Pure controlled
- * component — the host owns persistence.
- *
- * Semantics match the tobor.locker toolset model: `enabled` gates execution,
- * `hidden` gates discovery (visible vs hidden in list_tools).
+ * component — the host owns persistence. Binds the shared F4 tool-state
+ * contract (`ToolSection` / `EffectiveToolState` from `@/types/tool-state`),
+ * which mirrors F2 EffectiveToolset semantics: `enabled` gates execution,
+ * `visible` gates discovery (listing). Toggles only touch those two fields —
+ * override/temporal fields pass through untouched.
  */
-export default function ToolTogglesGrid({ groups, onChange, readOnly = false }: ToolTogglesGridProps) {
-  function patchTool(groupName: string, toolName: string, patch: Partial<ToolToggleEntry>) {
+export default function ToolTogglesGrid({ sections, onChange, readOnly = false }: ToolTogglesGridProps) {
+  function patchTool(sectionName: string, toolId: string, patch: Partial<EffectiveToolState>) {
     onChange(
-      groups.map((g) =>
-        g.group !== groupName
-          ? g
-          : { ...g, tools: g.tools.map((t) => (t.name === toolName ? { ...t, ...patch } : t)) },
+      sections.map((s) =>
+        s.name !== sectionName
+          ? s
+          : {
+              ...s,
+              tools: s.tools.map((e) =>
+                e.tool.id === toolId ? { ...e, state: { ...e.state, ...patch } } : e,
+              ),
+            },
       ),
     );
   }
 
-  function cascade(group: ToolToggleGroup, patch: (t: ToolToggleEntry) => Partial<ToolToggleEntry>) {
+  function cascade(section: ToolSection, patch: (e: ToolSection['tools'][number]) => Partial<EffectiveToolState>) {
     onChange(
-      groups.map((g) =>
-        g.group !== group.group
-          ? g
-          : { ...g, tools: g.tools.map((t) => ({ ...t, ...patch(t) })) },
+      sections.map((s) =>
+        s.name !== section.name
+          ? s
+          : { ...s, tools: s.tools.map((e) => ({ ...e, state: { ...e.state, ...patch(e) } })) },
       ),
     );
   }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }} role="group" aria-label="Tool toggles">
-      {groups.map((group) => {
-        const allEnabled = group.tools.length > 0 && group.tools.every((t) => t.enabled);
-        const allHidden = group.tools.length > 0 && group.tools.every((t) => t.hidden);
+      {sections.map((section) => {
+        const allEnabled = section.tools.length > 0 && section.tools.every((e) => e.state.enabled);
+        const allVisible = section.tools.length > 0 && section.tools.every((e) => e.state.visible);
         return (
           <section
-            key={group.group}
-            aria-label={`Tool group ${group.group}`}
+            key={section.name}
+            aria-label={`Tool group ${section.label ?? section.name}`}
             style={{
               borderRadius: 6,
               border: '1px solid var(--border)',
@@ -75,24 +72,24 @@ export default function ToolTogglesGrid({ groups, onChange, readOnly = false }: 
               }}
             >
               <span style={{ fontSize: 12, fontWeight: 600, flex: 1, color: 'var(--text-0)' }}>
-                {group.group}
+                {section.label ?? section.name}
                 <span style={{ fontWeight: 400, fontSize: 10, color: 'var(--text-3)', marginLeft: 6 }}>
-                  {group.tools.filter((t) => t.enabled).length}/{group.tools.length} enabled
+                  {section.tools.filter((e) => e.state.enabled).length}/{section.tools.length} enabled
                 </span>
               </span>
               <Toggle
-                id={`ttg-${group.group}-enabled`}
+                id={`ttg-${section.name}-enabled`}
                 label="Enabled"
                 checked={allEnabled}
                 disabled={readOnly}
-                onChange={(v) => cascade(group, () => ({ enabled: v }))}
+                onChange={(v) => cascade(section, () => ({ enabled: v }))}
               />
               <Toggle
-                id={`ttg-${group.group}-hidden`}
-                label="Hidden"
-                checked={allHidden}
+                id={`ttg-${section.name}-visible`}
+                label="Visible"
+                checked={allVisible}
                 disabled={readOnly}
-                onChange={(v) => cascade(group, () => ({ hidden: v }))}
+                onChange={(v) => cascade(section, () => ({ visible: v }))}
               />
             </div>
 
@@ -105,50 +102,53 @@ export default function ToolTogglesGrid({ groups, onChange, readOnly = false }: 
                 padding: 10,
               }}
             >
-              {group.tools.map((tool) => (
-                <div
-                  key={tool.name}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 10,
-                    padding: '6px 10px',
-                    borderRadius: 4,
-                    background: 'var(--bg-2)',
-                    border: '1px solid var(--border)',
-                    opacity: tool.enabled ? 1 : 0.6,
-                  }}
-                >
-                  <span
-                    title={tool.name}
+              {section.tools.map((entry) => {
+                const toolLabel = entry.tool.label ?? entry.tool.id;
+                return (
+                  <div
+                    key={entry.tool.id}
                     style={{
-                      flex: 1,
-                      fontSize: 11,
-                      fontFamily: 'monospace',
-                      color: tool.enabled ? 'var(--text-0)' : 'var(--text-3)',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '6px 10px',
+                      borderRadius: 4,
+                      background: 'var(--bg-2)',
+                      border: '1px solid var(--border)',
+                      opacity: entry.state.enabled ? 1 : 0.6,
                     }}
                   >
-                    {tool.name}
-                  </span>
-                  <Toggle
-                    id={`ttg-${group.group}-${tool.name}-enabled`}
-                    label="On"
-                    checked={tool.enabled}
-                    disabled={readOnly}
-                    onChange={(v) => patchTool(group.group, tool.name, { enabled: v })}
-                  />
-                  <Toggle
-                    id={`ttg-${group.group}-${tool.name}-hidden`}
-                    label="Hide"
-                    checked={tool.hidden}
-                    disabled={readOnly}
-                    onChange={(v) => patchTool(group.group, tool.name, { hidden: v })}
-                  />
-                </div>
-              ))}
+                    <span
+                      title={entry.tool.id}
+                      style={{
+                        flex: 1,
+                        fontSize: 11,
+                        fontFamily: 'monospace',
+                        color: entry.state.enabled ? 'var(--text-0)' : 'var(--text-3)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {toolLabel}
+                    </span>
+                    <Toggle
+                      id={`ttg-${section.name}-${entry.tool.id}-enabled`}
+                      label="On"
+                      checked={entry.state.enabled}
+                      disabled={readOnly}
+                      onChange={(v) => patchTool(section.name, entry.tool.id, { enabled: v })}
+                    />
+                    <Toggle
+                      id={`ttg-${section.name}-${entry.tool.id}-visible`}
+                      label="Show"
+                      checked={entry.state.visible}
+                      disabled={readOnly}
+                      onChange={(v) => patchTool(section.name, entry.tool.id, { visible: v })}
+                    />
+                  </div>
+                );
+              })}
             </div>
           </section>
         );

--- a/frontend/src/components/mcp-config/ClientPermissionsEditor.tsx
+++ b/frontend/src/components/mcp-config/ClientPermissionsEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { ToolTogglesGrid, TempWindowEditor, ACLEditor, type AclState } from '@/components/kit';
+import { ToolTogglesGrid, TempWindowEditor, ACLEditor, type AclState, type ToolSection } from '@/components/kit';
 
 // ---------------------------------------------------------------------------
 // ClientPermissionsEditor — shared per-client permission stack (W7).
@@ -49,7 +49,7 @@ const DEFAULT_TOOL_STATE: ClientPermissionsToolState = {
   enable_for_hours: null,
 };
 
-type GridGroups = { group: string; tools: { name: string; enabled: boolean; hidden: boolean }[] }[];
+type GridGroups = ToolSection[];
 type WindowValue = { hide_until: string | null; enable_for_hours: number | null };
 
 export function defaultClientPermissions(
@@ -110,22 +110,26 @@ export default function ClientPermissionsEditor({
 
   // --- Tools section (ToolTogglesGrid) ------------------------------------
   const gridGroups: GridGroups = catalog.map((g) => ({
-    group: g.group,
+    name: g.group,
     tools: g.tools.map((t) => {
       const s = stateFor(t.name);
-      return { name: t.name, enabled: s.enabled, hidden: !s.visible };
+      return {
+        tool: { kind: 'mcp_tool', id: t.name },
+        state: { enabled: s.enabled, visible: s.visible },
+      };
     }),
   }));
 
   function handleGridChange(nextGroups: GridGroups) {
     const tools = { ...value.tools };
-    for (const group of nextGroups) {
-      for (const tool of group.tools) {
+    for (const section of nextGroups) {
+      for (const entry of section.tools) {
+        const name = entry.tool.id;
         // Preserve window fields; take enabled/visible from the grid.
-        tools[tool.name] = {
-          ...stateFor(tool.name),
-          enabled: tool.enabled,
-          visible: !tool.hidden,
+        tools[name] = {
+          ...stateFor(name),
+          enabled: entry.state.enabled,
+          visible: entry.state.visible,
         };
       }
     }
@@ -188,7 +192,7 @@ export default function ClientPermissionsEditor({
             Toggle whether each tool is executable (enabled) and discoverable via listing
             (visible). Untouched tools stay enabled and visible.
           </p>
-          <ToolTogglesGrid groups={gridGroups} onChange={handleGridChange} readOnly={readOnly} />
+          <ToolTogglesGrid sections={gridGroups} onChange={handleGridChange} readOnly={readOnly} />
         </div>
       )}
 

--- a/frontend/src/lib/acl-api.ts
+++ b/frontend/src/lib/acl-api.ts
@@ -17,27 +17,10 @@
  */
 
 import type { McpCustomScopeConfig } from '@/lib/api';
+import type { AclGroup, AclRule, AclState } from '@/types/tool-state';
 
-/** Mirrors kit ACLEditor AclRule (binds F1 AclRule: subject/resource are opaque ERP ref strings). */
-export interface AclRule {
-  id: string;
-  subject: string;
-  resource: string;
-  effect: 'allow' | 'deny';
-  scope: string;
-}
-
-/** Mirrors kit ACLEditor AclGroup. */
-export interface AclGroup {
-  id: string;
-  name: string;
-  members: string[];
-}
-
-export interface AclState {
-  rules: AclRule[];
-  groups: AclGroup[];
-}
+/** Shared F4 tool-state contract (F1 ERP refs) — re-exported for kit consumers. */
+export type { AclGroup, AclRule, AclState } from '@/types/tool-state';
 
 export type ClientKind = 'api_key' | 'oauth_client';
 
@@ -112,21 +95,27 @@ const FIXTURE_ACL: AclState = {
   rules: [
     {
       id: 'rule-fixture-1',
-      subject: 'ref:client:key-fixture-1',
-      resource: 'ref:organization:the-robot-lives',
+      subject: { kind: 'client', id: 'key-fixture-1' },
+      resource: { kind: 'organization', id: 'the-robot-lives' },
       effect: 'allow',
       scope: 'read',
+      priority: 0,
     },
     {
       id: 'rule-fixture-2',
-      subject: 'ref:client:key-fixture-1',
-      resource: 'ref:wiki:internal-notes',
+      subject: { kind: 'client', id: 'key-fixture-1' },
+      resource: { kind: 'wiki', id: 'internal-notes' },
       effect: 'deny',
       scope: 'read',
+      priority: 0,
     },
   ],
   groups: [
-    { id: 'group-fixture-1', name: 'ci-bots', members: ['ref:client:key-fixture-1'] },
+    {
+      id: 'group-fixture-1',
+      name: 'ci-bots',
+      members: [{ kind: 'client', id: 'key-fixture-1' }],
+    },
   ],
 };
 
@@ -143,7 +132,7 @@ function fixturePermissions(client: ScopeClient): ClientPermissions {
     toolsetConfig: { groups: {} },
     tempWindows: {},
     acl: {
-      rules: FIXTURE_ACL.rules.map((r) => ({ ...r, subject: `ref:client:${client.id}` })),
+      rules: FIXTURE_ACL.rules.map((r) => ({ ...r, subject: { kind: 'client', id: client.id } })),
       groups: FIXTURE_ACL.groups.map((g) => ({ ...g })),
     },
     permissionGroups: client.kind === 'api_key' ? ['ci-bots'] : [],

--- a/frontend/src/types/tool-state.ts
+++ b/frontend/src/types/tool-state.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared tool-state contract (F4 binding) — the single vocabulary shared by
+ * the F4 kit components (ACLEditor, ToolTogglesGrid) and the F1/F2 backend
+ * shapes. Field names mirror what the backend actually exposes:
+ *
+ *  - `EntityRef` binds F1's `Acl.ERPRef` jsonb (`{"type": <kind>, "id": <id>}`);
+ *    `label` is display-only and host-supplied.
+ *  - `EffectiveToolState` binds `NoizuPromptLingua.MCP.EffectiveToolset`
+ *    tool_state/0 (enabled / visible / name_override / description_override /
+ *    expires_at).
+ *  - `AclRule` binds F1 `Schema.ACL.Rule` (subject_ref / resource_ref / effect
+ *    / scope / priority; the backend's `action` verb is host-mapped onto
+ *    `scope` for now).
+ */
+
+/** Polymorphic entity reference (F1 ERPRef). */
+export interface EntityRef {
+  kind: string;
+  id: string;
+  /** Display label (host-supplied, not persisted in the ref itself). */
+  label?: string;
+}
+
+export type AclEffect = 'allow' | 'deny';
+
+export interface AclRule {
+  /** Client-side id (host-assigned or generated). */
+  id: string;
+  subject: EntityRef;
+  /** `null` while unmatched / wildcard (host decides persistence). */
+  resource: EntityRef | null;
+  effect: AclEffect;
+  /** Permission scope label (e.g. "read", "write", "admin"); null = any. */
+  scope: string | null;
+  /** Tie-break weight; F1 evaluation still prefers deny on conflict. */
+  priority: number;
+  /** Optional F1 action verb override (e.g. "read"); host-mapped. */
+  action?: string;
+}
+
+export interface AclGroup {
+  id: string;
+  name: string;
+  /** Member subject refs. */
+  members: EntityRef[];
+}
+
+export interface AclState {
+  rules: AclRule[];
+  groups: AclGroup[];
+}
+
+/**
+ * F2 effective tool state for one tool — the merged verdict across scope
+ * config, client toolset_config, overrides, and F3 temporal windows.
+ */
+export interface EffectiveToolState {
+  /** Execution gate (ToolGuard). */
+  enabled: boolean;
+  /** Discovery gate (list_tools). */
+  visible: boolean;
+  name_override?: string | null;
+  description_override?: string | null;
+  /** ISO 8601 UTC instant the state expires (F3 window). */
+  expires_at?: string | null;
+}
+
+/** One tool inside a section: identity + effective state. */
+export interface ToolEntry {
+  tool: EntityRef;
+  state: EffectiveToolState;
+}
+
+/** A display section (toolset group) of tool entries. */
+export interface ToolSection {
+  name: string;
+  label?: string;
+  tools: ToolEntry[];
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -44,6 +44,7 @@
     "e2e",
     "playwright.config.ts",
     "cypress.config.ts",
-    "cypress.authentik.config.ts"
+    "cypress.authentik.config.ts",
+    "src/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
Follow-up to PR #16 (review findings in TOBOR-REVIEW.md):

- ContextMenu: Esc restores trigger focus, Home/End, Tab dismisses, scroll-dismiss, submenu fully keyboard-navigable, aria-activedescendant.
- TempWindowEditor: ISO-8601 UTC from onChange (naive-local path fixed), hours clamped 1..720, useId-namespaced ids.
- ACLEditor: deny-first sort, subject-based revoke labels, per-instance ids, priority field.
- New shared types/tool-state.ts (EntityRef/AclRule/EffectiveToolState — snake_case matching F1 ERPRef jsonb + F2 tool_state on develop); ToolTogglesGrid + consumers retyped.

Gates: tsc --noEmit clean, test:contracts 37/37 (4 new), next build green. Commit c5ee6d8f8.

Co-Authored-By: Loom <loom@therobotlives.com>