### PR TITLE
fix(mcp): F2 gates — I10 template isolation, perf hoist, I9 flag source, snapshot matrix, precedence, caps

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
@@ -9,9 +9,14 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   Resolution cascade (most specific wins per key; absent field inherits; a
   tool absent from every layer is ENABLED + VISIBLE — inverted semantics):
 
-    1. global `tobor` template config
-    2. custom-scope config (`mcp_custom_scopes.config`)
-    3. client `toolset_config` (API key today; OAuth client jsonb via W8)
+    1. custom-scope config (`mcp_custom_scopes.config`)
+    2. client `toolset_config` (API key today; OAuth client jsonb via W8)
+
+  The global `tobor` template is NOT a resolution layer (I10): user/org scopes
+  are clones that snapshot its groups at creation, so re-overlaying the live
+  template at request time would leak template flags onto frozen clones, root
+  listings, and ToolGuard denies. Template drift heals on the ensure_* clone
+  paths, never here.
 
   Per layer, a tool-level entry beats its group's flags (boolean overrides).
 
@@ -79,60 +84,53 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   def resolve(scope, client, user_ref_or_nil, at \\ DateTime.utc_now())
 
   def resolve(scope, client, _user_ref, at) do
-    template = template_config()
     scope_cfg = scope_config(scope)
     client_cfg = normalize_config(client_config(client))
 
-    groups = include_groups(scope_cfg, template, client_cfg)
-
-    groups
+    scope_cfg
+    |> include_groups(client_cfg)
     |> Enum.flat_map(fn group_id ->
-      tool_names(group_id, [client_cfg, scope_cfg, template])
+      tool_names(group_id, [client_cfg, scope_cfg])
       |> Enum.uniq()
       |> Map.new(fn tool_name ->
-        {canonical(tool_name), state(group_id, tool_name, template, scope_cfg, client_cfg, at)}
+        {canonical(tool_name), resolve_state(group_id, tool_name, scope_cfg, client_cfg, at)}
       end)
     end)
     |> Enum.into(%{})
   end
 
-  # Include set: with a scope, the scope's groups govern (clients/templates only
-  # flip flags). Without one (static subdomain servers, ToolGuard), union of
-  # template + client groups — there is no scope include set to respect.
-  defp include_groups(nil = _scope_cfg, template, client_cfg) do
-    (Map.get(template || %{}, "groups") || %{})
-    |> Map.merge(Map.get(client_cfg || %{}, "groups") || %{})
-    |> Map.keys()
-  end
+  # Include set: with a scope, the scope's normalized groups govern (clients
+  # only flip flags; the `tobor` template is never re-overlaid — I10). Without
+  # one (static subdomain servers), client groups only — a root/static listing
+  # is key-gated, never template-gated.
+  defp include_groups(nil = _scope_cfg, client_cfg),
+    do: Map.keys(Map.get(client_cfg || %{}, "groups") || %{})
 
-  defp include_groups(scope_cfg, _template, _client_cfg),
+  defp include_groups(scope_cfg, _client_cfg),
     do: Map.keys(Map.get(scope_cfg, "groups") || %{})
 
   @doc """
   Single-tool state — the hot-path entry point (ToolGuard / Catalog). Same
   cascade as `resolve/4` but resolves one (group, tool) pair without
   enumerating the group's catalog. `group_id: nil` (root-only Discovery/NPL
-  tools) is ungated: inherit-everything.
+  tools) is ungated: inherit-everything. DB reads: at most the scope + client
+  lookups the CALLER already performed — this body is pure.
   """
   @spec state(String.t() | nil, String.t(), scope, client, DateTime.t()) :: tool_state()
   def state(group_id, tool_name, scope, client, at \\ DateTime.utc_now())
 
   def state(group_id, tool_name, scope, client, at)
       when is_binary(group_id) and is_binary(tool_name) do
-    template = template_config()
-    scope_cfg = scope_config(scope)
-    client_cfg = normalize_config(client_config(client))
-
-    state(group_id, tool_name, template, scope_cfg, client_cfg, at)
+    resolve_state(group_id, tool_name, scope_config(scope), normalize_config(client_config(client)), at)
   end
 
   def state(nil, _tool_name, _scope, _client, _at), do: @default_state
 
-  # Cascade across [client, scope, template]: per key, the most specific layer
-  # with an opinion wins; within a layer, the tool entry beats the group flag.
-  defp state(group_id, tool_name, template, scope_cfg, client_cfg, at) do
+  # Cascade across [client, scope]: per key, the most specific layer with an
+  # opinion wins; within a layer, the tool entry beats the group flag.
+  defp resolve_state(group_id, tool_name, scope_cfg, client_cfg, at) do
     entries =
-      [client_cfg, scope_cfg, template]
+      [client_cfg, scope_cfg]
       |> Enum.flat_map(fn layer ->
         case layer_entries(layer, group_id, tool_name) do
           nil -> []
@@ -204,7 +202,8 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
     end)
   end
 
-  defp string_or_nil(v) when is_binary(v), do: v
+  # Spec §2.7: string values only; empty string is absent.
+  defp string_or_nil(v) when is_binary(v) and v != "", do: v
   defp string_or_nil(_), do: nil
 
   # ── consumers ──────────────────────────────────────────────────────────────
@@ -255,6 +254,9 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   `Tools.Catalog`): resolve the caller's client + scope states and drop
   hidden/disabled specs. Discovery/NPL categories are never gated. `group_id`
   pins the owning group when the caller knows it.
+
+  Scope + client configs are loaded ONCE per listing, never per spec — the
+  per-spec body is a pure map lookup (perf gate: no per-tool DB reads).
   """
   def apply_to_specs(specs, ctx, group_id \\ nil) when is_list(specs) do
     client = client_for_ctx(ctx)
@@ -263,12 +265,16 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
     if client == nil and scope == nil do
       specs
     else
+      scope_cfg = scope_config(scope)
+      client_cfg = normalize_config(client_config(client))
+      now = DateTime.utc_now()
+
       Enum.reject(specs, fn spec ->
         if ungated_category?(spec) do
-          true
+          false
         else
           gid = group_id || MCPServers.group_id_for_tool_module(spec.module)
-          ts = state(gid, spec.definition.name, scope, client)
+          ts = resolve_state(gid, spec.definition.name, scope_cfg, client_cfg, now)
           not ts.visible or not ts.enabled
         end
       end)
@@ -414,34 +420,51 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
     end
   end
 
+  @name_override_max 128
+  @description_override_max 1024
+
+  # Spec §2.7: string values only, empty string absent, caps enforced.
   defp override_value(map, key, overrides) do
     case Map.get(overrides, key) do
-      value when is_binary(value) -> Map.put(map, key, value)
-      _ -> map
+      value when is_binary(value) and value != "" ->
+        Map.put(map, key, String.slice(value, 0, override_cap(key)))
+
+      _ ->
+        map
     end
   end
 
-  # ── config layer readers ───────────────────────────────────────────────────
+  defp override_cap("description_override"), do: @description_override_max
+  defp override_cap(_), do: @name_override_max
 
-  # Raw read of the global `tobor` template — NO heal write on this hot path
-  # (drift repair stays on the ensure_* paths that own the template).
-  defp template_config do
-    case MCPCustomScopes.get_by_slug(MCPCustomScopes.default_package_slug()) do
-      %{config: config} when is_map(config) -> normalize_config(config)
-      _ -> nil
-    end
-  rescue
-    _ -> nil
-  end
+  # ── config layer readers ──────────────────────────────────────────────────
 
   defp scope_config(nil), do: nil
 
+  # I9: scope flags are read from the scope context's normalize_config/2 output
+  # (never the raw stored config) so the all_in_one required-core mutations —
+  # force-enable of unconfirmed disables, confirmed-disable honoring — apply on
+  # read, matching MCP.Custom's universe expansion which normalizes the same way.
   defp scope_config(scope) do
-    case scope do
-      %{config: config} -> normalize_config(config)
-      %{"config" => config} -> normalize_config(config)
-      _ -> nil
-    end
+    config =
+      case scope do
+        %{config: config} -> config
+        %{"config" => config} -> config
+        _ -> %{}
+      end
+
+    kind =
+      case scope do
+        %{kind: kind} when is_binary(kind) -> kind
+        %{"kind" => kind} when is_binary(kind) -> kind
+        _ -> "custom"
+      end
+
+    MCPCustomScopes.normalize_config(if(is_map(config), do: config, else: %{}), kind)
+  rescue
+    e ->
+      Logger.warning("[EffectiveToolset] scope config normalization failed: #{Exception.message(e)}")
+      %{"groups" => %{}}
   end
 
   defp client_config(nil), do: nil
@@ -511,7 +534,12 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
       with module when is_atom(module) and not is_nil(module) <- MCPServers.server_module(group_id),
            true <- Code.ensure_loaded?(module),
            true <- function_exported?(module, :__mcp__, 1) do
-        module.__mcp__(:tools) |> Tools.expand() |> Enum.map(& &1.definition.name)
+        module.__mcp__(:tools)
+        |> Tools.expand()
+        # Discovery tools are registered server-wide (browsing plane), never
+        # part of a group's include set — same rejection as MCP.Custom.custom_specs.
+        |> Enum.reject(&(discovery_category?(&1)))
+        |> Enum.map(& &1.definition.name)
       else
         _ -> []
       end
@@ -524,5 +552,9 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
       end)
 
     Enum.uniq(from_module ++ from_config)
+  end
+
+  defp discovery_category?(spec) do
+    spec.definition.meta && spec.definition.meta["category"] == "Discovery"
   end
 end

--- a/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
@@ -3,8 +3,9 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
   Per-API-key MCP toolset resolution — THIN CALLER over
   `NoizuPromptLingua.MCP.EffectiveToolset` (contract §2).
 
-  The cascade itself (global `tobor` template → custom-scope config → client
-  `toolset_config`) lives in EffectiveToolset; this module keeps the
+  The cascade itself (custom-scope config → client
+  `toolset_config`) lives in EffectiveToolset; the global `tobor` template is
+  not a layer (clones freeze it at creation — I10); this module keeps the
   key-shaped API the gateway grew up on:
 
     * `state/3` (group, tool, ctx) → `%{disabled:, hidden:}` — consumed by

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -1205,10 +1205,28 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
     Enum.reduce(@entry_extra_keys, map, fn key, acc ->
       case get_key(config, key) do
         nil -> acc
-        value -> Map.put(acc, key, value)
+        value -> maybe_carry_entry(acc, key, value)
       end
     end)
   end
+
+  # F2 §2.7: name/description overrides are string-only, empty string = absent,
+  # capped (name ≤ 128, description ≤ 1024). Other extra keys carried verbatim.
+  @name_override_max 128
+  @description_override_max 1024
+
+  defp maybe_carry_entry(acc, "name_override", value),
+    do: carry_override(acc, "name_override", value, @name_override_max)
+
+  defp maybe_carry_entry(acc, "description_override", value),
+    do: carry_override(acc, "description_override", value, @description_override_max)
+
+  defp maybe_carry_entry(acc, key, value), do: Map.put(acc, key, value)
+
+  defp carry_override(acc, key, value, cap) when is_binary(value) and value != "",
+    do: Map.put(acc, key, String.slice(value, 0, cap))
+
+  defp carry_override(acc, _key, _value, _cap), do: acc
 
   defp put_bool(map, _key, nil), do: map
   defp put_bool(map, key, value) when is_boolean(value), do: Map.put(map, key, value)

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_matrix_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_matrix_test.exs
@@ -1,0 +1,340 @@
+defmodule NoizuPromptLingua.MCP.EffectiveToolsetMatrixTest do
+  @moduledoc """
+  Old-vs-new snapshot matrix (F2 spec test case 9): runs the LEGACY resolution
+  composition (`KeyToolsets.overlay/2` + `state_from_config/3`, group-disabled =>
+  absent, keys never add groups) and the NEW `EffectiveToolset.resolve/4` cascade
+  over a fixture matrix (scope kinds × key configs) and asserts identical
+  listing + execution decisions — invariants I1–I10 encoded.
+  """
+
+  use NoizuPromptLingua.DataCase
+
+  alias Noizu.MCP.Ctx
+  alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.MCP.EffectiveToolset
+  alias NoizuPromptLingua.MCP.KeyToolsets
+  alias NoizuPromptLingua.MCP.ToolNames
+  alias NoizuPromptLingua.MCPApiKeys
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.MCPServers
+
+  @group "tickets"
+  @tool_hidden "Ticket.List"
+  @tool_plain "Ticket.Get"
+
+  # ── fixture matrix ──────────────────────────────────────────────────────────
+
+  defp scopes do
+    [
+      {"custom:flags",
+       %{
+         "groups" => %{
+           @group => %{
+             "tools" => %{
+               @tool_hidden => %{"hidden" => true},
+               @tool_plain => %{"disabled" => true}
+             }
+           }
+         }
+       }, "custom"},
+      {"custom:group-disabled", %{"groups" => %{"chat" => %{"disabled" => true}, @group => %{}}}, "custom"},
+      {"custom:empty", %{"groups" => %{}}, "custom"},
+      {"all_in_one:empty", %{}, "all_in_one"},
+      {"all_in_one:confirmed-disable",
+       %{
+         "groups" => %{
+           hd(MCPServers.required_ids()) => %{
+             "disabled" => true,
+             "confirmed" => true,
+             "disabled_confirmed_at" => "2026-01-01T00:00:00Z"
+           }
+         }
+       }, "all_in_one"}
+    ]
+  end
+
+  defp keys do
+    [
+      {"key:none", nil},
+      {"key:group-hidden", %{"groups" => %{@group => %{"hidden" => true}}}},
+      {"key:tool-disabled",
+       %{
+         "groups" => %{
+           @group => %{"tools" => %{@tool_hidden => %{"hidden" => false}}}
+         }
+       }},
+      {"key:foreign-group", %{"groups" => %{"sessions" => %{"disabled" => true}}}}
+    ]
+  end
+
+  # ── the legacy composition (pre-refactor semantics, spec §1.2) ─────────────
+
+  # %{canonical_name => %{listed: boolean, callable: boolean}}
+  defp legacy_decisions(scope_cfg, kind, key_cfg) do
+    scope_norm = MCPCustomScopes.normalize_config(scope_cfg || %{}, kind)
+    merged = if key_cfg, do: KeyToolsets.overlay(scope_norm, key_cfg), else: scope_norm
+
+    merged["groups"]
+    |> Enum.flat_map(fn {gid, gcfg} ->
+      names = group_tool_names(gid)
+
+      cond do
+        names == [] ->
+          []
+
+        gcfg["disabled"] == true ->
+          # group absent — contributes zero specs
+          Enum.map(names, fn name -> {ToolNames.canonical(name), %{listed: false, callable: false}} end)
+
+        true ->
+          Enum.map(names, fn name ->
+            %{disabled: d, hidden: h} = KeyToolsets.state_from_config(merged, gid, name)
+            {ToolNames.canonical(name), %{listed: not (d or h), callable: not d}}
+          end)
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp group_tool_names(gid) do
+    case MCPServers.server_module(gid) do
+      module when is_atom(module) and not is_nil(module) ->
+        module.__mcp__(:tools)
+        |> Tools.expand()
+        |> Enum.reject(&(category(&1) == "Discovery"))
+        |> Enum.map(& &1.definition.name)
+
+      _ ->
+        []
+    end
+  end
+
+  defp category(spec),
+    do: (spec.definition.meta && spec.definition.meta["category"]) || "Uncategorized"
+
+  defp new_decisions(scope_cfg, kind, key_cfg) do
+    scope = %{"config" => scope_cfg, "kind" => kind}
+    client = if key_cfg, do: %{id: "k1", kind: :api_key, toolset_config: key_cfg}, else: nil
+
+    EffectiveToolset.resolve(scope, client, nil)
+    |> Map.new(fn {name, ts} ->
+      {name, %{listed: ts.visible and ts.enabled, callable: ts.enabled}}
+    end)
+  end
+
+  # ── the matrix (I1 + I2) ────────────────────────────────────────────────────
+
+  describe "old vs new snapshot matrix" do
+    test "listing + execution decisions identical across scope kinds × key configs" do
+      for {scope_tag, cfg, kind} <- scopes(), {key_tag, key} <- keys() do
+        legacy = legacy_decisions(cfg, kind, key)
+        new = new_decisions(cfg, kind, key)
+
+        union = MapSet.union(MapSet.new(Map.keys(legacy)), MapSet.new(Map.keys(new)))
+
+        for name <- union do
+          l = Map.get(legacy, name, %{listed: false, callable: false})
+          n = Map.get(new, name, %{listed: false, callable: false})
+
+          assert n.listed == l.listed,
+                 "#{scope_tag} × #{key_tag}: listing mismatch for #{name} (legacy=#{inspect(l)} new=#{inspect(n)})"
+
+          assert n.callable == l.callable,
+                 "#{scope_tag} × #{key_tag}: execution mismatch for #{name} (legacy=#{inspect(l)} new=#{inspect(n)})"
+        end
+      end
+    end
+  end
+
+  # ── per-invariant explicit cases ────────────────────────────────────────────
+
+  describe "I1 scope-only resolution" do
+    test "hidden tool stays in the state map (invisible); disabled group dropped" do
+      {_, cfg, kind} = Enum.at(scopes(), 0)
+      states = EffectiveToolset.resolve(%{"config" => cfg, "kind" => kind}, nil, nil)
+
+      hidden = EffectiveToolset.lookup(states, @tool_hidden)
+      refute hidden.visible
+      assert hidden.enabled
+
+      disabled = EffectiveToolset.lookup(states, @tool_plain)
+      refute disabled.enabled
+    end
+  end
+
+  describe "I2 keys never add tools or groups" do
+    test "key-only group is ignored on a scoped endpoint" do
+      {_, cfg, kind} = Enum.at(scopes(), 2)
+      client = %{id: "k", kind: :api_key, toolset_config: %{"groups" => %{"sessions" => %{"disabled" => true}}}}
+
+      states = EffectiveToolset.resolve(%{"config" => cfg, "kind" => kind}, client, nil)
+      assert states == %{}
+    end
+  end
+
+  describe "I3 key disabled blocks execution" do
+    test "key-disabled tool resolves enabled: false" do
+      {_, cfg, kind} = Enum.at(scopes(), 0)
+
+      key = %{"groups" => %{@group => %{"tools" => %{@tool_plain => %{"disabled" => true}}}}}
+
+      states =
+        EffectiveToolset.resolve(
+          %{"config" => cfg, "kind" => kind},
+          %{id: "k", kind: :api_key, toolset_config: key},
+          nil
+        )
+
+      refute EffectiveToolset.lookup(states, @tool_plain).enabled
+    end
+  end
+
+  describe "I4 hidden-only remains callable" do
+    test "visible false, enabled true" do
+      {_, cfg, kind} = Enum.at(scopes(), 0)
+      states = EffectiveToolset.resolve(%{"config" => cfg, "kind" => kind}, nil, nil)
+
+      hidden = EffectiveToolset.lookup(states, @tool_hidden)
+      refute hidden.visible
+      assert hidden.enabled
+    end
+  end
+
+  describe "I5 OAuth-only (nil client) = scope-only state" do
+    test "nil client == client with empty config" do
+      {_, cfg, kind} = Enum.at(scopes(), 0)
+
+      a = EffectiveToolset.resolve(%{"config" => cfg, "kind" => kind}, nil, nil)
+      b = EffectiveToolset.resolve(%{"config" => cfg, "kind" => kind}, %{id: "k", kind: :api_key, toolset_config: nil}, nil)
+
+      assert a == b
+    end
+  end
+
+  describe "I6 static-hidden specs survive default state" do
+    test "apply_state is a no-op for the default state" do
+      spec = %{definition: %{name: "X.Y", description: "d", meta: %{}}, module: nil, hidden: true}
+
+      assert EffectiveToolset.apply_state(spec, EffectiveToolset.default_state()) == spec
+    end
+  end
+
+  describe "I7 ungated categories never key-gated" do
+    test "Discovery-category spec survives apply_to_specs even when its group is key-disabled" do
+      uniq = System.unique_integer([:positive])
+
+      user =
+        %NoizuPromptLingua.Schema.Users.User{
+          id: Ecto.UUID.generate(),
+          email: "matrix-#{uniq}@example.com",
+          user_name: "mx#{uniq}",
+          handle: "mx#{uniq}",
+          status: :active
+        }
+        |> NoizuPromptLingua.Repo.insert!()
+
+      {:ok, key, _raw} =
+        MCPApiKeys.generate_api_key(user.id, "matrix",
+          toolset_config: %{"groups" => %{@group => %{"disabled" => true}}}
+        )
+
+      ctx = %Ctx{server: NoizuPromptLingua.MCP, assigns: %{auth_claims: %{"api_key_id" => key.id}}}
+
+      discovery_spec =
+        NoizuPromptLingua.Domains.Tickets.MCP.__mcp__(:tools)
+        |> Tools.expand()
+        |> Enum.find(&(&1.definition.name == @tool_plain))
+        |> put_in([Access.key(:definition), Access.key(:meta)], %{"category" => "Discovery"})
+
+      plain_spec =
+        NoizuPromptLingua.Domains.Tickets.MCP.__mcp__(:tools)
+        |> Tools.expand()
+        |> Enum.find(&(&1.definition.name == @tool_plain))
+
+      kept = EffectiveToolset.apply_to_specs([discovery_spec, plain_spec], ctx)
+
+      assert Enum.map(kept, & &1.definition.name) == [discovery_spec.definition.name]
+    end
+  end
+
+  describe "I8 components pseudo-group gating unchanged" do
+    test "state_from_config flags the pseudo-group entry" do
+      config = %{"groups" => %{"components" => %{"tools" => %{"Comp.X" => %{"hidden" => true}}}}}
+
+      assert KeyToolsets.state_from_config(config, "components", "Comp.X") ==
+               %{disabled: false, hidden: true}
+    end
+  end
+
+  describe "I9 all_in_one required-core enforcement on read" do
+    test "unconfirmed disable is force-enabled; confirmed disable is honored" do
+      req = hd(MCPServers.required_ids())
+      [tool_name | _] = group_tool_names(req)
+
+      force_enabled =
+        EffectiveToolset.resolve(
+          %{"config" => %{"groups" => %{req => %{"disabled" => true}}}, "kind" => "all_in_one"},
+          nil,
+          nil
+        )
+
+      assert EffectiveToolset.lookup(force_enabled, tool_name).enabled
+
+      confirmed =
+        EffectiveToolset.resolve(
+          %{
+            "config" => %{
+              "groups" => %{
+                req => %{"disabled" => true, "confirmed" => true}
+              }
+            },
+            "kind" => "all_in_one"
+          },
+          nil,
+          nil
+        )
+
+      refute EffectiveToolset.lookup(confirmed, tool_name).enabled
+    end
+  end
+
+  describe "I10 template isolation" do
+    test "template flags never reach custom clones, root listings, or state/5" do
+      create_scope("tobor", %{"groups" => %{@group => %{"disabled" => true, "hidden" => true}}})
+
+      # clone with NO flags — template must not bleed in
+      clone = create_scope("clone-acme", %{"groups" => %{@group => %{"tools" => %{}}}})
+      clone_states = EffectiveToolset.resolve(clone, nil, nil)
+      assert EffectiveToolset.lookup(clone_states, @tool_plain) == EffectiveToolset.default_state()
+
+      # root/static universe: client groups only
+      client = %{id: "k", kind: :api_key, toolset_config: %{"groups" => %{"chat" => %{"tools" => %{}}}}}
+      root_states = EffectiveToolset.resolve(nil, client, nil)
+
+      for name <- Map.keys(root_states) do
+        refute String.starts_with?(ToolNames.dotted(name), "Ticket."),
+               "template tickets group leaked into root universe: #{name}"
+      end
+
+      # ToolGuard hot path: nil scope + nil client => ungated regardless of template
+      assert EffectiveToolset.state(@group, @tool_plain, nil, nil) == EffectiveToolset.default_state()
+    end
+  end
+
+  # ── helpers ─────────────────────────────────────────────────────────────────
+
+  defp create_scope(slug, config, extra \\ []) do
+    {:ok, scope} =
+      MCPCustomScopes.create(
+        %{
+          "slug" => slug,
+          "name" => slug,
+          "kind" => "custom",
+          "config" => config
+        }
+        |> Map.merge(Map.new(extra))
+      )
+
+    scope
+  end
+end

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
@@ -37,7 +37,9 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
     scope
   end
 
-  # The global `tobor` template — EffectiveToolset reads it by slug.
+  # The global `tobor` template row — resolution must NEVER read it (I10):
+  # scope clones freeze its config at creation, root/static listings are
+  # key-gated only.
   defp create_template(config), do: create_scope("tobor", config)
 
   defp key_ctx(config) do
@@ -60,19 +62,18 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
 
   defp client(config), do: %{id: "c1", kind: :api_key, toolset_config: config}
 
-  # ── cascade precedence ──────────────────────────────────────────────────────
+  # ── cascade precedence (scope < client; no template layer) ──────────────────
 
-  describe "cascade precedence (template < scope < client)" do
-    test "template flag is overridden by scope; absent = enabled" do
-      create_template(scope_config(%{@group => %{"disabled" => true}}))
-      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => false}}}}))
+  describe "cascade precedence (scope < client)" do
+    test "template is never overlaid at request time (I10)" do
+      create_template(scope_config(%{@group => %{"disabled" => true, "hidden" => true}}))
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
 
       state = EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool)
-      assert state.enabled
+      assert state == EffectiveToolset.default_state()
     end
 
-    test "scope hidden beats template absent; client visible beats scope hidden" do
-      create_template(scope_config(%{@group => %{"hidden" => true}}))
+    test "scope hidden; client visible beats scope hidden" do
       scope = create_scope("acme", scope_config(%{@group => %{"hidden" => true}}))
 
       refute EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool).visible
@@ -128,13 +129,23 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
       refute Map.has_key?(states, @tool_canonical)
     end
 
-    test "nil scope (static servers): template + client groups union" do
+    test "nil scope (static servers): client groups only — template ignored (I10)" do
       create_template(scope_config(%{"sessions" => %{"tools" => %{}}}))
       client = client(scope_config(%{@group => %{"disabled" => true}}))
 
       states = EffectiveToolset.resolve(nil, client, nil)
       assert Map.has_key?(states, @tool_canonical)
       refute EffectiveToolset.lookup(states, @tool).enabled
+
+      # template groups must not enter the root universe
+      session_tools =
+        NoizuPromptLingua.MCP.Sessions.__mcp__(:tools)
+        |> Noizu.MCP.Server.Features.Tools.expand()
+        |> Enum.map(&NoizuPromptLingua.MCP.ToolNames.canonical(&1.definition.name))
+
+      for name <- session_tools do
+        refute Map.has_key?(states, name)
+      end
     end
   end
 
@@ -162,19 +173,31 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
       assert state.description_override == "List tickets, focused view"
     end
 
-    test "client cannot set overrides (flags only)" do
-      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{}}}}))
-
-      client =
-        client(
-          scope_config(%{@group => %{"tools" => %{@tool => %{"name_override" => "Hax"}}}})
+    test "client layer wins over scope layer when non-null (§2.7)" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{
+            @group => %{
+              "tools" => %{
+                @tool => %{
+                  "name_override" => "Scope_Name",
+                  "description_override" => "Scope description"
+                }
+              }
+            }
+          })
         )
 
-      # client overrides are honored by the cascade shape — the override field
-      # is config, not a flag, so a client CAN carry it; policy (which clients
-      # may set what) is enforced at the editor layer (W9).
+      # client overrides only the name — the description inherits the scope value
+      client =
+        client(
+          scope_config(%{@group => %{"tools" => %{@tool => %{"name_override" => "Client_Name"}}}})
+        )
+
       state = EffectiveToolset.state(@group, @tool, scope, client)
-      assert state.name_override == "Hax"
+      assert state.name_override == "Client_Name"
+      assert state.description_override == "Scope description"
     end
 
     test "apply_state renames the spec definition for listing" do
@@ -350,6 +373,41 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
       entry = get_in(scope.config, ["groups", @group, "tools", @tool])
       assert entry["name_override"] == "Tickets_Listing"
       assert entry["hide_until"] == "2099-01-01T00:00:00Z"
+    end
+
+    test "empty string override is absent (§2.7)" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{@group => %{"tools" => %{@tool => %{"name_override" => ""}}}})
+        )
+
+      entry = get_in(scope.config, ["groups", @group, "tools", @tool])
+      refute Map.has_key?(entry, "name_override")
+
+      state = EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, nil), @tool)
+      assert is_nil(state.name_override)
+    end
+
+    test "override caps: name ≤ 128, description ≤ 1024 (§2.7)" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{
+            @group => %{
+              "tools" => %{
+                @tool => %{
+                  "name_override" => String.duplicate("n", 500),
+                  "description_override" => String.duplicate("d", 5000)
+                }
+              }
+            }
+          })
+        )
+
+      entry = get_in(scope.config, ["groups", @group, "tools", @tool])
+      assert String.length(entry["name_override"]) == 128
+      assert String.length(entry["description_override"]) == 1024
     end
   end
 end

--- a/backend/test/noizu_prompt_lingua/mcp/key_toolsets_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/key_toolsets_test.exs
@@ -176,9 +176,14 @@ defmodule NoizuPromptLingua.MCP.KeyToolsetsTest do
       refute "Ticket.List" in names
       assert "Ticket.Get" in names
 
-      # group-level disable on sessions hides the whole group from listing
+      # group-level disable on sessions hides the whole gated group from listing;
+      # Discovery/NPL categories are never gated (I7) — the server-wide browsing
+      # plane registered on every domain server stays.
       kept_sessions = KeyToolsets.apply_hidden(sessions_specs, ctx, "sessions")
-      assert kept_sessions == []
+      assert kept_sessions != []
+      assert Enum.all?(kept_sessions, fn spec ->
+               spec.definition.meta && spec.definition.meta["category"] in ["Discovery", "NPL"]
+             end)
 
       # no key config -> passthrough
       assert KeyToolsets.apply_hidden(tickets_specs, %Ctx{assigns: %{}}, nil) == tickets_specs


### PR DESCRIPTION
Follow-up to PR #14 (review findings in TOBOR-REVIEW.md). Merge blocker for the live gateway:

- **I10**: global `tobor` template no longer overlaid at request time — cascade is [client, scope]; custom clones frozen, root/static key-gated only. Enshrining tests rewritten.
- **Perf**: scope+client config loads hoisted out of the per-spec loop; ToolGuard hot path ≤2 reads (was 3+per-tool).
- **I9**: scope flags read via `MCPCustomScopes.normalize_config/2` — all_in_one force-enable / confirmed-disable now apply.
- **Snapshot matrix**: new `effective_toolset_matrix_test.exs` — legacy composition vs EffectiveToolset over 5 scopes × 4 keys + explicit I1–I10 cases (the live-gateway merge gate).
- **Precedence**: client layer wins when non-null; absent keys inherit scope.
- **§2.7 caps**: name_override ≤128, description_override ≤1024, empty/non-string dropped (both layers).
- Bonus: fixed ungated-category inversion (Discovery/NPL were being *dropped* from listings when any key/scope present — restored per I7).

Gates: 240 scoped tests green. Commit bd4899bbf.

Co-Authored-By: Loom <loom@therobotlives.com>