### PR TITLE
Debt D2: wire Acl into EffectiveToolset (per-user final override)

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
@@ -23,6 +23,39 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
         description_override: String.t() | nil,
         expires_at: DateTime.t() | nil}    # temporal window, via MCP.Window
 
+  ## ACL layer (debt D2 — per-user FINAL override)
+
+  When `user_ref` is present, an ACL pass runs AFTER the config cascade and
+  acts as the final override layer (`NoizuPromptLingua.Acl`, action
+  `"mcp.tool"`):
+
+    * per-tool resource: `{:ref, Schema.McpTool, canonical_tool_name}` — a
+      matching `deny` rule HIDES + DISABLES that tool for that user
+      (`enabled: false, visible: false`); kind wildcard
+      `{:ref, Schema.McpTool, :any}` covers every tool, `{:ref, :any, :any}`
+      globally.
+    * scope-wide resource: `{:ref, Schema.MCPCustomScope, scope.id}` — a
+      matching `deny` disables EVERY tool the scope serves.
+    * `allow` verdicts and no-matches (resolved with `default: :allow`) are
+      NO-OPS — the config cascade's state survives untouched. Explicit allow
+      never overrides a config `disabled`/`hidden`.
+    * users with NO rules match nothing => no-op, so nothing changes for
+      anyone without ACL rules. `user_ref` absent => no ACL pass at all
+      (legacy behavior byte-identical).
+
+  `user_ref` normalization: an ERP ref passes through as-is, any entity struct
+  via the ERP protocol, a bare binary is treated as a
+  `NoizuPromptLingua.Users.User` id.
+
+  Group membership comes free via `Acl.resolve` (transitive BFS expansion):
+  W6's "permission group assignment" = adding the user's ref to an `acl_group`
+  whose rules target tool/scope resources (`subject_ref = group.ref`).
+
+  Enforcement seams: `resolve/4` (listings, Session.Manifest) and `state/6`
+  (the hot path — ToolGuard via `KeyToolsets.state/3`, `apply_to_specs`).
+  Root-only Discovery/NPL tools stay ungated, matching the existing
+  toolset-gating policy.
+
   Semantics preserved from the pre-refactor split:
 
     * `enabled: false` — blocks EXECUTION (`ToolGuard` via `KeyToolsets.state/3`,
@@ -34,14 +67,24 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   """
 
   alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.Acl
   alias NoizuPromptLingua.MCP.Window
   alias NoizuPromptLingua.MCPApiKeys
   alias NoizuPromptLingua.MCPCustomScopes
   alias NoizuPromptLingua.MCPServers
   alias NoizuPromptLingua.Repo
   alias NoizuPromptLingua.Schema.McpApiKey
+  alias NoizuPromptLingua.Schema.MCPCustomScope
+  alias NoizuPromptLingua.Schema.McpTool
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
 
   require Logger
+
+  # ACL action for the toolset override layer (debt D2): subject performs
+  # `mcp.tool` on a tool (or scope) resource; deny hides + disables.
+  @acl_action "mcp.tool"
 
   @type tool_state :: %{
           enabled: boolean(),
@@ -72,28 +115,33 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
 
   Returns a map keyed by canonical tool name (underscore form once F5 lands;
   dotted today — `canonical/1` picks up `MCP.ToolNames` automatically at
-  merge). `user_ref_or_nil` is reserved for the F1 ACL layering (per-user
-  denies/grants folded into the same map) and does not affect state yet.
+  merge). When `user_ref_or_nil` is present, the ACL override layer (see
+  "ACL layer" in the moduledoc) applies as the final pass — per-user denies
+  hide + disable tools; absent user or no rules => config cascade unchanged.
   """
   @spec resolve(scope, client, term(), DateTime.t()) :: %{String.t() => tool_state()}
   def resolve(scope, client, user_ref_or_nil, at \\ DateTime.utc_now())
 
-  def resolve(scope, client, _user_ref, at) do
+  def resolve(scope, client, user_ref, at) do
     template = template_config()
     scope_cfg = scope_config(scope)
     client_cfg = normalize_config(client_config(client))
 
     groups = include_groups(scope_cfg, template, client_cfg)
 
-    groups
-    |> Enum.flat_map(fn group_id ->
-      tool_names(group_id, [client_cfg, scope_cfg, template])
-      |> Enum.uniq()
-      |> Map.new(fn tool_name ->
-        {canonical(tool_name), state(group_id, tool_name, template, scope_cfg, client_cfg, at)}
+    states =
+      groups
+      |> Enum.flat_map(fn group_id ->
+        tool_names(group_id, [client_cfg, scope_cfg, template])
+        |> Enum.uniq()
+        |> Map.new(fn tool_name ->
+          {canonical(tool_name),
+           cascade_state(group_id, tool_name, template, scope_cfg, client_cfg, at)}
+        end)
       end)
-    end)
-    |> Enum.into(%{})
+      |> Enum.into(%{})
+
+    apply_acl(states, scope, at, user_ref)
   end
 
   # Include set: with a scope, the scope's groups govern (clients/templates only
@@ -112,7 +160,8 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   Single-tool state — the hot-path entry point (ToolGuard / Catalog). Same
   cascade as `resolve/4` but resolves one (group, tool) pair without
   enumerating the group's catalog. `group_id: nil` (root-only Discovery/NPL
-  tools) is ungated: inherit-everything.
+  tools) is ungated: inherit-everything. No user context (5th arg is `at`) =>
+  no ACL pass.
   """
   @spec state(String.t() | nil, String.t(), scope, client, DateTime.t()) :: tool_state()
   def state(group_id, tool_name, scope, client, at \\ DateTime.utc_now())
@@ -123,14 +172,35 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
     scope_cfg = scope_config(scope)
     client_cfg = normalize_config(client_config(client))
 
-    state(group_id, tool_name, template, scope_cfg, client_cfg, at)
+    cascade_state(group_id, tool_name, template, scope_cfg, client_cfg, at)
   end
 
   def state(nil, _tool_name, _scope, _client, _at), do: @default_state
 
+  @doc """
+  Single-tool state WITH the per-user ACL override (debt D2) — the
+  enforcement hot path (ToolGuard via `KeyToolsets.state/3`, `apply_to_specs`).
+  Same cascade as `state/5`, then the ACL pass for `user_ref` (ERP ref, user
+  struct, or bare `Users.User` id; nil => no ACL pass — identical to `state/5`).
+  """
+  @spec state(String.t() | nil, String.t(), scope, client, term(), DateTime.t()) :: tool_state()
+  def state(group_id, tool_name, scope, client, user_ref, at)
+
+  def state(group_id, tool_name, scope, client, user_ref, at)
+      when is_binary(group_id) and is_binary(tool_name) do
+    template = template_config()
+    scope_cfg = scope_config(scope)
+    client_cfg = normalize_config(client_config(client))
+
+    cascade_state(group_id, tool_name, template, scope_cfg, client_cfg, at)
+    |> apply_acl_tool(scope, at, user_ref, tool_name)
+  end
+
+  def state(nil, _tool_name, _scope, _client, _user_ref, _at), do: @default_state
+
   # Cascade across [client, scope, template]: per key, the most specific layer
   # with an opinion wins; within a layer, the tool entry beats the group flag.
-  defp state(group_id, tool_name, template, scope_cfg, client_cfg, at) do
+  defp cascade_state(group_id, tool_name, template, scope_cfg, client_cfg, at) do
     entries =
       [client_cfg, scope_cfg, template]
       |> Enum.flat_map(fn layer ->
@@ -207,6 +277,105 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   defp string_or_nil(v) when is_binary(v), do: v
   defp string_or_nil(_), do: nil
 
+  # ── ACL override layer (debt D2) ───────────────────────────────────────────
+
+  @doc "The ACL action the toolset layer resolves (`\"mcp.tool\"`; `\"*\"` also matches)."
+  def acl_action, do: @acl_action
+
+  @doc "ACL resource ref for a canonical tool name (action `#{inspect(@acl_action)}`)."
+  def tool_resource(tool_name), do: McpTool.ref(canonical(tool_name))
+
+  @doc """
+  The ACL subject for a request ctx: `MCP.Resolve.current_user_id/1` claims
+  normalized to a `NoizuPromptLingua.Users.User` ref — nil (=> no ACL pass)
+  for API-key-only/service principals and unauthenticated calls.
+  """
+  def user_for_ctx(ctx) do
+    case NoizuPromptLingua.MCP.Resolve.current_user_id(ctx) do
+      id when is_binary(id) and id != "" -> R.ref(module: NoizuPromptLingua.Users.User, id: id)
+      _ -> nil
+    end
+  end
+
+  # Final override pass over resolved states: deny hides + disables; allow and
+  # no-match (`default: :allow`) are no-ops. nil user => identity (legacy).
+  defp apply_acl(states, _scope, _at, nil), do: states
+
+  defp apply_acl(states, scope, at, user_ref) do
+    case acl_subject(user_ref) do
+      nil ->
+        states
+
+      subject ->
+        if match?({:deny, _}, scope_verdict(subject, scope, opts(at))) do
+          Map.new(states, fn {name, st} -> {name, %{st | enabled: false, visible: false}} end)
+        else
+          Map.new(states, fn
+            # Already blocked by the cascade — nothing an ACL pass could add.
+            {name, %{enabled: false} = st} ->
+              {name, st}
+
+            {name, st} ->
+              {name, apply_acl_tool(st, subject, at, name)}
+          end)
+        end
+    end
+  end
+
+  # Single-tool ACL override (hot path). 4-arity: scope verdict already
+  # resolved (map pass); 5-arity entry resolves it (state/6).
+  defp apply_acl_tool(%{enabled: false} = ts, _subject, _at, _tool_name), do: ts
+
+  defp apply_acl_tool(ts, subject, at, tool_name) do
+    case Acl.resolve(subject, @acl_action, tool_resource(tool_name), opts(at)) do
+      {:deny, _} -> %{ts | enabled: false, visible: false}
+      _ -> ts
+    end
+  end
+
+  defp apply_acl_tool(ts, _scope, _at, nil, _tool_name), do: ts
+
+  defp apply_acl_tool(ts, scope, at, user_ref, tool_name) do
+    case acl_subject(user_ref) do
+      nil ->
+        ts
+
+      subject ->
+        if match?({:deny, _}, scope_verdict(subject, scope, opts(at))) do
+          %{ts | enabled: false, visible: false}
+        else
+          apply_acl_tool(ts, subject, at, tool_name)
+        end
+    end
+  end
+
+  defp opts(at), do: [default: :allow, at: at]
+
+  # Scope-wide knob: `mcp.tool` on the scope's own ref denies every tool the
+  # scope serves (kind/global wildcards apply via the standard rule matching).
+  defp scope_verdict(_subject, nil, _opts), do: {:allow, :default}
+
+  defp scope_verdict(subject, scope, opts) do
+    case scope do
+      %{id: id} when is_binary(id) ->
+        Acl.resolve(subject, @acl_action, R.ref(module: MCPCustomScope, id: id), opts)
+
+      %{"id" => id} when is_binary(id) ->
+        Acl.resolve(subject, @acl_action, R.ref(module: MCPCustomScope, id: id), opts)
+
+      _ ->
+        {:allow, :default}
+    end
+  end
+
+  # Normalize the caller-supplied user: ERP ref as-is, entity struct via the
+  # protocol (Acl casts it), bare binary = Users.User id, anything else => nil
+  # (no ACL pass rather than a bogus subject lookup).
+  defp acl_subject(R.ref() = ref), do: ref
+  defp acl_subject(subject) when is_struct(subject), do: subject
+  defp acl_subject(id) when is_binary(id), do: R.ref(module: NoizuPromptLingua.Users.User, id: id)
+  defp acl_subject(_), do: nil
+
   # ── consumers ──────────────────────────────────────────────────────────────
 
   @doc """
@@ -253,12 +422,14 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   @doc """
   Listing filter for the shared server pipeline (`MCP.Server.list_tools`,
   `Tools.Catalog`): resolve the caller's client + scope states and drop
-  hidden/disabled specs. Discovery/NPL categories are never gated. `group_id`
-  pins the owning group when the caller knows it.
+  hidden/disabled specs (config cascade + per-user ACL override, debt D2).
+  Discovery/NPL categories are never gated. `group_id` pins the owning group
+  when the caller knows it.
   """
   def apply_to_specs(specs, ctx, group_id \\ nil) when is_list(specs) do
     client = client_for_ctx(ctx)
     scope = scope_from_ctx(ctx)
+    user_ref = user_for_ctx(ctx)
 
     if client == nil and scope == nil do
       specs
@@ -268,7 +439,7 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
           true
         else
           gid = group_id || MCPServers.group_id_for_tool_module(spec.module)
-          ts = state(gid, spec.definition.name, scope, client)
+          ts = state(gid, spec.definition.name, scope, client, user_ref, DateTime.utc_now())
           not ts.visible or not ts.enabled
         end
       end)

--- a/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
@@ -48,7 +48,9 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
 
   @doc """
   Resolve the effective (disabled, hidden) flags for a (group, tool) pair from
-  the calling ctx — full EffectiveToolset cascade (client + scope + template).
+  the calling ctx — full EffectiveToolset cascade (client + scope + template)
+  plus the per-user ACL override (debt D2: `mcp.tool` deny rules hide + disable
+  the tool for that user; no rules => unchanged).
 
     * `disabled` — blocks EXECUTION (ToolGuard, pre-RBAC, both authz modes).
     * `hidden` — blocks LISTING/DISCOVERY only; the tool remains callable
@@ -60,7 +62,9 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
         group_id,
         tool_name,
         EffectiveToolset.scope_from_ctx(ctx),
-        EffectiveToolset.client_for_ctx(ctx)
+        EffectiveToolset.client_for_ctx(ctx),
+        EffectiveToolset.user_for_ctx(ctx),
+        DateTime.utc_now()
       )
 
     %{disabled: not ts.enabled, hidden: not ts.visible}

--- a/backend/lib/noizu_prompt_lingua/schema/mcp/mcp_tool.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/mcp/mcp_tool.ex
@@ -1,0 +1,23 @@
+defmodule NoizuPromptLingua.Schema.McpTool do
+  @moduledoc """
+  Phantom ERP entity kind for MCP tool ACL resources (debt D2).
+
+  NOT backed by a table — the module exists so `NoizuPromptLingua.Acl.ERPRef`
+  can round-trip tool resource refs through the JSONB encoding
+  (`{"type": "NoizuPromptLingua.Schema.McpTool", "id": "<canonical tool name>"}`;
+  load goes through `String.to_existing_atom/1`, so the kind atom must exist on
+  a running node) and so kind-wildcard rules (`"id": "any"`) resolve.
+
+  ACL convention (TOBOR-CONTRACTS §1 + EffectiveToolset):
+
+    * action: `"mcp.tool"` (or the `"*"` wildcard)
+    * per-tool resource: `{:ref, NoizuPromptLingua.Schema.McpTool, canonical_tool_name}`
+    * every-tool resource: `{:ref, NoizuPromptLingua.Schema.McpTool, :any}`
+  """
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  @doc "Resource ref for a canonical tool name (ACL action `mcp.tool`)."
+  def ref(tool_name), do: R.ref(module: __MODULE__, id: tool_name)
+end

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_acl_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_acl_test.exs
@@ -1,0 +1,253 @@
+defmodule NoizuPromptLingua.MCP.EffectiveToolsetAclTest do
+  @moduledoc """
+  Debt D2 — the ACL override layer on EffectiveToolset (`mcp.tool` rules as a
+  FINAL pass over the config cascade). Guarantees under test:
+
+    * no user_ref => byte-identical legacy behavior
+    * user with NO rules => unchanged (the critical compat invariant)
+    * explicit deny beats config allow
+    * explicit allow never overrides config disabled
+    * group-based deny (via transitive membership expansion)
+    * tool kind-wildcard + scope-wide denies
+    * state/6 hot path + KeyToolsets.state ctx seam
+  """
+
+  use NoizuPromptLingua.DataCase, async: true
+
+  require Noizu.EntityReference.Records
+  alias Noizu.EntityReference.Records, as: R
+
+  alias Noizu.MCP.Ctx
+  alias NoizuPromptLingua.Acl
+  alias NoizuPromptLingua.MCP.EffectiveToolset
+  alias NoizuPromptLingua.MCP.KeyToolsets
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.Schema.MCPCustomScope
+  alias NoizuPromptLingua.Schema.McpTool
+
+  @tool "Ticket.List"
+  @tool_canonical "Ticket_List"
+  @group "tickets"
+  @action "mcp.tool"
+
+  defp uid, do: Ecto.UUID.generate()
+  defp user_ref, do: R.ref(module: NoizuPromptLingua.Users.User, id: uid())
+
+  defp tool_ref(name \\ @tool_canonical), do: R.ref(module: McpTool, id: name)
+
+  defp scope_config(groups) when is_map(groups), do: %{"groups" => groups}
+
+  defp create_scope(slug, config) do
+    {:ok, scope} =
+      MCPCustomScopes.create(%{
+        "slug" => slug,
+        "name" => slug,
+        "kind" => "custom",
+        "config" => config
+      })
+
+    scope
+  end
+
+  defp rule!(subject_ref, resource_ref, effect) do
+    {:ok, _} =
+      Acl.create_rule(%{
+        subject_ref: subject_ref,
+        resource_ref: resource_ref,
+        action: @action,
+        effect: effect
+      })
+  end
+
+  defp group_with_member!(member) do
+    {:ok, group} =
+      Acl.create_group(%{
+        name: "acl-d2-" <> Ecto.UUID.generate(),
+        ref: R.ref(module: NoizuPromptLingua.Projects.Project, id: Ecto.UUID.generate())
+      })
+
+    {:ok, _} = Acl.add_member(group, member)
+    group
+  end
+
+  defp lookup(scope, client, user),
+    do: EffectiveToolset.lookup(EffectiveToolset.resolve(scope, client, user), @tool)
+
+  # ── compat invariants ───────────────────────────────────────────────────────
+
+  describe "compat (no ACL rules in play)" do
+    test "nil user_ref ignores ACL rules entirely (legacy behavior)" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{}}}}))
+      rule!(user_ref(), tool_ref(), "deny")
+
+      state = lookup(scope, nil, nil)
+      assert state == EffectiveToolset.default_state()
+    end
+
+    test "user with NO rules is a no-op (critical invariant)" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"hidden" => true}}}}))
+      state = lookup(scope, nil, user_ref())
+
+      refute state.visible
+      assert state.enabled
+    end
+
+    test "user with no rules + cascade flags keeps cascade state verbatim" do
+      scope = create_scope("acme", scope_config(%{@group => %{"disabled" => true}}))
+
+      for spec <-
+            NoizuPromptLingua.Domains.Tickets.MCP.__mcp__(:tools)
+            |> Noizu.MCP.Server.Features.Tools.expand()
+            |> Enum.reject(&EffectiveToolset.ungated_category?(&1)) do
+        refute EffectiveToolset.lookup(EffectiveToolset.resolve(scope, nil, user_ref()), spec.definition.name).enabled
+      end
+    end
+  end
+
+  # ── precedence vs the config cascade ────────────────────────────────────────
+
+  describe "ACL vs config cascade" do
+    test "explicit deny wins over config allow (hides + disables)" do
+      scope =
+        create_scope(
+          "acme",
+          scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => false, "hidden" => false}}}})
+        )
+
+      denied_user = user_ref()
+      rule!(denied_user, tool_ref(), "deny")
+
+      state = lookup(scope, nil, denied_user)
+      refute state.enabled
+      refute state.visible
+
+      # per-user: everyone else keeps the config state
+      assert lookup(scope, nil, user_ref()).enabled
+    end
+
+    test "explicit allow does NOT override config disabled" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => true}}}}))
+      rule!(user_ref(), tool_ref(), "allow")
+
+      state = lookup(scope, nil, user_ref())
+      refute state.enabled
+    end
+
+    test "deny is per-tool (other tools unaffected)" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      user = user_ref()
+      rule!(user, tool_ref(), "deny")
+
+      states = EffectiveToolset.resolve(scope, nil, user)
+      refute EffectiveToolset.lookup(states, @tool).enabled
+
+      other = Enum.find(states, fn {name, _} -> name != @tool_canonical end)
+      assert other
+      assert elem(other, 1).enabled
+    end
+  end
+
+  # ── wildcards + scope knob ──────────────────────────────────────────────────
+
+  describe "wildcards + scope-wide deny" do
+    test "tool kind wildcard (:any) denies every tool" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      user = user_ref()
+      rule!(user, R.ref(module: McpTool, id: :any), "deny")
+
+      states = EffectiveToolset.resolve(scope, nil, user)
+      assert states != %{}
+      assert Enum.all?(Map.values(states), fn st -> not st.enabled end)
+    end
+
+    test "scope resource deny disables every tool the scope serves" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      user = user_ref()
+      rule!(user, R.ref(module: MCPCustomScope, id: scope.id), "deny")
+
+      states = EffectiveToolset.resolve(scope, nil, user)
+      assert states != %{}
+      assert Enum.all?(Map.values(states), fn st -> not st.enabled and not st.visible end)
+    end
+  end
+
+  # ── group membership ────────────────────────────────────────────────────────
+
+  describe "group-based denies (W6 permission groups)" do
+    test "deny rule on the group ref denies its members" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      user = user_ref()
+      group = group_with_member!(user)
+      rule!(group.ref, tool_ref(), "deny")
+
+      state = lookup(scope, nil, user)
+      refute state.enabled
+      refute state.visible
+
+      # non-members keep the config state
+      assert lookup(scope, nil, user_ref()).enabled
+    end
+
+    test "nested group membership expands transitively" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      user = user_ref()
+      inner = group_with_member!(user)
+      outer = group_with_member!(inner.ref)
+
+      # deny on the OUTER group only — inner membership pulls it in.
+      rule!(outer.ref, tool_ref(), "deny")
+
+      refute lookup(scope, nil, user).enabled
+    end
+  end
+
+  # ── hot path + ctx seam ─────────────────────────────────────────────────────
+
+  describe "state/6 hot path + ctx seams" do
+    test "state/6 applies the deny; state/5 (no user) does not" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+
+      id = uid()
+      user = R.ref(module: NoizuPromptLingua.Users.User, id: id)
+      rule!(user, tool_ref(), "deny")
+
+      at = DateTime.utc_now()
+      refute EffectiveToolset.state(@group, @tool, scope, nil, user, at).enabled
+      assert EffectiveToolset.state(@group, @tool, scope, nil, at).enabled
+      # bare binary user id normalizes to a Users.User ref
+      refute EffectiveToolset.state(@group, @tool, scope, nil, id, at).enabled
+    end
+
+    test "KeyToolsets.state/3 (ToolGuard seam) enforces the deny via ctx claims" do
+      scope = create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      id = uid()
+      rule!(R.ref(module: NoizuPromptLingua.Users.User, id: id), tool_ref(), "deny")
+
+      ctx = %Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: %{custom_scope_slug: "acme", auth_claims: %{"sub" => id}}
+      }
+
+      assert KeyToolsets.state(@group, @tool, ctx).disabled
+
+      ctx_no_user = %Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: %{custom_scope_slug: "acme", auth_claims: %{}}
+      }
+
+      refute KeyToolsets.state(@group, @tool, ctx_no_user).disabled
+    end
+
+    test "service principals (svc:/client: subs) get no ACL pass" do
+      create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      rule!(user_ref(), tool_ref(), "deny")
+
+      ctx = %Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: %{custom_scope_slug: "acme", auth_claims: %{"sub" => "client:abc"}}
+      }
+
+      refute KeyToolsets.state(@group, @tool, ctx).disabled
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Turns the permission UI into enforcement: the F1 ACL library now gates F2's EffectiveToolset. When a `user_ref` is present, an ACL pass runs AFTER the config cascade as the FINAL override layer.

## Action/resource convention (documented in moduledoc + `Schema.McpTool`)

- Action: `mcp.tool` (`*` wildcard also matches, per Acl)
- Per-tool resource: `{:ref, NoizuPromptLingua.Schema.McpTool, canonical_tool_name}`
  - kind wildcard `{:ref, Schema.McpTool, :any}` = every tool; `{:ref, :any, :any}` = global
- Scope-wide knob: same action on `{:ref, NoizuPromptLingua.Schema.MCPCustomScope, scope.id}` — denies every tool the scope serves
- `Schema.McpTool` is a documented phantom ERP kind (no table) so `ERPRef` round-trips tool refs through JSONB (`String.to_existing_atom` needs the atom to exist)

## Semantics

- `deny` => `enabled: false, visible: false` (hidden + disabled) for that user
- `allow` and no-match (`default: :allow`) => config cascade state untouched — explicit allow never overrides config `disabled`/`hidden`
- `user_ref` absent => no ACL pass — legacy behavior byte-identical
- Users with NO rules match nothing => no-op (critical compat invariant)
- Group membership comes free via `Acl.resolve` BFS expansion: W6 "permission group assignment" = adding the user ref to an `acl_group` whose rules target tool/scope resources (`subject_ref = group.ref`); nested groups resolve transitively

## Changes

- `EffectiveToolset.resolve/4` — ACL pass over the resolved states map
- `EffectiveToolset.state/6` — single-tool hot path with the override (`state/5` signature unchanged; its 5th arg remains `at`, no user => no ACL pass)
- `EffectiveToolset.user_for_ctx/1` — normalizes `MCP.Resolve.current_user_id` claims to a `Users.User` ref; `svc:`/`client:` principals and unauthenticated calls skip the pass
- `apply_to_specs` (listing) and `KeyToolsets.state/3` (ToolGuard execution gate) now pass the ctx user — deny rules block both discovery AND execution
- Root-only Discovery/NPL tools remain ungated, matching existing toolset-gating policy

## Compat evidence

- 22/22 pre-existing `effective_toolset_test.exs` green (unmodified)
- New suite covers: nil-user unchanged; no-rule user unchanged (both plain and cascaded configs); deny-beats-config-allow; allow-does-not-override-config-disabled; per-tool granularity; kind wildcard; scope-wide deny; direct + nested group denies; state/6 vs state/5; ToolGuard ctx seam; service principals
- Gates: `mix test test/noizu_prompt_lingua/mcp test/noizu_prompt_lingua/acl test/noizu_prompt_lingua/acl_test.exs` => **276 passed**, compile clean (no new warnings)

Co-Authored-By: Loom <loom@therobotlives.com>