### PR TITLE
D3: real client-permission endpoints — toolset_config + ACL groups

### DIFF
--- a/backend/lib/noizu_prompt_lingua_web/controllers/admin_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/admin_controller.ex
@@ -1299,6 +1299,446 @@ defmodule NoizuPromptLinguaWeb.AdminController do
     end
   end
 
+  # ── D3: per-scope client permissions + ACL group admin ────────────────────
+  #
+  # Clients that can hit a scope's MCP endpoint: user MCP API keys (PATs) and
+  # OAuth clients. No scope↔client association table exists (api keys are
+  # user-scoped credentials; oauth clients carry only an OIDC scope string),
+  # so every client is listed with `linked: false` — the Manage Clients UI
+  # treats the list as the addressable client universe and each client's
+  # `toolset_config` jsonb as the permission surface (F2 EffectiveToolset
+  # cascade layer 3).
+  #
+  # The toolset_config PUT normalizes on write: dotted tool keys collapse to
+  # canonical underscore (F5), unknown fields are rejected (strict 422 — the
+  # scope-side normalizer is silent-drop; client configs are admin-written so
+  # strictness is cheap), and an empty map resets to %{}.
+
+  alias NoizuPromptLingua.Schema.McpApiKey
+  alias NoizuPromptLingua.Schema.OAuthClient
+  alias NoizuPromptLingua.Schema.Acl.Group
+  alias NoizuPromptLingua.Schema.Acl.GroupMember
+  alias NoizuPromptLingua.Acl
+  alias NoizuPromptLingua.Acl.ERPRef
+  alias NoizuPromptLingua.MCP.ToolNames
+  alias NoizuPromptLingua.MCP.Window
+
+  @client_kinds %{
+    "api_key" => :api_key,
+    "api-key" => :api_key,
+    "oauth_client" => :oauth_client,
+    "oauth-client" => :oauth_client
+  }
+
+  # "enabled_at" rides along (Window's enable_for_hours anchor, stamped on
+  # write) so fetched configs round-trip through PUT without unknown-field 422s.
+  @tool_entry_keys ~w(disabled hidden name_override description_override hide_until enable_for_hours enabled_at)
+
+  def list_scope_clients(conn, %{"slug" => slug}) do
+    case MCPCustomScopes.get_by_slug(slug) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "Scope not found"})
+
+      _scope ->
+        keys =
+          NoizuPromptLingua.Repo.all(from k in McpApiKey, order_by: [desc: k.inserted_at])
+          |> Enum.map(&api_key_client_json/1)
+
+        oauth =
+          NoizuPromptLingua.Repo.all(from c in OAuthClient, order_by: [desc: c.inserted_at])
+          |> Enum.map(&oauth_client_client_json/1)
+
+        conn |> put_status(:ok) |> json(%{clients: keys ++ oauth})
+    end
+  end
+
+  defp api_key_client_json(key) do
+    %{
+      id: key.id,
+      kind: "api_key",
+      label: String.trim_trailing("#{key.label}#{key_prefix_suffix(key)}"),
+      status: key.status,
+      inserted_at: key.inserted_at,
+      linked: false
+    }
+  end
+
+  defp key_prefix_suffix(%{key_prefix: nil}), do: ""
+  defp key_prefix_suffix(%{key_prefix: ""}), do: ""
+  defp key_prefix_suffix(%{key_prefix: prefix}), do: " (#{prefix})"
+
+  defp oauth_client_client_json(client) do
+    %{
+      id: client.id,
+      kind: "oauth_client",
+      label: client.client_name,
+      status: client.status,
+      inserted_at: client.inserted_at,
+      linked: false
+    }
+  end
+
+  def show_client_toolset_config(conn, %{"kind" => kind, "id" => id}) do
+    case fetch_client(kind, id) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "Client not found"})
+
+      client ->
+        conn |> put_status(:ok) |> json(%{toolset_config: client.toolset_config || %{}})
+    end
+  end
+
+  def update_client_toolset_config(conn, %{"kind" => kind, "id" => id, "toolset_config" => cfg}) do
+    client = fetch_client(kind, id)
+
+    with %{toolset_config: _} <- client || :not_found,
+         {:ok, normalized} <- normalize_toolset_config(cfg) do
+      changeset =
+        case client do
+          %McpApiKey{} = key -> McpApiKey.toolset_changeset(key, %{"toolset_config" => normalized})
+          %OAuthClient{} = oc -> OAuthClient.changeset(oc, %{"toolset_config" => normalized})
+        end
+
+      case NoizuPromptLingua.Repo.update(changeset) do
+        {:ok, updated} ->
+          conn |> put_status(:ok) |> json(%{toolset_config: updated.toolset_config || %{}})
+
+        {:error, %Ecto.Changeset{} = cs} ->
+          conn |> put_status(:unprocessable_entity) |> json(%{errors: format_errors(cs)})
+      end
+    else
+      :not_found ->
+        conn |> put_status(:not_found) |> json(%{error: "Client not found"})
+
+      {:error, errors} when is_list(errors) ->
+        conn |> put_status(:unprocessable_entity) |> json(%{errors: errors})
+
+      {:error, changeset} ->
+        conn |> put_status(:bad_request) |> json(%{error: inspect(changeset)})
+    end
+  end
+
+  def update_client_toolset_config(conn, _params),
+    do: conn |> put_status(:bad_request) |> json(%{error: "toolset_config required"})
+
+  defp fetch_client(kind, id) when is_binary(id) do
+    case @client_kinds[kind] do
+      :api_key -> NoizuPromptLingua.Repo.get(McpApiKey, id)
+      # The W7 editor route may carry either the row uuid or the public
+      # client_id string (DCR identifier).
+      :oauth_client ->
+        NoizuPromptLingua.Repo.get(OAuthClient, id) ||
+          NoizuPromptLingua.Repo.one(from c in OAuthClient, where: c.client_id == ^id)
+      _ -> nil
+    end
+  end
+
+  defp fetch_client(_, _), do: nil
+
+  # Empty config = reset (client inherits scope/template layers untouched).
+  defp normalize_toolset_config(cfg) when cfg == %{}, do: {:ok, %{}}
+
+  defp normalize_toolset_config(%{"groups" => groups} = cfg) when is_map(groups) do
+    unknown = Map.keys(cfg) -- ["groups"]
+
+    cond do
+      unknown != [] ->
+        {:error, ["unknown field(s): #{Enum.join(unknown, ", ")} (only \"groups\" is supported)"]}
+
+      true ->
+        normalize_groups(groups)
+    end
+  end
+
+  defp normalize_toolset_config(_),
+    do: {:error, ["toolset_config must be an object with a \"groups\" map, or empty to reset"]}
+
+  defp normalize_groups(groups) do
+    groups
+    |> Enum.reduce_while({:ok, %{}}, fn {gid, group_cfg}, {:ok, acc} ->
+      case normalize_group(group_cfg) do
+        {:ok, normalized} -> {:cont, {:ok, Map.put(acc, to_string(gid), normalized)}}
+        {:error, errs} -> {:halt, {:error, Enum.map(errs, &"groups.#{gid}.#{&1}")}}
+      end
+    end)
+    |> case do
+      {:ok, wrapped} -> {:ok, %{"groups" => wrapped}}
+      error -> error
+    end
+  end
+
+  defp normalize_group(group_cfg) when is_map(group_cfg) do
+    unknown = Map.keys(group_cfg) -- ["disabled", "hidden", "tools"]
+
+    cond do
+      unknown != [] ->
+        {:error, ["unknown field(s): #{Enum.join(unknown, ", ")}"]}
+
+      true ->
+        with {:ok, flags} <- bool_fields(group_cfg, ["disabled", "hidden"]),
+             {:ok, tools} <- normalize_tools(Map.get(group_cfg, "tools") || %{}) do
+          {:ok, flags |> maybe_put_tools(tools)}
+        end
+    end
+  end
+
+  defp normalize_group(_), do: {:error, ["must be an object"]}
+
+  defp maybe_put_tools(flags, tools) when tools == %{}, do: flags
+  defp maybe_put_tools(flags, tools), do: Map.put(flags, "tools", tools)
+
+  # Collapse dotted (F5-alias) tool keys into their canonical underscore form
+  # so repeated edits stop accumulating both spellings. A dotted alias merges
+  # under its canonical key (field-level: canonical values win).
+  defp normalize_tools(tools) when is_map(tools) do
+    {canonical_list, dotted_list} =
+      Enum.split_with(tools, fn {name, _} -> not ToolNames.alias?(name) end)
+
+    canonical = Map.new(canonical_list)
+
+    dotted_list
+    |> Enum.map(fn {name, entry} -> {ToolNames.canonical(name), entry} end)
+    |> Enum.into(canonical, fn {key, dotted_entry} ->
+      {key, Map.merge(dotted_entry, Map.get(canonical, key, %{}))}
+    end)
+    |> Enum.reduce_while({:ok, %{}}, fn {name, entry}, {:ok, acc} ->
+      case normalize_tool_entry(entry) do
+        {:ok, normalized} -> {:cont, {:ok, Map.put(acc, name, normalized)}}
+        {:error, errs} -> {:halt, {:error, Enum.map(errs, &"tools.#{name}.#{&1}")}}
+      end
+    end)
+  end
+
+  defp normalize_tools(_), do: {:error, ["tools must be an object"]}
+
+  defp normalize_tool_entry(entry) when is_map(entry) do
+    unknown = Map.keys(entry) -- @tool_entry_keys
+
+    cond do
+      unknown != [] ->
+        {:error, ["unknown field(s): #{Enum.join(unknown, ", ")}"]}
+
+      true ->
+        with {:ok, flags} <- bool_fields(entry, ["disabled", "hidden"]),
+             {:ok, overrides} <- string_fields(entry, ["name_override", "description_override"]),
+             {:ok, window} <- window_fields(entry) do
+          {:ok, flags |> Map.merge(overrides) |> Window.normalize_entry(entry) |> Map.merge(window)}
+        end
+    end
+  end
+
+  defp normalize_tool_entry(_), do: {:error, ["must be an object"]}
+
+  defp bool_fields(map, keys) do
+    Enum.reduce_while(keys, {:ok, %{}}, fn key, {:ok, acc} ->
+      case Map.get(map, key) do
+        nil -> {:cont, {:ok, acc}}
+        value when is_boolean(value) -> {:cont, {:ok, Map.put(acc, key, value)}}
+        other -> {:halt, {:error, ["#{key}: must be a boolean (got #{inspect(other)})"]}}
+      end
+    end)
+  end
+
+  defp string_fields(map, keys) do
+    Enum.reduce_while(keys, {:ok, %{}}, fn key, {:ok, acc} ->
+      case Map.get(map, key) do
+        nil -> {:cont, {:ok, acc}}
+        value when is_binary(value) -> {:cont, {:ok, Map.put(acc, key, value)}}
+        other -> {:halt, {:error, ["#{key}: must be a string (got #{inspect(other)})"]}}
+      end
+    end)
+  end
+
+  # Strict window validation (unlike the silent-drop scope-side path): invalid
+  # values are rejected with 422 so the admin UI surfaces them. Valid values
+  # are then stored via Window.normalize_entry (ISO8601 UTC + enabled_at anchor).
+  defp window_fields(entry) do
+    case Window.validate_entry(entry) do
+      [] ->
+        {:ok, %{}}
+
+      errs ->
+        {:error, errs}
+    end
+  end
+
+  # ── D3: ACL group admin (F1 NoizuPromptLingua.Acl context) ────────────────
+
+  def list_acl_groups(conn, _params) do
+    groups =
+      NoizuPromptLingua.Repo.all(from g in Group, where: g.status == "active", order_by: g.name)
+
+    members_by_group =
+      NoizuPromptLingua.Repo.all(from m in GroupMember, order_by: m.inserted_at)
+      |> Enum.group_by(& &1.group_id)
+
+    conn
+    |> put_status(:ok)
+    |> json(%{
+      groups:
+        Enum.map(groups, fn g ->
+          acl_group_json(g, Map.get(members_by_group, g.id, []))
+        end)
+    })
+  end
+
+  def create_acl_group(conn, %{"group" => attrs}) do
+    case Acl.create_group(filter_nils(%{"name" => attrs["name"], "description" => attrs["description"]})) do
+      {:ok, group} ->
+        conn |> put_status(:created) |> json(%{group: acl_group_json(group, [])})
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{errors: format_errors(cs)})
+    end
+  end
+
+  def create_acl_group(conn, _params),
+    do: conn |> put_status(:bad_request) |> json(%{error: "group required"})
+
+  def update_acl_group(conn, %{"id" => id, "group" => attrs}) do
+    group = Acl.get_group(id)
+
+    cond do
+      is_nil(group) or group.status == "archived" ->
+        conn |> put_status(:not_found) |> json(%{error: "Group not found"})
+
+      true ->
+        case Acl.update_group(
+               group,
+               filter_nils(%{
+                 "name" => attrs["name"],
+                 "description" => attrs["description"],
+                 "status" => attrs["status"]
+               })
+             ) do
+          {:ok, updated} ->
+            conn
+            |> put_status(:ok)
+            |> json(%{group: acl_group_json(updated, Acl.members(updated))})
+
+          {:error, %Ecto.Changeset{} = cs} ->
+            conn |> put_status(:unprocessable_entity) |> json(%{errors: format_errors(cs)})
+        end
+    end
+  end
+
+  def update_acl_group(conn, _params),
+    do: conn |> put_status(:bad_request) |> json(%{error: "group required"})
+
+  # Soft-disable (archive) — archived groups stop resolving; rows survive for
+  # audit/membership history.
+  def delete_acl_group(conn, %{"id" => id}) do
+    case Acl.archive_group(id) do
+      {:ok, _group} ->
+        conn |> put_status(:ok) |> json(%{message: "Group archived"})
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "Group not found"})
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{errors: format_errors(cs)})
+    end
+  end
+
+  def add_acl_group_member(conn, %{"id" => id, "member" => member} = params) do
+    with {:ok, ref} <- parse_ref(member),
+         {:ok, expires_at} <- parse_member_expires_at(params["expires_at"]),
+         {:ok, _member} <- Acl.add_member(id, ref, expires_at: expires_at) do
+      group = Acl.get_group(id)
+      conn |> put_status(:created) |> json(%{group: acl_group_json(group, Acl.members(group))})
+    else
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "Group not found"})
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{errors: format_errors(cs)})
+
+      {:error, :invalid_ref} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "member must be {type, id} or \"type:id\" (ERP ref)"})
+
+      {:error, :invalid_expires_at} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "expires_at must be an ISO8601 datetime"})
+    end
+  end
+
+  def add_acl_group_member(conn, _params),
+    do: conn |> put_status(:bad_request) |> json(%{error: "member required"})
+
+  def remove_acl_group_member(conn, %{"id" => id, "member" => member}) do
+    with {:ok, ref} <- parse_ref(member),
+         {:ok, count} <- Acl.remove_member(id, ref) do
+      conn |> put_status(:ok) |> json(%{removed: count})
+    else
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "Group not found"})
+
+      {:error, :invalid_ref} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "member must be {type, id} or \"type:id\" (ERP ref)"})
+    end
+  end
+
+  def remove_acl_group_member(conn, _params),
+    do: conn |> put_status(:bad_request) |> json(%{error: "member required"})
+
+  defp acl_group_json(group, members) do
+    %{
+      id: group.id,
+      name: group.name,
+      description: group.description,
+      status: group.status,
+      ref: ERPRef.dump_map(group.ref),
+      inserted_at: group.inserted_at,
+      members:
+        Enum.map(members, fn m ->
+          %{
+            ref: ERPRef.dump_map(m.member_ref),
+            ref_string: ref_string(m.member_ref),
+            expires_at: m.expires_at
+          }
+        end)
+    }
+  end
+
+  # Member refs arrive as jsonb maps ({"type", "id"} — ERPRef.load form) or
+  # opaque "type:id" strings (TS side treats refs as plain strings).
+  defp filter_nils(map), do: Map.reject(map, fn {_k, v} -> is_nil(v) end)
+
+  defp parse_ref(%{"type" => type, "id" => id}) when is_binary(type) and is_binary(id),
+    do: ERPRef.load(%{"type" => type, "id" => id})
+
+  defp parse_ref(ref) when is_binary(ref) do
+    case String.split(ref, ":", parts: 2) do
+      [type, id] -> parse_ref(%{"type" => type, "id" => id})
+      _ -> {:error, :invalid_ref}
+    end
+  end
+
+  defp parse_ref(_), do: {:error, :invalid_ref}
+
+  defp parse_member_expires_at(nil), do: {:ok, nil}
+
+  defp parse_member_expires_at(bin) when is_binary(bin) do
+    case DateTime.from_iso8601(bin) do
+      {:ok, dt, _} -> {:ok, dt}
+      _ -> {:error, :invalid_expires_at}
+    end
+  end
+
+  defp parse_member_expires_at(_), do: {:error, :invalid_expires_at}
+
+  defp ref_string(ref) do
+    case ERPRef.dump_map(ref) do
+      %{"type" => type, "id" => id} -> "#{type}:#{id}"
+      _ -> nil
+    end
+  end
+
   # ── W4 MCP entities: versioned prompts, resources, resource templates ─────
 
   def list_mcp_prompts(conn, _params) do

--- a/backend/lib/noizu_prompt_lingua_web/router.ex
+++ b/backend/lib/noizu_prompt_lingua_web/router.ex
@@ -530,6 +530,22 @@ defmodule NoizuPromptLinguaWeb.Router do
     # external callers with copy in their scripts keep working.
     post "/mcp-custom-scopes/:slug/copy", AdminController, :clone_mcp_custom_scope
 
+    # D3: per-scope client permissions — client universe + per-client
+    # toolset_config jsonb (F2 EffectiveToolset cascade layer 3).
+    get "/mcp-custom-scopes/:slug/clients", AdminController, :list_scope_clients
+    get "/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config", AdminController, :show_client_toolset_config
+    put "/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config", AdminController, :update_client_toolset_config
+
+    # D3: ACL group admin (F1 NoizuPromptLingua.Acl context) — group CRUD +
+    # membership. DELETE groups is a soft archive; member refs are ERP refs
+    # ({"type","id"} maps or "type:id" strings).
+    get "/acl/groups", AdminController, :list_acl_groups
+    post "/acl/groups", AdminController, :create_acl_group
+    patch "/acl/groups/:id", AdminController, :update_acl_group
+    delete "/acl/groups/:id", AdminController, :delete_acl_group
+    post "/acl/groups/:id/members", AdminController, :add_acl_group_member
+    delete "/acl/groups/:id/members", AdminController, :remove_acl_group_member
+
     # W4 MCP entities — versioned prompts + resources/resource templates.
     get "/mcp-prompts", AdminController, :list_mcp_prompts
     post "/mcp-prompts", AdminController, :create_mcp_prompt

--- a/backend/test/noizu_prompt_lingua_web/controllers/client_permissions_admin_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/client_permissions_admin_test.exs
@@ -1,0 +1,285 @@
+defmodule NoizuPromptLinguaWeb.ClientPermissionsAdminTest do
+  use NoizuPromptLinguaWeb.ConnCase
+
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.Users.User
+  alias NoizuPromptLingua.Schema.McpApiKey
+  alias NoizuPromptLingua.Schema.OAuthClient
+
+  @user_ref_type "NoizuPromptLingua.Schema.Users.User"
+
+  setup %{conn: conn} do
+    %{user: user, access_token: token} = setup_user_and_token()
+    Repo.get!(User, user.id) |> Ecto.Changeset.change(role: :admin) |> Repo.update!()
+    {:ok, conn: authenticated_conn(conn, token), user: user}
+  end
+
+  defp create_scope(conn, slug) do
+    post(conn, "/api/v1/admin/mcp-custom-scopes", %{
+      scope: %{slug: slug, name: slug, description: "test scope", config: %{groups: %{}}}
+    })
+    |> json_response(201)
+  end
+
+  defp create_api_key(user_id, label) do
+    %McpApiKey{}
+    |> McpApiKey.create_changeset(%{
+      user_id: user_id,
+      label: label,
+      key_prefix: "k#{:rand.uniform(9_999_999)}" |> String.slice(0, 8),
+      key_hash: "h#{:rand.uniform(9_999_999)}" |> String.slice(0, 8)
+    })
+    |> Repo.insert!()
+  end
+
+  defp create_oauth_client(name) do
+    %OAuthClient{}
+    |> OAuthClient.changeset(%{
+      client_id: "d3_#{name}_#{:rand.uniform(1_000_000)}",
+      client_name: name,
+      redirect_uris: ["http://localhost/callback"]
+    })
+    |> Repo.insert!()
+  end
+
+  # ── Auth gate ──────────────────────────────────────────────────────────────
+
+  test "non-admin is blocked from client-permission endpoints", %{conn: conn} do
+    %{user: _user, access_token: token} = setup_user_and_token()
+    plain = authenticated_conn(conn, token)
+
+    assert plain |> get("/api/v1/admin/mcp-custom-scopes/any/clients") |> response(403)
+    assert plain |> get("/api/v1/admin/acl/groups") |> response(403)
+    assert plain
+           |> put("/api/v1/admin/mcp-custom-scopes/any/clients/api_key/none/toolset_config", %{
+             toolset_config: %{}
+           })
+           |> response(403)
+  end
+
+  # ── Client listing ─────────────────────────────────────────────────────────
+
+  test "lists api keys and oauth clients (linked: false — no scope association)", %{conn: conn} do
+    create_scope(conn, "d3-clients")
+    api_key = create_api_key(setup_user_and_token().user.id, "ci-runner")
+    oauth = create_oauth_client("Claude Desktop")
+
+    body =
+      conn |> get("/api/v1/admin/mcp-custom-scopes/d3-clients/clients") |> json_response(200)
+
+    assert %{"clients" => clients} = body
+    api_entry = Enum.find(clients, &(&1["id"] == api_key.id))
+    oauth_entry = Enum.find(clients, &(&1["id"] == oauth.id))
+
+    assert api_entry["kind"] == "api_key"
+    assert api_entry["label"] =~ "ci-runner"
+    assert api_entry["status"] == "active"
+    assert api_entry["linked"] == false
+
+    assert oauth_entry["kind"] == "oauth_client"
+    assert oauth_entry["label"] == "Claude Desktop"
+    assert oauth_entry["linked"] == false
+  end
+
+  test "unknown scope slug 404s", %{conn: conn} do
+    assert conn |> get("/api/v1/admin/mcp-custom-scopes/nope/clients") |> response(404)
+  end
+
+  # ── toolset_config read/write + normalization ──────────────────────────────
+
+  test "PUT normalizes dotted keys to canonical underscore and persists", %{conn: conn} do
+    create_scope(conn, "d3-toolset")
+    api_key = create_api_key(setup_user_and_token().user.id, "normalizer")
+    url = "/api/v1/admin/mcp-custom-scopes/d3-toolset/clients/api_key/#{api_key.id}/toolset_config"
+
+    body =
+      conn
+      |> put(url, %{
+        toolset_config: %{
+          groups: %{
+            sessions: %{
+              tools: %{
+                "Session.Create" => %{disabled: true},
+                "Session_Create" => %{hidden: true}
+              }
+            }
+          }
+        }
+      })
+      |> json_response(200)
+
+    tools = body["toolset_config"]["groups"]["sessions"]["tools"]
+    # Canonical entry wins; the dotted alias merged under it, no dual spellings.
+    assert Map.keys(tools) == ["Session_Create"]
+    assert tools["Session_Create"]["disabled"] == true
+    assert tools["Session_Create"]["hidden"] == true
+
+    fetched = (conn |> get(url) |> json_response(200))["toolset_config"]
+    assert fetched == body["toolset_config"]
+  end
+
+  test "PUT validates windows + override fields and rejects junk", %{conn: conn} do
+    create_scope(conn, "d3-validate")
+    api_key = create_api_key(setup_user_and_token().user.id, "validator")
+    url = "/api/v1/admin/mcp-custom-scopes/d3-validate/clients/api_key/#{api_key.id}/toolset_config"
+
+    valid = %{
+      toolset_config: %{
+        groups: %{
+          sessions: %{
+            hidden: true,
+            tools: %{
+              "Session_List" => %{
+                name_override: "list_sessions",
+                hide_until: "2030-01-01T00:00:00Z"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    body = conn |> put(url, valid) |> json_response(200)
+    tool = body["toolset_config"]["groups"]["sessions"]["tools"]["Session_List"]
+    assert tool["name_override"] == "list_sessions"
+    assert tool["hide_until"] == "2030-01-01T00:00:00Z"
+
+    assert conn
+           |> put(url, %{toolset_config: %{groups: %{sessions: %{nope: true}}}})
+           |> json_response(422)
+
+    assert conn
+           |> put(url, %{
+             toolset_config: %{
+               groups: %{sessions: %{tools: %{"Session_List" => %{bogus: true}}}}
+             }
+           })
+           |> json_response(422)
+
+    # Mutually exclusive windows rejected.
+    assert conn
+           |> put(url, %{
+             toolset_config: %{
+               groups: %{
+                 sessions: %{
+                   tools: %{"Session_List" => %{hide_until: "2030-01-01T00:00:00Z", enable_for_hours: 2}}
+                 }
+               }
+             }
+           })
+           |> json_response(422)
+
+    # Bad kinds / unknown clients 404.
+    assert conn |> get("/api/v1/admin/mcp-custom-scopes/d3-validate/clients/widget/xyz/toolset_config") |> response(404)
+    assert conn |> put("/api/v1/admin/mcp-custom-scopes/d3-validate/clients/api_key/00000000-0000-0000-0000-000000000000/toolset_config", %{toolset_config: %{}}) |> response(404)
+  end
+
+  test "PUT accepts fetched config back (enabled_at round-trip) and empty resets", %{conn: conn} do
+    create_scope(conn, "d3-roundtrip")
+    api_key = create_api_key(setup_user_and_token().user.id, "roundtrip")
+    url = "/api/v1/admin/mcp-custom-scopes/d3-roundtrip/clients/api_key/#{api_key.id}/toolset_config"
+
+    conn
+    |> put(url, %{
+      toolset_config: %{groups: %{sessions: %{tools: %{"Session_List" => %{enable_for_hours: 3}}}}}
+    })
+    |> json_response(200)
+
+    fetched = (conn |> get(url) |> json_response(200))["toolset_config"]
+    assert fetched["groups"]["sessions"]["tools"]["Session_List"]["enable_for_hours"] == 3
+    assert fetched["groups"]["sessions"]["tools"]["Session_List"]["enabled_at"]
+
+    # Round-trip write of exactly what GET returned is accepted (no unknown-field 422).
+    round = conn |> put(url, %{toolset_config: fetched}) |> json_response(200)
+    assert round["toolset_config"] == fetched
+
+    # Empty map resets to inherit-everything.
+    reset = conn |> put(url, %{toolset_config: %{}}) |> json_response(200)
+    assert reset["toolset_config"] == %{}
+  end
+
+  test "oauth client toolset_config persists on the oauth_clients row", %{conn: conn} do
+    create_scope(conn, "d3-oauth")
+    oauth = create_oauth_client("OAuth Normalizer")
+    url = "/api/v1/admin/mcp-custom-scopes/d3-oauth/clients/oauth_client/#{oauth.id}/toolset_config"
+
+    body =
+      conn
+      |> put(url, %{toolset_config: %{groups: %{tickets: %{tools: %{"Ticket.List" => %{disabled: true}}}}}})
+      |> json_response(200)
+
+    assert body["toolset_config"]["groups"]["tickets"]["tools"]["Ticket_List"]["disabled"] == true
+    assert Repo.reload!(oauth).toolset_config == body["toolset_config"]
+  end
+
+  # ── ACL groups ─────────────────────────────────────────────────────────────
+
+  defp unique_name(prefix), do: "#{prefix}-#{:rand.uniform(1_000_000_000)}"
+
+  test "group CRUD + membership (map and string ref forms)", %{conn: conn} do
+    %{user: member} = setup_user_and_token()
+
+    created =
+      conn
+      |> post("/api/v1/admin/acl/groups", %{group: %{name: unique_name("d3-crud"), description: "ops"}})
+      |> json_response(201)
+
+    assert %{"group" => %{"id" => group_id, "status" => "active"}} = created
+
+    # Duplicate name rejected.
+    assert conn
+           |> post("/api/v1/admin/acl/groups", %{group: %{name: created["group"]["name"]}})
+           |> json_response(422)
+
+    listed = conn |> get("/api/v1/admin/acl/groups") |> json_response(200)
+    assert Enum.any?(listed["groups"], &(&1["id"] == group_id))
+
+    patched =
+      conn
+      |> patch("/api/v1/admin/acl/groups/#{group_id}", %{group: %{description: "renamed"}})
+      |> json_response(200)
+
+    assert patched["group"]["description"] == "renamed"
+
+    # Add members — map form and opaque "type:id" string form.
+    conn
+    |> post("/api/v1/admin/acl/groups/#{group_id}/members", %{
+      member: %{"type" => @user_ref_type, "id" => member.id}
+    })
+    |> json_response(201)
+
+    conn
+    |> post("/api/v1/admin/acl/groups/#{group_id}/members", %{member: "any:any"})
+    |> json_response(201)
+
+    with_members = conn |> get("/api/v1/admin/acl/groups") |> json_response(200)
+    group = Enum.find(with_members["groups"], &(&1["id"] == group_id))
+    assert length(group["members"]) == 2
+
+    # Invalid ref → 422.
+    assert conn
+           |> post("/api/v1/admin/acl/groups/#{group_id}/members", %{member: "no-separator"})
+           |> json_response(422)
+
+    # Remove via string form.
+    removed =
+      conn
+      |> delete("/api/v1/admin/acl/groups/#{group_id}/members", member: "any:any")
+      |> json_response(200)
+
+    assert removed["removed"] == 1
+
+    after_remove = conn |> get("/api/v1/admin/acl/groups") |> json_response(200)
+    group = Enum.find(after_remove["groups"], &(&1["id"] == group_id))
+    assert length(group["members"]) == 1
+
+    # Delete archives (soft) — group leaves the list, rows survive.
+    assert conn |> delete("/api/v1/admin/acl/groups/#{group_id}") |> json_response(200)
+    listed = conn |> get("/api/v1/admin/acl/groups") |> json_response(200)
+    refute Enum.any?(listed["groups"], &(&1["id"] == group_id))
+
+    assert conn
+           |> patch("/api/v1/admin/acl/groups/#{group_id}", %{group: %{description: "x"}})
+           |> response(404)
+  end
+end

--- a/frontend/src/app/app/admin/mcp-config/[kind]/[id]/page.tsx
+++ b/frontend/src/app/app/admin/mcp-config/[kind]/[id]/page.tsx
@@ -4,23 +4,25 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { toast } from 'sonner';
-import { api, type OAuthClient } from '@/lib/api';
+import { api, type McpCustomScopeConfig, type OAuthClient } from '@/lib/api';
 import ClientPermissionsEditor, {
   defaultClientPermissions,
   type ClientPermissionsCatalogGroup,
   type ClientPermissionsValue,
 } from '@/components/mcp-config/ClientPermissionsEditor';
+import { putClientToolsetConfig } from '@/lib/acl-api';
+import { canonicalToolName } from '@/lib/tool-overrides';
 
 // W7 — per-item client permission editor for the MCP Config hub.
-//   /app/admin/mcp-config/api-key/:id      → legacy API key
-//   /app/admin/mcp-config/oauth-client/:id → OAuth client
-// Renders the shared W6/W7 client-permission stack (kit ToolTogglesGrid +
-// TempWindowEditor + ACLEditor via ClientPermissionsEditor).
+//   /app/admin/mcp-config/api-key/:id      → legacy API key (row uuid)
+//   /app/admin/mcp-config/oauth-client/:id → OAuth client (uuid or client_id)
 //
-// Persistence: per-client toolset_config jsonb read/write lands with F2
-// (EffectiveToolset consumers) and W6 page wiring — until that API exists the
-// editor holds local state and Save reports the pending wiring (contract §8:
-// stub cross-module calls; tsc may fail until feat/ui-kit merges).
+// Persistence (D3): the editor's tool/window state serializes into the
+// client's `toolset_config` jsonb (F2 EffectiveToolset cascade layer 3) via
+// PUT /api/v1/admin/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config.
+// The :slug segment is URL context only; the backend resolves the client by
+// kind+id. ACL rule editing is hidden here — rule CRUD endpoints are not part
+// of D3 (group membership is managed from the W6 Manage Clients tab).
 
 type ClientKind = 'api-key' | 'oauth-client';
 
@@ -36,11 +38,13 @@ export default function ClientPermissionsPage() {
   const [value, setValue] = useState<ClientPermissionsValue | null>(null);
   const [displayName, setDisplayName] = useState<string>('');
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
 
   const loadCatalog = useCallback(async () => {
     try {
       const res = await api.adminMcpCustomScopeCatalog();
       const groups: ClientPermissionsCatalogGroup[] = (res.groups ?? []).map((g) => ({
+        id: g.id,
         group: g.label,
         tools: g.tools.map((t) => ({ name: t.name, description: t.description })),
       }));
@@ -90,9 +94,39 @@ export default function ClientPermissionsPage() {
     loadCatalog();
   }, [validKind, loadCatalog]);
 
-  function save() {
-    // toolset_config write arrives with F2/W6 (per-client jsonb + admin API).
-    toast.info('Saved locally — per-client persistence lands with the toolset_config API (F2/W6)');
+  async function save() {
+    if (!value) return;
+    setSaving(true);
+    try {
+      // Serialize the editor state into the toolset_config jsonb shape:
+      // {groups: {gid: {tools: {canonical_name: {disabled, hidden, windows}}}}}
+      // Absent entries stay enabled + visible (inverted semantics). Keys are
+      // canonicalized server-side too; doing it here keeps the payload clean.
+      const groups: McpCustomScopeConfig['groups'] = {};
+      for (const group of catalog) {
+        const tools: McpCustomScopeConfig['groups'][string]['tools'] = {};
+        for (const tool of group.tools) {
+          const state = value.tools[tool.name];
+          if (!state) continue;
+          const entry: NonNullable<NonNullable<McpCustomScopeConfig['groups'][string]['tools']>[string]> = {};
+          if (!state.enabled) entry.disabled = true;
+          if (!state.visible) entry.hidden = true;
+          if (state.hide_until) entry.hide_until = state.hide_until;
+          if (state.enable_for_hours != null) entry.enable_for_hours = state.enable_for_hours;
+          if (Object.keys(entry).length > 0) tools[canonicalToolName(tool.name)] = entry;
+        }
+        if (Object.keys(tools).length > 0) groups[group.id] = { tools };
+      }
+      // Route kind is hyphenated; the API client type uses snake_case (the
+      // backend accepts both spellings).
+      const apiKind = kind === 'api-key' ? 'api_key' : 'oauth_client';
+      await putClientToolsetConfig('any', apiKind, id, { groups });
+      toast.success('Client permissions saved');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
   }
 
   if (!validKind) {
@@ -127,7 +161,7 @@ export default function ClientPermissionsPage() {
           {kind === 'api-key' ? 'API key' : 'OAuth client'} permissions
         </h1>
         <p className="sg-page-intro">
-          Tool toggles, access windows, and ACL grants for this client.{' '}
+          Tool toggles and access windows for this client (ACL rules arrive with the rules API).{' '}
           <Link href="/app/admin/mcp-config">Back to MCP Config</Link>
         </p>
 
@@ -136,14 +170,15 @@ export default function ClientPermissionsPage() {
           catalog={catalog}
           value={value}
           onChange={setValue}
+          showAcl={false}
         />
 
         <div className="modal-actions">
           <Link className="sg-btn sg-btn--outline" href="/app/admin/mcp-config">
             Cancel
           </Link>
-          <button type="button" className="sg-btn sg-btn--black" onClick={save}>
-            Save
+          <button type="button" className="sg-btn sg-btn--black" onClick={save} disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
           </button>
         </div>
       </main>

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -14,19 +14,22 @@ import {
 import {
   ContextMenu,
   SlideOverSidebar,
-  ACLEditor,
   ToolTogglesGrid,
   TempWindowEditor,
   type ContextMenuItem,
-  type AclState,
   type ToolToggleGroup,
   type TempWindow,
 } from '@/components/kit';
 import {
+  addAclGroupMember,
+  clientAclRefString,
+  createAclGroup,
   fetchAclGroups,
   fetchClientPermissions,
   fetchScopeClients,
+  removeAclGroupMember,
   saveClientPermissions,
+  type AclGroup,
   type ClientPermissions,
   type ScopeClient,
 } from '@/lib/acl-api';
@@ -36,6 +39,7 @@ import {
   applyOverridePatch,
   canonicalToolName,
   hasOverrides,
+  normalizeConfigToolKeys,
   overrideEntry,
   type ToolOverrideEntry,
 } from '@/lib/tool-overrides';
@@ -153,7 +157,7 @@ function AdminMcpCustomScopesInner() {
   const [clientPerms, setClientPerms] = useState<ClientPermissions | null>(null);
   const [clientPermsLoading, setClientPermsLoading] = useState(false);
   const [clientSaving, setClientSaving] = useState(false);
-  const [aclGroups, setAclGroups] = useState<{ id: string; name: string }[]>([]);
+  const [aclGroups, setAclGroups] = useState<AclGroup[]>([]);
   const [tempTool, setTempTool] = useState('');
   const [newGroupName, setNewGroupName] = useState('');
   const [setupScope, setSetupScope] = useState<McpCustomScope | null>(null);
@@ -274,10 +278,15 @@ function AdminMcpCustomScopesInner() {
     updateConfig((draft) => {
       const group = draft.groups[groupId] ?? { tools: {} };
       group.tools = group.tools ?? {};
-      const tool = group.tools[toolName] ?? {};
+      // F5 dotted-write normalization: key by canonical underscore; a legacy
+      // dotted entry migrates under it instead of accumulating both spellings.
+      const toolKey = canonicalToolName(toolName);
+      const legacy = toolKey !== toolName ? (group.tools[toolName] ?? {}) : {};
+      const tool = { ...legacy, ...(group.tools[toolKey] ?? {}) };
       if (value) delete tool.disabled;
       else tool.disabled = true;
-      group.tools[toolName] = tool;
+      if (toolKey !== toolName) delete group.tools[toolName];
+      group.tools[toolKey] = tool;
       draft.groups[groupId] = group;
     });
   }
@@ -286,7 +295,14 @@ function AdminMcpCustomScopesInner() {
     updateConfig((draft) => {
       const group = draft.groups[groupId] ?? { tools: {} };
       group.tools = group.tools ?? {};
-      group.tools[toolName] = { ...(group.tools[toolName] ?? {}), hidden: !value };
+      const toolKey = canonicalToolName(toolName);
+      const tool = {
+        ...(group.tools[toolKey] ?? {}),
+        ...(toolKey !== toolName ? (group.tools[toolName] ?? {}) : {}),
+        hidden: !value,
+      };
+      if (toolKey !== toolName) delete group.tools[toolName];
+      group.tools[toolKey] = tool;
       draft.groups[groupId] = group;
     });
   }
@@ -318,7 +334,9 @@ function AdminMcpCustomScopesInner() {
         name: form.name.trim(),
         description: form.description.trim(),
         kind: form.kind || 'custom',
-        config: form.config,
+        // D3 dotted-write normalization: collapse legacy dotted tool keys to
+        // canonical underscore so configs stop accumulating both spellings.
+        config: normalizeConfigToolKeys(form.config),
       };
       const res = form.originalSlug
         ? await api.adminUpdateMcpCustomScope(form.originalSlug, payload)
@@ -533,41 +551,59 @@ function AdminMcpCustomScopesInner() {
     );
   }
 
-  const groupNameSuggestions = useMemo(() => {
-    const names = new Set(aclGroups.map((g) => g.name));
-    for (const g of clientPerms?.acl.groups ?? []) names.add(g.name);
-    return [...names];
-  }, [aclGroups, clientPerms]);
+  const groupNameSuggestions = useMemo(() => aclGroups.map((g) => g.name), [aclGroups]);
+
+  // D3: membership is real (acl_group_members rows) — derive the selected
+  // client's groups from the fetched ACL groups instead of local bundle state.
+  const currentPermissionGroups = useMemo(() => {
+    if (!selectedClient) return [];
+    const refString = clientAclRefString(selectedClient.kind, selectedClient.id);
+    return aclGroups.filter((g) => g.members.some((m) => m.ref_string === refString)).map((g) => g.name);
+  }, [aclGroups, selectedClient]);
 
   function assignPermissionGroup(name: string) {
     const trimmed = name.trim();
-    if (!trimmed || !clientPerms) return;
-    if (clientPerms.permissionGroups.includes(trimmed)) return;
-    setClientPerms({
-      ...clientPerms,
-      permissionGroups: [...clientPerms.permissionGroups, trimmed],
-    });
-    setNewGroupName('');
+    const client = selectedClient;
+    if (!trimmed || !client) return;
+    (async () => {
+      try {
+        // D3: group membership persists immediately via the ACL endpoints —
+        // create the group on first use, then attach the client's ERP ref.
+        let group = aclGroups.find((g) => g.name === trimmed);
+        if (!group) group = await createAclGroup(trimmed);
+        await addAclGroupMember(group.id, client.kind, client.id);
+        const groups = await fetchAclGroups();
+        setAclGroups(groups);
+        setNewGroupName('');
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to add group');
+      }
+    })();
   }
 
   function unassignPermissionGroup(name: string) {
-    setClientPerms((current) =>
-      current
-        ? { ...current, permissionGroups: current.permissionGroups.filter((g) => g !== name) }
-        : current,
-    );
+    const client = selectedClient;
+    const group = aclGroups.find((g) => g.name === name);
+    if (!client || !group) return;
+    (async () => {
+      try {
+        await removeAclGroupMember(group.id, client.kind, client.id);
+        setAclGroups(await fetchAclGroups());
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to remove group');
+      }
+    })();
   }
 
   async function saveClient() {
     if (!form.originalSlug || !clientPerms) return;
     setClientSaving(true);
     try {
-      const res = await saveClientPermissions(form.originalSlug, clientPerms);
-      if (res.stub) {
-        toast.success('Saved locally (stub — ACL backend endpoints not merged yet)');
-      } else {
-        toast.success('Client permissions saved');
-      }
+      // D3: real persistence — toolset_config (+ temporal windows folded into
+      // the per-tool entries) PUT to the backend; permission-group membership
+      // is applied immediately by assign/unassignPermissionGroup.
+      await saveClientPermissions(form.originalSlug, clientPerms);
+      toast.success('Client permissions saved');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Save failed');
     } finally {
@@ -849,15 +885,11 @@ function AdminMcpCustomScopesInner() {
           </section>
 
           <section style={{ border: '1px solid var(--border, #e5e5e5)', borderRadius: 8, padding: '0.875rem' }}>
-            <h3 style={{ margin: '0 0 0.5rem', fontSize: 13, fontWeight: 700 }}>ACL permissions</h3>
-            <ACLEditor
-              value={clientPerms.acl}
-              onChange={(next: AclState) => setClientPerms({ ...clientPerms, acl: next })}
-            />
-          </section>
-
-          <section style={{ border: '1px solid var(--border, #e5e5e5)', borderRadius: 8, padding: '0.875rem' }}>
             <h3 style={{ margin: '0 0 0.5rem', fontSize: 13, fontWeight: 700 }}>Permission groups</h3>
+            <span className="sg-field__hint" style={{ display: 'block', marginBottom: '0.5rem' }}>
+              Membership is applied immediately via the ACL API (acl_group_members). Per-client ACL
+              rules land with the rules API — group-level rules already resolve through F1.
+            </span>
             <div style={{ display: 'flex', gap: 8 }}>
               <input
                 list="acl-group-names"
@@ -885,9 +917,9 @@ function AdminMcpCustomScopesInner() {
                 Add
               </button>
             </div>
-            {clientPerms.permissionGroups.length > 0 && (
+            {currentPermissionGroups.length > 0 && (
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
-                {clientPerms.permissionGroups.map((name) => (
+                {currentPermissionGroups.map((name) => (
                   <span
                     key={name}
                     style={{

--- a/frontend/src/components/mcp-config/ClientPermissionsEditor.tsx
+++ b/frontend/src/components/mcp-config/ClientPermissionsEditor.tsx
@@ -38,6 +38,8 @@ export interface ClientPermissionsValue {
 }
 
 export interface ClientPermissionsCatalogGroup {
+  /** Catalog group id (used as the toolset_config groups key on save). */
+  id: string;
   group: string;
   tools: { name: string; description?: string }[];
 }

--- a/frontend/src/lib/acl-api.ts
+++ b/frontend/src/lib/acl-api.ts
@@ -1,24 +1,28 @@
 'use client';
 
 /**
- * W6 scope-manager-ux — typed API client for ACL + per-client MCP permissions.
+ * Typed API client for ACL + per-client MCP permissions (W6/W7, D3 debt sprint).
  *
- * Backend status (2026-08-31):
- *  - ACL core is F1's (branch feat/acl-core): `NoizuPromptLingua.ACL` context,
- *    tables acl_groups / acl_group_members / acl_rules (TOBOR-CONTRACTS.md §1).
- *    The REST endpoints below DO NOT EXIST yet.
- *  - Per-scope client listing / per-client toolset_config persistence does not
- *    exist yet either (generalized key_toolsets layering lands via F2).
+ * Backend (AdminController D3 section, all behind the admin gate):
+ *  - GET   /api/v1/admin/mcp-custom-scopes/:slug/clients
+ *  - GET   /api/v1/admin/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config
+ *  - PUT   /api/v1/admin/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config
+ *  - GET   /api/v1/admin/acl/groups
+ *  - POST  /api/v1/admin/acl/groups
+ *  - PATCH /api/v1/admin/acl/groups/:id
+ *  - DELETE /api/v1/admin/acl/groups/:id            (soft archive)
+ *  - POST   /api/v1/admin/acl/groups/:id/members    (member = ERP ref map or "type:id")
+ *  - DELETE /api/v1/admin/acl/groups/:id/members    (body: {member})
  *
- * Until those endpoints ship, every function here falls back to clearly marked
- * FIXTURE data (or a no-op success) so the W6 UI is fully wireable. Each stub
- * is tagged with `// STUB:` — integration (I1) swaps the fallbacks for real
- * responses without touching callers.
+ * The W6 stub-phase fixture fallbacks are gone — every call hits the real API
+ * and errors surface to callers. Per-client ACL *rules* are NOT persisted by
+ * D3 (rule CRUD endpoints are out of scope); group membership IS.
  */
 
 import type { McpCustomScopeConfig } from '@/lib/api';
+import { canonicalToolName, normalizeConfigToolKeys } from '@/lib/tool-overrides';
 
-/** Mirrors kit ACLEditor AclRule (binds F1 AclRule: subject/resource are opaque ERP ref strings). */
+/** Mirrors kit ACLEditor AclRule (subject/resource are opaque ERP ref strings). */
 export interface AclRule {
   id: string;
   subject: string;
@@ -27,11 +31,20 @@ export interface AclRule {
   scope: string;
 }
 
-/** Mirrors kit ACLEditor AclGroup. */
+/** An ACL group member — backend serializes ERP refs as jsonb map + string form. */
+export interface AclGroupMember {
+  ref: { type: string; id: string };
+  ref_string: string;
+  expires_at: string | null;
+}
+
+/** Mirrors kit ACLEditor AclGroup, with real backend membership. */
 export interface AclGroup {
   id: string;
   name: string;
-  members: string[];
+  description?: string | null;
+  status?: string;
+  members: AclGroupMember[];
 }
 
 export interface AclState {
@@ -45,27 +58,30 @@ export type ClientKind = 'api_key' | 'oauth_client';
 export interface ScopeClient {
   id: string;
   kind: ClientKind;
-  /** Display label (key label or OAuth client_name). */
+  /** Display label (key label + prefix, or OAuth client_name). */
   label: string;
   status: 'active' | 'revoked';
   inserted_at: string;
+  /** No scope↔client association table exists yet — always false today. */
+  linked: boolean;
 }
+
+/** F3 temporal window fields per canonical tool name (mutually exclusive). */
+export type TempWindows = Record<string, { hide_until: string | null; enable_for_hours: number | null }>;
 
 /**
  * Per-client permission bundle persisted as the client's `toolset_config`
- * jsonb (same shape family as scope config) + ACL rows + permission-group
- * membership. This is the payload W6's Manage Clients tab edits and saves.
+ * jsonb (temporal windows ride the per-tool entries, F3) + ACL permission-group
+ * membership. ACL rules stay local (no rule CRUD endpoints in D3).
  */
 export interface ClientPermissions {
   clientId: string;
   clientKind: ClientKind;
-  /** Tool restrict config — same jsonb shape as scope config ({groups:{gid:{tools:{name:{disabled,hidden}}}}}). */
+  /** Tool restrict config — same jsonb shape as scope config ({groups:{gid:{tools:{name:{...}}}}}). */
   toolsetConfig: McpCustomScopeConfig;
-  /** F3 temporal windows per canonical tool name: {hide_until, enable_for_hours} (mutually exclusive). */
-  tempWindows: Record<string, { hide_until: string | null; enable_for_hours: number | null }>;
-  /** F1 ACL grants/denies bound to this client as subject. */
+  tempWindows: TempWindows;
   acl: AclState;
-  /** Names of ACL permission groups this client belongs to (datalist-driven). */
+  /** Names of ACL permission groups this client belongs to. */
   permissionGroups: string[];
 }
 
@@ -84,149 +100,174 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Request failed: ${res.status}`);
+    throw new Error(body.error || body.errors?.join?.(', ') || `Request failed: ${res.status}`);
   }
   return res.json();
 }
 
-// ── Fixture data (STUB fallbacks — remove when F1/F2 endpoints land) ──
+// ── Clients ────────────────────────────────────────────────────────────────
 
-const FIXTURE_CLIENTS: ScopeClient[] = [
-  {
-    id: 'key-fixture-1',
-    kind: 'api_key',
-    label: 'ci-runner key (…ab12)',
-    status: 'active',
-    inserted_at: '2026-08-01T00:00:00Z',
-  },
-  {
-    id: 'oauth-fixture-1',
-    kind: 'oauth_client',
-    label: 'Claude Desktop (fixture)',
-    status: 'active',
-    inserted_at: '2026-08-15T00:00:00Z',
-  },
-];
-
-const FIXTURE_ACL: AclState = {
-  rules: [
-    {
-      id: 'rule-fixture-1',
-      subject: 'ref:client:key-fixture-1',
-      resource: 'ref:organization:the-robot-lives',
-      effect: 'allow',
-      scope: 'read',
-    },
-    {
-      id: 'rule-fixture-2',
-      subject: 'ref:client:key-fixture-1',
-      resource: 'ref:wiki:internal-notes',
-      effect: 'deny',
-      scope: 'read',
-    },
-  ],
-  groups: [
-    { id: 'group-fixture-1', name: 'ci-bots', members: ['ref:client:key-fixture-1'] },
-  ],
-};
-
-const FIXTURE_GROUPS: AclGroup[] = [
-  { id: 'group-fixture-1', name: 'ci-bots', members: [] },
-  { id: 'group-fixture-2', name: 'admins', members: [] },
-  { id: 'group-fixture-3', name: 'read-only', members: [] },
-];
-
-function fixturePermissions(client: ScopeClient): ClientPermissions {
-  return {
-    clientId: client.id,
-    clientKind: client.kind,
-    toolsetConfig: { groups: {} },
-    tempWindows: {},
-    acl: {
-      rules: FIXTURE_ACL.rules.map((r) => ({ ...r, subject: `ref:client:${client.id}` })),
-      groups: FIXTURE_ACL.groups.map((g) => ({ ...g })),
-    },
-    permissionGroups: client.kind === 'api_key' ? ['ci-bots'] : [],
-  };
-}
-
-// ── Public API ──
-
-/**
- * List clients (API keys + OAuth clients) attached to a custom scope.
- *
- * STUB: GET /api/v1/admin/mcp-custom-scopes/:slug/clients — endpoint does not
- * exist yet (F2 generalizes client layering). Falls back to fixtures on 404.
- */
+/** GET /mcp-custom-scopes/:slug/clients — api keys + oauth clients (linked: false). */
 export async function fetchScopeClients(scopeSlug: string): Promise<ScopeClient[]> {
-  try {
-    const res = await request<{ clients: ScopeClient[] }>(
-      `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients`,
-    );
-    return res.clients;
-  } catch {
-    // STUB fallback — fixture clients until the endpoint exists.
-    return FIXTURE_CLIENTS.map((c) => ({ ...c }));
+  const res = await request<{ clients: ScopeClient[] }>(
+    `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients`,
+  );
+  return res.clients;
+}
+
+/** Extract F3 temporal windows out of a config's per-tool entries. */
+function extractTempWindows(config: McpCustomScopeConfig): TempWindows {
+  const windows: TempWindows = {};
+  for (const group of Object.values(config.groups ?? {})) {
+    for (const [toolName, entry] of Object.entries(group.tools ?? {})) {
+      if (entry && (entry.hide_until != null || entry.enable_for_hours != null)) {
+        windows[toolName] = {
+          hide_until: entry.hide_until ?? null,
+          enable_for_hours: entry.enable_for_hours ?? null,
+        };
+      }
+    }
   }
+  return windows;
+}
+
+/** Merge temporal windows into a config's per-tool entries (canonical keys). */
+function mergeTempWindows(
+  config: McpCustomScopeConfig,
+  tempWindows: TempWindows,
+): McpCustomScopeConfig {
+  const draft = normalizeConfigToolKeys(config);
+  for (const group of Object.values(draft.groups)) {
+    for (const [toolName, win] of Object.entries(tempWindows)) {
+      const key = canonicalToolName(toolName);
+      const entry = group.tools?.[key] ?? {};
+      group.tools = group.tools ?? {};
+      group.tools[key] = { ...entry, hide_until: win.hide_until, enable_for_hours: win.enable_for_hours };
+    }
+  }
+  return draft;
 }
 
 /**
- * Load the permission bundle for one client on one scope.
- *
- * STUB: GET /api/v1/admin/mcp-custom-scopes/:slug/clients/:clientId/permissions
- * — falls back to fixtures on 404.
+ * Load the permission bundle for one client on one scope (GET toolset_config,
+ * ACL/rules state left empty — rule CRUD endpoints are not part of D3).
  */
 export async function fetchClientPermissions(
   scopeSlug: string,
   client: ScopeClient,
 ): Promise<ClientPermissions> {
-  try {
-    const res = await request<{ permissions: ClientPermissions }>(
-      `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients/${encodeURIComponent(client.id)}/permissions`,
-    );
-    return res.permissions;
-  } catch {
-    // STUB fallback — fixture bundle until the endpoint exists.
-    return fixturePermissions(client);
-  }
+  const res = await request<{ toolset_config: McpCustomScopeConfig }>(
+    `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients/${encodeURIComponent(client.kind)}/${encodeURIComponent(client.id)}/toolset_config`,
+  );
+  const toolsetConfig = res.toolset_config ?? {};
+  return {
+    clientId: client.id,
+    clientKind: client.kind,
+    toolsetConfig,
+    tempWindows: extractTempWindows(toolsetConfig),
+    acl: { rules: [], groups: [] },
+    permissionGroups: [],
+  };
 }
 
 /**
- * Persist a client's permission bundle.
- *
- * STUB: PUT /api/v1/admin/mcp-custom-scopes/:slug/clients/:clientId/permissions
- * — endpoint does not exist yet (F1 ACL writes + F2 toolset_config). Resolves
- * as success without persisting anything.
+ * Persist a client's permission bundle: temporal windows fold into the
+ * toolset_config entries (keys canonicalized) and the bundle is PUT to the
+ * backend. Permission-group membership is synced by the caller.
  */
 export async function saveClientPermissions(
   scopeSlug: string,
   permissions: ClientPermissions,
-): Promise<{ ok: true; stub?: true }> {
-  try {
-    return await request<{ ok: true }>(
-      `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients/${encodeURIComponent(permissions.clientId)}/permissions`,
-      { method: 'PUT', body: JSON.stringify({ permissions }) },
-    );
-  } catch {
-    // STUB fallback — pretend-save until the endpoint exists.
-    console.info(
-      `[acl-api] STUB saveClientPermissions (scope=${scopeSlug}, client=${permissions.clientId}) — backend endpoint not implemented yet`,
-    );
-    return { ok: true, stub: true };
-  }
+): Promise<{ ok: true; toolsetConfig: McpCustomScopeConfig }> {
+  const res = await request<{ toolset_config: McpCustomScopeConfig }>(
+    `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients/${encodeURIComponent(permissions.clientKind)}/${encodeURIComponent(permissions.clientId)}/toolset_config`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        toolset_config: mergeTempWindows(permissions.toolsetConfig, permissions.tempWindows),
+      }),
+    },
+  );
+  return { ok: true, toolsetConfig: res.toolset_config ?? {} };
 }
 
+// ── ACL groups ─────────────────────────────────────────────────────────────
+
 /**
- * List available ACL permission groups (names for the assignment datalist).
- *
- * STUB: GET /api/v1/admin/acl/groups — F1 backend. Falls back to fixtures.
+ * Raw toolset_config PUT for the W7 per-item editor (no bundle context). The
+ * :slug segment is URL context only — the backend resolves the client by
+ * kind+id.
  */
+export async function putClientToolsetConfig(
+  scopeSlug: string,
+  kind: ClientKind,
+  clientId: string,
+  toolsetConfig: McpCustomScopeConfig,
+): Promise<McpCustomScopeConfig> {
+  const res = await request<{ toolset_config: McpCustomScopeConfig }>(
+    `/api/v1/admin/mcp-custom-scopes/${encodeURIComponent(scopeSlug)}/clients/${encodeURIComponent(kind)}/${encodeURIComponent(clientId)}/toolset_config`,
+    { method: 'PUT', body: JSON.stringify({ toolset_config: normalizeConfigToolKeys(toolsetConfig) }) },
+  );
+  return res.toolset_config ?? {};
+}
+
+/** GET /admin/acl/groups — active groups with members. */
 export async function fetchAclGroups(): Promise<AclGroup[]> {
-  try {
-    const res = await request<{ groups: AclGroup[] }>('/api/v1/admin/acl/groups');
-    return res.groups;
-  } catch {
-    // STUB fallback.
-    return FIXTURE_GROUPS.map((g) => ({ ...g }));
-  }
+  const res = await request<{ groups: AclGroup[] }>('/api/v1/admin/acl/groups');
+  return res.groups;
+}
+
+/** POST /admin/acl/groups. */
+export async function createAclGroup(name: string, description?: string): Promise<AclGroup> {
+  const res = await request<{ group: AclGroup }>('/api/v1/admin/acl/groups', {
+    method: 'POST',
+    body: JSON.stringify({ group: { name, description } }),
+  });
+  return res.group;
+}
+
+/** DELETE /admin/acl/groups/:id — soft archive (group stops resolving). */
+export async function deleteAclGroup(groupId: string): Promise<void> {
+  await request(`/api/v1/admin/acl/groups/${encodeURIComponent(groupId)}`, { method: 'DELETE' });
+}
+
+function refForClient(kind: ClientKind, clientId: string): { type: string; id: string } {
+  return {
+    type: kind === 'api_key' ? 'NoizuPromptLingua.Schema.McpApiKey' : 'NoizuPromptLingua.Schema.OAuthClient',
+    id: clientId,
+  };
+}
+
+/** Opaque ERP ref string for a client ("Type:id") — membership comparisons use it. */
+export function clientAclRefString(kind: ClientKind, clientId: string): string {
+  return refString(kind, clientId);
+}
+
+function refString(kind: ClientKind, clientId: string): string {
+  const ref = refForClient(kind, clientId);
+  return `${ref.type}:${ref.id}`;
+}
+
+/** POST /admin/acl/groups/:id/members — attach a client to a permission group. */
+export async function addAclGroupMember(
+  groupId: string,
+  kind: ClientKind,
+  clientId: string,
+): Promise<void> {
+  await request(`/api/v1/admin/acl/groups/${encodeURIComponent(groupId)}/members`, {
+    method: 'POST',
+    body: JSON.stringify({ member: refForClient(kind, clientId) }),
+  });
+}
+
+/** DELETE /admin/acl/groups/:id/members — detach a client from a permission group. */
+export async function removeAclGroupMember(
+  groupId: string,
+  kind: ClientKind,
+  clientId: string,
+): Promise<void> {
+  await request(`/api/v1/admin/acl/groups/${encodeURIComponent(groupId)}/members`, {
+    method: 'DELETE',
+    body: JSON.stringify({ member: refString(kind, clientId) }),
+  });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -348,6 +348,10 @@ export interface McpCustomScopeConfig {
       name_override?: string;
       description_override?: string;
       arg_overrides?: Record<string, string>;
+      // F3 temporal windows (mutually exclusive; enabled_at stamped server-side)
+      hide_until?: string | null;
+      enable_for_hours?: number | null;
+      enabled_at?: string;
     }>;
   }>;
 }

--- a/frontend/src/lib/tool-overrides.test.ts
+++ b/frontend/src/lib/tool-overrides.test.ts
@@ -16,6 +16,7 @@ import {
   applyOverridePatch,
   canonicalToolName,
   hasOverrides,
+  normalizeConfigToolKeys,
   overrideEntry,
 } from './tool-overrides';
 import type { McpCustomScopeConfig } from './api';
@@ -114,4 +115,44 @@ test('source config is never mutated', () => {
   applyOverridePatch(cfg, 'sessions', 'Session_Create', { name_override: 'Z' });
   assert.equal(cfg.groups.sessions.tools?.Session_Create?.name_override, undefined);
   assert.deepEqual(Object.keys(cfg.groups), ['sessions']);
+});
+
+// ── D3 dotted-write normalization ──────────────────────────────────────────
+
+test('normalizeConfigToolKeys collapses dotted aliases under canonical entries', () => {
+  const cfg = normalizeConfigToolKeys(base());
+  const tools = cfg.groups.sessions.tools ?? {};
+  assert.deepEqual(Object.keys(tools).sort(), ['Session_Create', 'Session_List']);
+  assert.equal(tools.Session_Create?.disabled, true);
+  // Session.List is the legacy dotted spelling of Session_List — its fields
+  // ride the canonical key, and no dotted spelling survives.
+  assert.equal(tools.Session_List?.hidden, true);
+  assert.ok(!Object.keys(tools).some((k) => k.includes('.')), 'no dotted keys survive');
+});
+
+test('normalizeConfigToolKeys keeps multiple tools and non-tool group keys', () => {
+  const cfg: McpCustomScopeConfig = {
+    groups: {
+      tickets: {
+        hidden: true,
+        tools: {
+          'Ticket.List': { disabled: true },
+          Ticket_Create: { hidden: true },
+          'Ticket.Get': { name_override: 'fetch' },
+        },
+      },
+    },
+  };
+  const next = normalizeConfigToolKeys(cfg);
+  const tools = next.groups.tickets.tools ?? {};
+  assert.deepEqual(Object.keys(tools).sort(), ['Ticket_Create', 'Ticket_Get', 'Ticket_List']);
+  assert.equal(next.groups.tickets.hidden, true, 'group-level flags untouched');
+  assert.equal(cfg.groups.tickets.tools?.['Ticket.List']?.disabled, true, 'input never mutated');
+});
+
+test('normalizeConfigToolKeys is a no-op on already-canonical configs', () => {
+  const cfg: McpCustomScopeConfig = {
+    groups: { sessions: { tools: { Session_Create: { disabled: true } } } },
+  };
+  assert.deepEqual(normalizeConfigToolKeys(cfg), cfg);
 });

--- a/frontend/src/lib/tool-overrides.ts
+++ b/frontend/src/lib/tool-overrides.ts
@@ -129,3 +129,26 @@ export function hasOverrides(config: McpCustomScopeConfig, groupId: string, tool
     !!entry.arg_overrides && Object.values(entry.arg_overrides).some((v) => v.trim() !== '')
   );
 }
+
+/**
+ * D3 dotted-write normalization: rewrite EVERY tools key in a config to the
+ * canonical underscore form (F5). Legacy dotted entries merge under their
+ * canonical key (canonical field values win), so saved configs stop carrying
+ * both spellings of the same tool. Run this on save from every write path that
+ * keys tool entries by catalog name.
+ */
+export function normalizeConfigToolKeys(config: McpCustomScopeConfig): McpCustomScopeConfig {
+  const draft = cloneConfig(config);
+  for (const group of Object.values(draft.groups)) {
+    if (!group.tools) continue;
+    const next: Record<string, ScopeToolEntry> = {};
+    for (const [key, entry] of Object.entries(group.tools)) {
+      const canonicalKey = canonicalToolName(key);
+      const existing = next[canonicalKey];
+      next[canonicalKey] =
+        existing && key !== canonicalKey ? { ...entry, ...existing } : { ...(existing ?? entry) };
+    }
+    group.tools = next;
+  }
+  return draft;
+}


### PR DESCRIPTION
## Summary
- Backend (admin-gated): `GET /mcp-custom-scopes/:slug/clients` (all api keys + oauth clients, `linked:false` — no scope↔client assoc table yet); `GET/PUT /mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config` with write-time normalization (dotted tool keys merged under canonical underscore names, unknown fields rejected, F3 windows validated, empty config → `%{}`); full ACL group + membership CRUD (`/acl/groups*`) via the `NoizuPromptLingua.Acl` context (soft archive on delete, ERP ref map or `"Type:id"` member form).
- Frontend: `acl-api.ts` fixtures removed — all calls hit the real API. W6 scope-manager client saves now persist (stub toast removed), permission-group assign/unassign is real. W7 per-client editor (`/app/admin/mcp-config/[kind]/[id]`) serializes to `toolset_config` with canonical keys. Dotted-key writes normalized via new `normalizeConfigToolKeys` (tool-overrides.ts). ACL *rules* editing parked (no rule CRUD endpoints in D3) — group membership is live.
- Tests: new `client_permissions_admin_test.exs` (8 tests: 403 gate, listing, 404s, dotted-key merge, validation 422s, GET→PUT round-trip incl. `enabled_at`, oauth persistence, ACL CRUD/membership). 3 new `tool-overrides` unit tests.

## Test plan
- [x] `MIX_ENV=test mix test test/noizu_prompt_lingua_web/controllers/client_permissions_admin_test.exs` — 8/8 green
- [x] Scoped gate `mix test test/noizu_prompt_lingua/mcp test/noizu_prompt_lingua_web` — 405/406; single failure (`AssetControllerTest` 503-expectation) reproduces identically on clean main, unrelated to this PR
- [x] `tsc --noEmit` clean; `npx tsx src/lib/tool-overrides.test.ts` 13/13

Co-Authored-By: Loom <loom@therobotlives.com>