### PR TITLE
test(assets): hermetic provider-key tests via media_tool_runner stubs

### DIFF
--- a/backend/test/noizu_prompt_lingua/domains/assets/assets_generate_test.exs
+++ b/backend/test/noizu_prompt_lingua/domains/assets/assets_generate_test.exs
@@ -12,6 +12,16 @@ defmodule NoizuPromptLingua.Domains.AssetsGenerateTest do
 
   @moduletag :db
 
+  # Hermetic: availability must not depend on the workstation having (or lacking)
+  # the `generate-media-prompt` binary on PATH. Stub the swappable runner to fail
+  # so the graceful-unavailable contract is exercised deterministically.
+  defmodule NoProviderStub do
+    @behaviour NoizuPromptLingua.Domains.Assets.MediaToolRunner
+
+    @impl true
+    def run(_prompt_path, _tmp_dir, _opts), do: {:error, :no_provider_stub}
+  end
+
   setup do
     org_id = insert_org()
 
@@ -37,14 +47,13 @@ defmodule NoizuPromptLingua.Domains.AssetsGenerateTest do
     assert {:ok, %AssetOutput{}} = Assets.generate(ctx.entry_id, content: "rendered content")
   end
 
-  test "no provider key -> {:error, :generation_unavailable}, never a crash", ctx do
-    prev = System.get_env("OPENAI_API_KEY")
-    System.put_env("OPENAI_API_KEY", "")
+  test "no provider available -> {:error, :generation_unavailable}, never a crash", ctx do
+    prev = Application.get_env(:noizu_prompt_lingua, :media_tool_runner)
+    Application.put_env(:noizu_prompt_lingua, :media_tool_runner, NoProviderStub)
 
     on_exit(fn ->
-      if prev,
-        do: System.put_env("OPENAI_API_KEY", prev),
-        else: System.delete_env("OPENAI_API_KEY")
+      if prev, do: Application.put_env(:noizu_prompt_lingua, :media_tool_runner, prev),
+        else: Application.delete_env(:noizu_prompt_lingua, :media_tool_runner)
     end)
 
     assert {:error, :generation_unavailable} = Assets.generate(ctx.entry_id, provider: "openai")

--- a/backend/test/noizu_prompt_lingua_web/controllers/asset_controller_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/asset_controller_test.exs
@@ -8,6 +8,37 @@ defmodule NoizuPromptLinguaWeb.AssetControllerTest do
 
   alias NoizuPromptLingua.Domains.Assets
 
+  # Hermetic provider stubs: the 503/201 generate branches depend on the configured
+  # MediaToolRunner, and the default CLI shell-out succeeds on any workstation that
+  # has `generate-media-prompt` on PATH (env-dependent, so the 503 test flapped).
+  # Tests swap in a stub via the documented `:media_tool_runner` config instead.
+  defmodule NoProviderStub do
+    @behaviour NoizuPromptLingua.Domains.Assets.MediaToolRunner
+
+    @impl true
+    def run(_prompt_path, _tmp_dir, _opts), do: {:error, :no_provider_stub}
+  end
+
+  defmodule HappyStub do
+    @behaviour NoizuPromptLingua.Domains.Assets.MediaToolRunner
+
+    @impl true
+    def run(_prompt_path, tmp_dir, _opts) do
+      path = Path.join(tmp_dir, "generated.png")
+      File.write!(path, <<0x89, "PNG-stub">>)
+      {:ok, %{output_path: path, mime: "image/png"}}
+    end
+  end
+
+  defp with_runner(mod) do
+    prev = Application.get_env(:noizu_prompt_lingua, :media_tool_runner)
+    Application.put_env(:noizu_prompt_lingua, :media_tool_runner, mod)
+    on_exit(fn ->
+      if prev, do: Application.put_env(:noizu_prompt_lingua, :media_tool_runner, prev),
+        else: Application.delete_env(:noizu_prompt_lingua, :media_tool_runner)
+    end)
+  end
+
   setup %{conn: conn} do
     %{access_token: token} = setup_user_and_token()
     auth_conn = authenticated_conn(conn, token)
@@ -32,19 +63,18 @@ defmodule NoizuPromptLinguaWeb.AssetControllerTest do
     {:ok, conn: auth_conn, org_id: org_id, entry_id: entry.id, base: base}
   end
 
-  test "generate with no provider configured -> 503, not 500", %{conn: conn, base: base} do
-    prev = System.get_env("OPENAI_API_KEY")
-    System.put_env("OPENAI_API_KEY", "")
-
-    on_exit(fn ->
-      if prev,
-        do: System.put_env("OPENAI_API_KEY", prev),
-        else: System.delete_env("OPENAI_API_KEY")
-    end)
+  test "generate with no provider available -> 503, not 500", %{conn: conn, base: base} do
+    with_runner(NoProviderStub)
 
     conn = post(conn, base, %{provider: "openai"})
     assert conn.status == 503
     assert json_response(conn, 503)["error"] =~ "not available"
+  end
+
+  test "generate with a resolved provider -> 201 binary output", %{conn: conn, base: base} do
+    with_runner(HappyStub)
+
+    assert json_response(post(conn, base, %{provider: "openai"}), 201)["output"]
   end
 
   test "generate with llm_generate:false -> 201 placeholder output", %{conn: conn, base: base} do


### PR DESCRIPTION
## Summary
- Env fix E2: the asset provider-key tests (AssetControllerTest 503-no-provider, AssetsGenerateTest generation_unavailable) depended on workstation config — blanking `OPENAI_API_KEY` did nothing when the `generate-media-prompt` binary is on PATH (it then succeeds and the "no provider" assertions fail).
- Both tests now swap the documented `:media_tool_runner` config to a **failing stub**, pinning the `{:error, :generation_unavailable}` → 503 branch deterministically.
- Added a **happy-path stub** test covering the provider-resolved 201 branch (previously untested), so both branches are exercised regardless of environment.
- Memory-domain audit: `@moduletag :memory` already covers every Weaviate-touching test (`memory_test.exs`, `scope_isolation_test.exs`); `agents_test.exs` is PG-only by design. CI's `--exclude memory` shape unchanged and verified green.

## Test plan
- [x] `MIX_TEST_PARTITION=envhygiene mix test` (full, no excludes): **817 passed** (813 tests + 4 properties), 0 failures
- [x] `MIX_TEST_PARTITION=envhygiene mix test --exclude memory` (CI shape): **811 passed, 6 excluded**, 0 failures
- [x] No new compiler warnings from touched files

Co-Authored-By: Loom <loom@therobotlives.com>