### PR TITLE
fix(ci): tsc and effective toolset after debt merges

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
@@ -75,6 +75,7 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   alias NoizuPromptLingua.MCPServers
   alias NoizuPromptLingua.Repo
   alias NoizuPromptLingua.Schema.McpApiKey
+  alias NoizuPromptLingua.Schema.MCPCustomScope
   alias NoizuPromptLingua.Schema.OAuthClient
   alias NoizuPromptLingua.Schema.McpTool
   require Noizu.EntityReference.Records

--- a/frontend/src/lib/mcp-setup.test.ts
+++ b/frontend/src/lib/mcp-setup.test.ts
@@ -9,7 +9,7 @@ import {
   mcpOauthServerName,
   mcpOauthSnippet,
   type McpOauthClient,
-} from './mcp-setup.ts';
+} from './mcp-setup';
 
 const URL = 'https://tobor.locker/custom/tobor/mcp';
 const NAME = 'tobor-tobor';


### PR DESCRIPTION
## Why

`origin/main` after #33/#34 is red on real CI (not quota):

- **frontend tsc TS5097** — `frontend/src/lib/mcp-setup.test.ts` imported `./mcp-setup.ts`
- **mix test** — `EffectiveToolset` scope-wide ACL deny no-op'd because the #33 merge dropped `alias Schema.MCPCustomScope` while keeping `R.ref(module: MCPCustomScope, ...)` (resolved as `Elixir.MCPCustomScope`, so deny rules on the real schema never matched)

## Changes

- Drop the `.ts` suffix on the mcp-setup test import (matches the rest of the frontend tests; does not enable `allowImportingTsExtensions`)
- Restore `alias NoizuPromptLingua.Schema.MCPCustomScope` next to the D1 `OAuthClient` / `ToolsetCache` aliases so D2 scope-wide deny still works

## Tests

- `frontend`: `npx tsc --noEmit` (via `node node_modules/typescript/bin/tsc --noEmit`) — pass
- `backend`: `mix test` on `effective_toolset_acl_test.exs` + `effective_toolset_test.exs` — 35 passed
- `backend`: `mix test --exclude memory` — 825 passed (4 properties, 821 tests), 6 excluded

Do not merge this from the agent side.