### PR TITLE
fix(mcp): N1 manifest parity — scope-bound universe, W8 client_for, write-path notifies

### DIFF
--- a/backend/lib/noizu_prompt_lingua/entities/mcp_api_keys.ex
+++ b/backend/lib/noizu_prompt_lingua/entities/mcp_api_keys.ex
@@ -55,7 +55,9 @@ defmodule NoizuPromptLingua.MCPApiKeys do
   defp maybe_put_expires_at(attrs, %DateTime{} = dt), do: Map.put(attrs, :expires_at, dt)
 
   defp maybe_put_toolset(attrs, nil), do: attrs
-  defp maybe_put_toolset(attrs, config), do: Map.put(attrs, :toolset_config, normalize_toolset(config))
+
+  defp maybe_put_toolset(attrs, config),
+    do: Map.put(attrs, :toolset_config, normalize_toolset(config))
 
   @doc """
   Normalize a toolset config to the canonical shape (string keys, known groups
@@ -205,7 +207,6 @@ defmodule NoizuPromptLingua.MCPApiKeys do
     KeySchema |> order_by([k], desc: k.inserted_at) |> NoizuPromptLingua.Repo.all()
   end
 
-
   @doc """
   Parses an optional `expires_at` request param into `{:ok, %DateTime{} | nil}`
   for `generate_api_key/3`, or `:error` if it's present but not a valid,
@@ -279,9 +280,11 @@ defmodule NoizuPromptLingua.MCPApiKeys do
   end
 
   # Cached keys (ToolsetCache) feed the EffectiveToolset cascade — drop the
-  # cache whenever a key's status/toolset write lands.
+  # cache whenever a key's status/toolset write lands. The cache bump +
+  # tools/list_changed broadcast are ONE best-effort step (N1 manifest parity):
+  # connected clients re-list before serving stale key flags.
   defp bump_cache_on_ok({:ok, _} = ok) do
-    NoizuPromptLingua.MCP.ToolsetCache.bump()
+    NoizuPromptLingua.MCP.Server.notify_toolset_changed()
     ok
   end
 

--- a/backend/lib/noizu_prompt_lingua/mcp/server.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/server.ex
@@ -36,6 +36,9 @@ defmodule NoizuPromptLingua.MCP.Server do
 
   alias Noizu.MCP.Server.Features.Pagination
   alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.MCPServers
+
+  require Logger
 
   @doc """
   Shared `handle_list_tools` implementation: expand the server's tool set
@@ -59,5 +62,47 @@ defmodule NoizuPromptLingua.MCP.Server do
     |> Enum.reject(& &1.hidden)
     |> Enum.map(& &1.definition)
     |> Pagination.paginate(cursor)
+  end
+
+  @doc """
+  Write-path invalidation for toolset-affecting writes (custom-scope
+  create/update/delete, API-key toolset/status writes, OAuth-client
+  toolset_config/revoke): bump the `ToolsetCache` generation AND broadcast
+  `notifications/tools/list_changed` to every connected session on every NPL
+  MCP server (root aggregate, the custom-scope endpoint, and all group
+  servers — `notify_changed/1` is generated per server module by the
+  `use Noizu.MCP.Server` macro, so the broadcast fans out over the catalog).
+
+  This is the FINAL home of the notify call sites (N1 parity workstream):
+  best-effort by contract — a server whose session registry is down is logged
+  and skipped, never fails the write that triggered it.
+  """
+  def notify_toolset_changed do
+    NoizuPromptLingua.MCP.ToolsetCache.bump()
+
+    for mod <- server_modules() do
+      try do
+        if Code.ensure_loaded?(mod) and function_exported?(mod, :notify_changed, 1) do
+          mod.notify_changed(:tools)
+        end
+      rescue
+        e ->
+          Logger.warning(
+            "[MCP.Server] notify_changed(:tools) failed for #{inspect(mod)}: #{Exception.message(e)}"
+          )
+      end
+    end
+
+    :ok
+  end
+
+  defp server_modules do
+    [NoizuPromptLingua.MCP, NoizuPromptLingua.MCP.Custom] ++
+      Enum.flat_map(MCPServers.all(), fn %{id: id} ->
+        case MCPServers.server_module(id) do
+          nil -> []
+          mod -> [mod]
+        end
+      end)
   end
 end

--- a/backend/lib/noizu_prompt_lingua/mcp/session_manifest.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/session_manifest.ex
@@ -12,6 +12,14 @@ defmodule NoizuPromptLingua.MCP.SessionManifest do
   resolved map (or with no flags) is `enabled: true, visible: true,
   expires_at: nil`.
 
+  Universe (N1 manifest parity): a scope-bound ctx (assigns
+  `custom_scope_slug`) enumerates EXACTLY what the custom endpoint serves —
+  `NoizuPromptLingua.MCP.Custom.custom_specs/1` — so the manifest can never
+  advertise a tool the endpoint does not include (the 14-vs-270 incident
+  class). The root-aggregate ctx keeps the full-catalog enumeration. Every
+  entry carries `included: true` ("in the endpoint's include set"); client/ACL
+  layers flip `enabled`/`visible` but never shrink the universe.
+
   Tool names are emitted in the canonical underscore form (§4) — dotted
   registered names (e.g. `Session.Create`) are folded via
   `NoizuPromptLingua.MCP.ToolNames.canonical/1` when that module is present
@@ -20,6 +28,8 @@ defmodule NoizuPromptLingua.MCP.SessionManifest do
   """
 
   alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.MCP.Custom
+  alias NoizuPromptLingua.MCP.EffectiveToolset
   alias NoizuPromptLingua.MCPServers
 
   @manifest_tool "Session_Manifest"
@@ -27,7 +37,7 @@ defmodule NoizuPromptLingua.MCP.SessionManifest do
   @doc """
   Build the manifest for the calling ctx.
 
-      %{tools: [%{name, group, enabled, visible, expires_at}], generated_at}
+      %{tools: [%{name, group, enabled, visible, expires_at, included}], generated_at}
   """
   def generate(ctx, at \\ DateTime.utc_now()) do
     states = effective_states(ctx, at)
@@ -44,7 +54,8 @@ defmodule NoizuPromptLingua.MCP.SessionManifest do
           group: group_id,
           enabled: Map.get(state, :enabled, true),
           visible: Map.get(state, :visible, true),
-          expires_at: Map.get(state, :expires_at)
+          expires_at: Map.get(state, :expires_at),
+          included: true
         }
       end)
       |> Enum.uniq_by(& &1.name)
@@ -65,20 +76,39 @@ defmodule NoizuPromptLingua.MCP.SessionManifest do
 
   # ---- registered method enumeration -----------------------------------------
 
-  # Every server in the MCPServers catalog (root = the bare-host aggregate
-  # server), expanded to concrete tool specs. Returns `{group_id, spec}` pairs;
-  # `group_id` is the owning MCP group (`sessions`, `tickets`, ...), `nil`
-  # resolving tools (root-only Discovery/NPL) fall back to `"root"`.
-  defp registered_specs(_ctx) do
-    Enum.flat_map(servers(), fn {group_id, server_mod} ->
-      specs = expand(server_mod)
+  # Scope-bound ctx (`/custom/:slug/mcp`): the universe is EXACTLY the custom
+  # endpoint's include set — `NoizuPromptLingua.MCP.Custom.custom_specs/1` — so
+  # manifest and endpoint cannot drift (parity by construction; the endpoint
+  # serves catalog_specs = custom_specs + Discovery/NPL, and the scope's tools
+  # are what manifest consumers must see). Root-aggregate ctx keeps the
+  # full-catalog walk: root + every MCPServers group, expanded to concrete tool
+  # specs with absent => enabled + visible defaults. Entries carry
+  # `included: true`: the client/ACL layers flip flags, they never shrink the
+  # universe. Returns `{group_id, spec}` pairs; `group_id` is the owning MCP
+  # group (`sessions`, `tickets`, ...), nil-resolving tools fall back to
+  # `"root"`.
+  defp registered_specs(ctx) do
+    if scope_bound?(ctx) do
+      Custom.custom_specs(ctx)
+      |> Enum.map(fn spec -> {group_for(spec.module, "root"), spec} end)
+    else
+      Enum.flat_map(servers(), fn {group_id, server_mod} ->
+        specs = expand(server_mod)
 
-      Enum.map(specs, fn spec ->
-        {group_for(spec.module, group_id), spec}
+        Enum.map(specs, fn spec ->
+          {group_for(spec.module, group_id), spec}
+        end)
       end)
-    end)
+    end
   rescue
     _ -> []
+  end
+
+  defp scope_bound?(ctx) do
+    case assigns(ctx)[:custom_scope_slug] || assigns(ctx)["custom_scope_slug"] do
+      slug when is_binary(slug) and slug != "" -> true
+      _ -> false
+    end
   end
 
   defp servers do
@@ -150,40 +180,17 @@ defmodule NoizuPromptLingua.MCP.SessionManifest do
   end
 
   @doc """
-  The calling client per §2: `%{id, kind: :api_key | :oauth_client, toolset_config}`.
-  API keys carry their stored `toolset_config`; OAuth clients (and anonymous /
-  system principals) have none yet (W8 wires per-client `toolset_config`).
+  The calling client per §2, resolved by `EffectiveToolset.client_for_ctx/1`:
+  `%{id, kind: :api_key | :oauth_client, toolset_config}` with the client's
+  stored `toolset_config` actually loaded (W8: OAuth clients ride the same
+  cascade as API keys), or nil when the request carries neither an active API
+  key nor an active OAuth client (ungated / system principal).
   """
-  def client_for(ctx) do
-    claims = claims(ctx)
+  def client_for(ctx), do: EffectiveToolset.client_for_ctx(ctx)
 
-    case claims["api_key_id"] do
-      api_key_id when is_binary(api_key_id) ->
-        %{
-          id: api_key_id,
-          kind: :api_key,
-          toolset_config: toolset_config(api_key_id)
-        }
+  defp claims(ctx),
+    do: get_in(ctx, [Access.key(:assigns, %{}), Access.key(:auth_claims, %{})]) || %{}
 
-      _ ->
-        %{
-          id: claims["oauth_client_id"] || claims["sub"],
-          kind: :oauth_client,
-          toolset_config: nil
-        }
-    end
-  end
-
-  defp toolset_config(api_key_id) do
-    case NoizuPromptLingua.Repo.get(NoizuPromptLingua.Schema.McpApiKey, api_key_id) do
-      %{toolset_config: config} when is_map(config) -> config
-      _ -> nil
-    end
-  rescue
-    _ -> nil
-  end
-
-  defp claims(ctx), do: get_in(ctx, [Access.key(:assigns, %{}), Access.key(:auth_claims, %{})]) || %{}
   defp assigns(ctx), do: Map.get(ctx || %{}, :assigns) || %{}
 
   @doc "The canonical name of this manifest tool itself."

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -831,9 +831,11 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   end
 
   # Scope rows feed the EffectiveToolset cascade (template / scope configs) via
-  # the ToolsetCache — drop the cache whenever a scope write lands.
+  # the ToolsetCache — drop the cache whenever a scope write lands. The cache
+  # bump + tools/list_changed broadcast are ONE best-effort step: connected
+  # clients re-list before serving a stale include set (N1 manifest parity).
   defp bump_cache_on_ok({:ok, _} = ok) do
-    NoizuPromptLingua.MCP.ToolsetCache.bump()
+    NoizuPromptLingua.MCP.Server.notify_toolset_changed()
     ok
   end
 

--- a/backend/lib/noizu_prompt_lingua/oauth/clients.ex
+++ b/backend/lib/noizu_prompt_lingua/oauth/clients.ex
@@ -62,9 +62,11 @@ defmodule NoizuPromptLingua.OAuth.Clients do
   end
 
   # Cached OAuth clients (ToolsetCache) feed the EffectiveToolset cascade —
-  # drop the cache whenever a client's config/status write lands.
+  # drop the cache whenever a client's config/status write lands. The cache
+  # bump + tools/list_changed broadcast are ONE best-effort step (N1 manifest
+  # parity): connected clients re-list before serving stale narrowing flags.
   defp tap_ok_bump_cache({:ok, _} = ok) do
-    NoizuPromptLingua.MCP.ToolsetCache.bump()
+    NoizuPromptLingua.MCP.Server.notify_toolset_changed()
     ok
   end
 
@@ -83,7 +85,10 @@ defmodule NoizuPromptLingua.OAuth.Clients do
 
     with :ok <- validate_redirects(redirect_uris) do
       client_id = "dcr_" <> random_id(16)
-      auth_method = attrs["token_endpoint_auth_method"] || attrs[:token_endpoint_auth_method] || "none"
+
+      auth_method =
+        attrs["token_endpoint_auth_method"] || attrs[:token_endpoint_auth_method] || "none"
+
       {secret, secret_hash} = maybe_secret(auth_method)
 
       cs =

--- a/backend/lib/noizu_prompt_lingua_web/controllers/admin_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/admin_controller.ex
@@ -1376,12 +1376,19 @@ defmodule NoizuPromptLinguaWeb.AdminController do
          {:ok, normalized} <- normalize_toolset_config(cfg) do
       changeset =
         case client do
-          %McpApiKey{} = key -> McpApiKey.toolset_changeset(key, %{"toolset_config" => normalized})
-          %OAuthClient{} = oc -> OAuthClient.changeset(oc, %{"toolset_config" => normalized})
+          %McpApiKey{} = key ->
+            McpApiKey.toolset_changeset(key, %{"toolset_config" => normalized})
+
+          %OAuthClient{} = oc ->
+            OAuthClient.changeset(oc, %{"toolset_config" => normalized})
         end
 
       case NoizuPromptLingua.Repo.update(changeset) do
         {:ok, updated} ->
+          # This admin writer bypasses the context helpers, so fire the
+          # invalidation + tools/list_changed broadcast here (N1 manifest
+          # parity) — best-effort, never fails the write.
+          NoizuPromptLingua.MCP.Server.notify_toolset_changed()
           conn |> put_status(:ok) |> json(%{toolset_config: updated.toolset_config || %{}})
 
         {:error, %Ecto.Changeset{} = cs} ->
@@ -1404,13 +1411,17 @@ defmodule NoizuPromptLinguaWeb.AdminController do
 
   defp fetch_client(kind, id) when is_binary(id) do
     case @client_kinds[kind] do
-      :api_key -> NoizuPromptLingua.Repo.get(McpApiKey, id)
+      :api_key ->
+        NoizuPromptLingua.Repo.get(McpApiKey, id)
+
       # The W7 editor route may carry either the row uuid or the public
       # client_id string (DCR identifier).
       :oauth_client ->
         NoizuPromptLingua.Repo.get(OAuthClient, id) ||
           NoizuPromptLingua.Repo.one(from c in OAuthClient, where: c.client_id == ^id)
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
 
@@ -1503,7 +1514,8 @@ defmodule NoizuPromptLinguaWeb.AdminController do
         with {:ok, flags} <- bool_fields(entry, ["disabled", "hidden"]),
              {:ok, overrides} <- string_fields(entry, ["name_override", "description_override"]),
              {:ok, window} <- window_fields(entry) do
-          {:ok, flags |> Map.merge(overrides) |> Window.normalize_entry(entry) |> Map.merge(window)}
+          {:ok,
+           flags |> Map.merge(overrides) |> Window.normalize_entry(entry) |> Map.merge(window)}
         end
     end
   end
@@ -1564,7 +1576,9 @@ defmodule NoizuPromptLinguaWeb.AdminController do
   end
 
   def create_acl_group(conn, %{"group" => attrs}) do
-    case Acl.create_group(filter_nils(%{"name" => attrs["name"], "description" => attrs["description"]})) do
+    case Acl.create_group(
+           filter_nils(%{"name" => attrs["name"], "description" => attrs["description"]})
+         ) do
       {:ok, group} ->
         conn |> put_status(:created) |> json(%{group: acl_group_json(group, [])})
 

--- a/backend/test/noizu_prompt_lingua/mcp/session_manifest_parity_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/session_manifest_parity_test.exs
@@ -1,0 +1,243 @@
+defmodule NoizuPromptLingua.MCP.SessionManifestParityTest do
+  @moduledoc """
+  N1 manifest parity: the Session_Manifest universe must match what the calling
+  endpoint actually serves, and the calling client's toolset_config must flow
+  into the manifest's state resolution.
+
+    * scope-bound ctx — the universe IS `MCP.Custom.custom_specs/1` (the
+      endpoint's include set); the 14-vs-270 incident class (manifest advertises
+      the full catalog while the endpoint serves a narrow include set) is
+      closed by construction.
+    * `client_for/1` delegates to `EffectiveToolset.client_for_ctx/1` — OAuth
+      clients carry their stored `toolset_config` (W8), not the stale pre-W8 nil.
+    * root-aggregate ctx keeps the full-catalog enumeration.
+    * a client-layer disable shows `enabled: false` in the manifest while the
+      tool STAYS in the universe with `included: true` (client layers flip
+      flags, never shrink the universe).
+  """
+
+  use NoizuPromptLingua.DataCase, async: false
+
+  alias Noizu.MCP.Ctx
+  alias Noizu.MCP.Server.Features.Tools
+  alias NoizuPromptLingua.MCP.Custom
+  alias NoizuPromptLingua.MCP.EffectiveToolset
+  alias NoizuPromptLingua.MCP.SessionManifest
+  alias NoizuPromptLingua.MCPApiKeys
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.OAuth.Clients
+
+  @group "tickets"
+  @tool "Ticket_List"
+  @ungrouped_tool "Session_Create"
+
+  # ---- helpers -----------------------------------------------------------------
+
+  defp create_scope(slug, groups) do
+    {:ok, scope} =
+      MCPCustomScopes.create(%{
+        "slug" => slug,
+        "name" => slug,
+        "kind" => "custom",
+        "config" => %{"groups" => groups}
+      })
+
+    scope
+  end
+
+  defp scope_ctx(slug, claims \\ %{}) do
+    %Ctx{
+      server: NoizuPromptLingua.MCP.Custom,
+      assigns: %{custom_scope_slug: slug, auth_claims: claims}
+    }
+  end
+
+  defp canonical_names(names) when is_list(names),
+    do: names |> Enum.map(&SessionManifest.canonical_name/1) |> Enum.sort()
+
+  defp manifest_names(manifest), do: manifest.tools |> Enum.map(& &1.name) |> Enum.sort()
+
+  defp listing_names(ctx, specs \\ nil) do
+    (specs || Custom.custom_specs(ctx))
+    |> EffectiveToolset.apply_to_specs(ctx, nil)
+    |> Enum.map(&SessionManifest.canonical_name(&1.definition.name))
+    |> Enum.sort()
+  end
+
+  # D1/W8: OAuth clients flow through the same cascade as API keys. The test
+  # schema helper keeps the oauth tables present; a real narrowing row (non-empty
+  # groups) is persisted so client_for_ctx actually loads toolset_config.
+  defp oauth_client_with(config) do
+    NoizuPromptLingua.OAuthTestSchema.ensure!()
+    uniq = System.unique_integer([:positive])
+
+    {:ok, reg} =
+      Clients.register(%{
+        "client_name" => "manifest-parity-#{uniq}",
+        "redirect_uris" => ["http://127.0.0.1:9876/callback"],
+        "token_endpoint_auth_method" => "none"
+      })
+
+    client = Clients.get_active(reg["client_id"])
+
+    {:ok, client} = Clients.update_toolset_config(client, config)
+    client
+  end
+
+  # Mirror of SessionManifest's root-aggregate enumeration (root + every
+  # MCPServers group), used to pin the root-ctx universe exactly.
+  defp full_catalog_names do
+    group_servers =
+      Enum.flat_map(MCPServers.all(), fn %{id: id} ->
+        case MCPServers.server_module(id) do
+          nil -> []
+          mod -> [{id, mod}]
+        end
+      end)
+
+    ([{"root", NoizuPromptLingua.MCP}] ++ group_servers)
+    |> Enum.flat_map(fn {_gid, mod} ->
+      if Code.ensure_loaded?(mod) and function_exported?(mod, :__mcp__, 1) do
+        mod.__mcp__(:tools) |> Tools.expand()
+      else
+        []
+      end
+    end)
+    |> MapSet.new(&SessionManifest.canonical_name(&1.definition.name))
+  end
+
+  # ---- (a) scope-bound universe parity ------------------------------------------
+
+  describe "scope-bound ctx" do
+    test "manifest universe == custom_specs == apply_to_specs visible output" do
+      create_scope("parity-a-01", %{@group => %{"tools" => %{}}})
+      ctx = scope_ctx("parity-a-01")
+
+      manifest = SessionManifest.generate(ctx)
+      spec_names = canonical_names(Enum.map(Custom.custom_specs(ctx), & &1.definition.name))
+
+      # The manifest's universe is EXACTLY the endpoint's include set — a tool
+      # the scope does not include (any other group's tools) never appears.
+      assert manifest_names(manifest) == spec_names
+      assert Enum.all?(manifest.tools, & &1.included)
+      refute @ungrouped_tool in manifest_names(manifest)
+
+      # And the endpoint's own listing filter keeps every one of them visible.
+      assert listing_names(ctx) == spec_names
+    end
+
+    test "manifest names are canonical underscore, entries keep the §5 shape" do
+      create_scope("parity-a-02", %{@group => %{"tools" => %{}}})
+      ctx = scope_ctx("parity-a-02")
+
+      manifest = SessionManifest.generate(ctx)
+
+      for tool <- manifest.tools do
+        refute String.contains?(tool.name, ".")
+        assert is_binary(tool.group)
+        assert is_boolean(tool.enabled) and is_boolean(tool.visible)
+        assert tool.included == true
+      end
+
+      assert Enum.any?(manifest.tools, &(&1.name == @tool))
+    end
+  end
+
+  # ---- (b) client_for/1 ≡ client_for_ctx/1 (OAuth toolset_config loaded) --------
+
+  describe "client_for/1 delegation" do
+    test "OAuth-client ctx: identical to client_for_ctx/1 with the stored config loaded" do
+      client =
+        oauth_client_with(%{
+          "groups" => %{
+            @group => %{"tools" => %{@tool => %{"disabled" => true}}}
+          }
+        })
+
+      ctx = scope_ctx("parity-b-01", %{"client_id" => client.client_id})
+
+      assert SessionManifest.client_for(ctx) == EffectiveToolset.client_for_ctx(ctx)
+
+      # Not the stale pre-W8 shape: the OAuth client's narrowing is LOADED.
+      assert %{id: id, kind: :oauth_client, toolset_config: config} =
+               SessionManifest.client_for(ctx)
+
+      assert is_binary(id)
+      assert is_map(config) and config != %{}
+    end
+
+    test "api-key ctx: identical to client_for_ctx/1, key config carried" do
+      uniq = System.unique_integer([:positive])
+
+      user =
+        %NoizuPromptLingua.Schema.Users.User{
+          id: Ecto.UUID.generate(),
+          email: "parity-key-#{uniq}@example.com",
+          user_name: "paritykey#{uniq}",
+          handle: "pk#{uniq}",
+          status: :active
+        }
+        |> NoizuPromptLingua.Repo.insert!()
+
+      {:ok, key, _raw} =
+        MCPApiKeys.generate_api_key(user.id, "parity",
+          toolset_config: %{"groups" => %{@group => %{"disabled" => true}}}
+        )
+
+      ctx = scope_ctx("parity-b-02", %{"api_key_id" => key.id})
+
+      assert SessionManifest.client_for(ctx) == EffectiveToolset.client_for_ctx(ctx)
+      assert %{kind: :api_key, toolset_config: config} = SessionManifest.client_for(ctx)
+      assert is_map(config) and config != %{}
+    end
+  end
+
+  # ---- (c) root-aggregate ctx keeps the full catalog ------------------------------
+
+  describe "root-aggregate ctx" do
+    test "full-catalog enumeration with included: true for served tools" do
+      ctx = %Ctx{server: NoizuPromptLingua.MCP, assigns: %{}}
+      manifest = SessionManifest.generate(ctx)
+
+      assert manifest.tools != []
+      assert MapSet.new(manifest_names(manifest)) == full_catalog_names()
+      assert Enum.all?(manifest.tools, & &1.included)
+
+      # Representatives from the root aggregate (Discovery/NPL) and the groups.
+      names = manifest_names(manifest)
+      assert "ToolSummary" in names
+      assert "Session_Create" in names
+      assert "Ticket_List" in names
+    end
+  end
+
+  # ---- (d) client-layer disable stays in the universe ------------------------------
+
+  describe "client-layer disable" do
+    test "enabled: false in the manifest, tool stays included: true — 14-vs-270 class closed" do
+      create_scope("parity-d-01", %{@group => %{"tools" => %{}}})
+
+      client =
+        oauth_client_with(%{
+          "groups" => %{
+            @group => %{"tools" => %{@tool => %{"disabled" => true}}}
+          }
+        })
+
+      ctx = scope_ctx("parity-d-01", %{"client_id" => client.client_id})
+
+      manifest = SessionManifest.generate(ctx)
+      entry = Enum.find(manifest.tools, &(&1.name == @tool))
+
+      # The disable shows, and the tool REMAINS in the universe (client layers
+      # flip flags, never shrink the universe).
+      assert entry.enabled == false
+      assert entry.included == true
+
+      # The endpoint's listing drops it — the manifest REPORTS the disable
+      # instead of silently diverging from (or flooding past) the endpoint.
+      refute @tool in listing_names(ctx)
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua/mcp/session_manifest_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/session_manifest_test.exs
@@ -26,14 +26,18 @@ defmodule NoizuPromptLingua.MCP.SessionManifestTest do
     assert %DateTime{} = generated_at
     assert tools != []
 
-    # No dotted names ever escape (§4); each entry carries the §5 shape.
+    # No dotted names ever escape (§4); each entry carries the §5 shape
+    # (+ the N1 `included` flag).
     for tool <- tools do
       refute String.contains?(tool.name, ".")
       assert is_binary(tool.group) or is_nil(tool.group)
+
       assert MapSet.subset?(
                MapSet.new(Map.keys(tool)),
-               MapSet.new([:name, :group, :enabled, :visible, :expires_at])
+               MapSet.new([:name, :group, :enabled, :visible, :expires_at, :included])
              )
+
+      assert tool.included == true
     end
 
     names = Enum.map(tools, & &1.name)
@@ -91,9 +95,9 @@ defmodule NoizuPromptLingua.MCP.SessionManifestTest do
       EffectiveToolsetStub.set(%{})
       _ = Manifest.call(%{}, bare_ctx())
 
-      # No api_key_id claim → oauth-style client, no toolset config.
-      client = EffectiveToolsetStub.last_client()
-      assert client == %{id: nil, kind: :oauth_client, toolset_config: nil}
+      # No api_key_id / client_id claim => client_for_ctx resolves nil (ungated,
+      # system principal) — N1: client_for/1 delegates to client_for_ctx/1.
+      assert EffectiveToolsetStub.last_client() == nil
     end
   end
 
@@ -130,6 +134,7 @@ defmodule NoizuPromptLingua.MCP.SessionManifestTest do
       # Missing group re-added with the manifest seed; sessions gains the tool.
       assert Map.has_key?(groups["pubsub"]["tools"], @manifest) or
                Map.has_key?(groups["sessions"]["tools"], @manifest)
+
       assert Map.has_key?(groups["sessions"]["tools"], @manifest)
 
       # An explicit owner override on the manifest tool survives the heal.

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -847,6 +847,8 @@ function AdminMcpCustomScopesInner() {
             <h3 style={{ margin: '0 0 0.5rem', fontSize: 13, fontWeight: 700 }}>Restrict tools</h3>
             <span className="sg-field__hint" style={{ display: 'block', marginBottom: '0.5rem' }}>
               Per-client overrides layer on top of the scope config (absent = enabled + visible).
+              Narrowing only — clients never ADD tools to an endpoint. Edit the scope&apos;s
+              include-set to add groups.
             </span>
             <ToolTogglesGrid
               sections={clientToggleGroups}


### PR DESCRIPTION
## Summary

Workstream N1 (R6 parity fixes) against pinned hex noizu_mcp 0.1.5 — no lib/path-dep changes.

- **Scope-bound manifest universe** (`session_manifest.ex`): when the ctx carries `custom_scope_slug`, `generate/2` enumerates `MCP.Custom.custom_specs/1` as THE universe — parity by construction, closing the 14-vs-270 incident class (manifest advertising the full catalog while the endpoint serves a narrow include set). Root-aggregate ctx keeps the full-catalog enumeration (root + all `MCPServers` groups, absent => enabled+visible defaults). Every entry emits `included: true` ("in the endpoint's include set"); client/ACL layers flip `enabled`/`visible` but never shrink the universe.
- **`client_for/1` delegates to `EffectiveToolset.client_for_ctx/1`** — OAuth clients now carry their stored `toolset_config` (W8) in manifest state resolution instead of the stale pre-W8 nil; anonymous/system principals resolve nil (ungated).
- **Write-path invalidation** — new `NoizuPromptLingua.MCP.Server.notify_toolset_changed/0`: bumps `ToolsetCache` AND fans out `notifications/tools/list_changed` to every NPL server (root aggregate, Custom, all group servers; `notify_changed/1` is generated per server module by the `use Noizu.MCP.Server` macro). Best-effort: per-server rescue + `Logger.warning`, never fails the write. Wired into:
  - `MCPCustomScopes` create/update/delete (via `bump_cache_on_ok/1`)
  - `MCPApiKeys` key writes (update/revoke/copy_toolset_from via `bump_cache_on_ok/1`)
  - `OAuth.Clients` toolset_config/revoke (via `tap_ok_bump_cache/1`)
  - `AdminController.update_client_toolset_config` — **this writer bypasses the context helpers and previously fired neither bump nor notify**; it now calls the helper directly.
- **Admin scopes UI**: "Restrict tools" (client-permissions editor) caption: "Narrowing only — clients never ADD tools to an endpoint. Edit the scope's include-set to add groups."

## Test evidence

New `backend/test/noizu_prompt_lingua/mcp/session_manifest_parity_test.exs` (6 tests):
- (a) scope-bound manifest names == `custom_specs/1` names == `apply_to_specs/3` visible output; tools outside the include set absent from the manifest
- (b) `client_for/1` == `client_for_ctx/1` for OAuth-client ctx with a real stored narrowing (config actually loaded, non-nil)
- (c) root ctx: manifest universe == exact full-catalog enumeration, all `included: true`
- (d) client-layer disable: `enabled: false` in the manifest while the tool stays in the universe `included: true`, and the endpoint listing drops it

Scoped suites (per repo policy), isolated test DB (MIX_TEST_PARTITION):
```
session_manifest_test + session_manifest_parity_test + effective_toolset(_acl/_matrix)
+ custom_scope + custom_key_toolset + scope_packaging + key_toolsets(_guard) + toolset_cache
Result: 134 passed
```
`mix compile` clean (only pre-existing type warnings in untouched domain files); `mix format` applied to touched files.

## Notes / deviations

- `session_manifest_test.exs`: shape assertion gains `:included` (directed shape change); the bare-ctx stub assertion now expects `nil` (the W8-correct `client_for_ctx` resolution for system principals) in place of the stale pre-W8 client map.
- Formatter re-wrapped a few adjacent pre-existing clauses in `admin_controller.ex` (`mix format` gate on touched files).
- Frontend: no lint/typecheck script exists in `frontend/package.json` — nothing scoped to run; change is a text-only hint addition.
- Fresh-DB `mix ecto.migrate` fails at migration 20260813000000 (`user_sessions` referenced before creation) — pre-existing on base, reproduced independent of this branch; tests ran against a cloned migrated DB.

Co-Authored-By: Loom <loom@therobotlives.com>