### PR TITLE
N2a: tool-set storage + profiles-as-data (PRD-N2)

### DIFF
--- a/backend/db/changelog/083-mcp-tool-sets.yaml
+++ b/backend/db/changelog/083-mcp-tool-sets.yaml
@@ -1,0 +1,49 @@
+databaseChangeLog:
+  # MCP tool sets (PRD-N2 FR-2A-1): NPL-owned durable storage for named tool
+  # sets — the N2a sibling of mcp_custom_scopes. One org-wide slug namespace
+  # across all audience shapes (org-set / project-set / group-set — R4), a
+  # closed-vocabulary `config` jsonb (validated in the app layer), and a
+  # whitelisted `settings` jsonb. Rows start empty in prod until N3 serves
+  # sets; profiles are virtual (code-only, never rows).
+  #
+  # FK targets verified: organizations, projects, groups (authz — table name
+  # confirmed from schema/authz/group.ex:6). Style follows 070a: raw SQL +
+  # tableExists guard so a manually pre-applied table MARK_RANs.
+  - changeSet:
+      id: 083a-create-mcp-tool-sets
+      author: tobor-locker
+      preConditions:
+        - onFail: MARK_RAN
+        - onFailMessage: mcp_tool_sets already exists (prior apply)
+        - not:
+            tableExists:
+              tableName: mcp_tool_sets
+      changes:
+        - sql:
+            sql: |
+              CREATE TABLE mcp_tool_sets (
+                id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+                project_id uuid REFERENCES projects (id) ON DELETE CASCADE,
+                group_id uuid REFERENCES groups (id) ON DELETE CASCADE,
+                slug varchar(64) NOT NULL,
+                display_name varchar(200),
+                description text,
+                source varchar(20) NOT NULL DEFAULT 'custom' CHECK (source IN ('custom', 'clone')),
+                source_profile varchar(64),
+                config jsonb NOT NULL DEFAULT '{}'::jsonb,
+                settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+                expires_at timestamptz,
+                is_active boolean NOT NULL DEFAULT true,
+                inserted_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now()
+              );
+              ALTER TABLE mcp_tool_sets
+                ADD CONSTRAINT mcp_tool_sets_org_slug_key UNIQUE (organization_id, slug);
+              CREATE INDEX mcp_tool_sets_org_idx ON mcp_tool_sets (organization_id);
+              CREATE INDEX mcp_tool_sets_proj_idx ON mcp_tool_sets (project_id);
+              CREATE INDEX mcp_tool_sets_group_idx ON mcp_tool_sets (group_id);
+      rollback:
+        - sql:
+            sql: |
+              DROP TABLE IF EXISTS mcp_tool_sets;

--- a/backend/db/changelog/db.changelog-master.yaml
+++ b/backend/db/changelog/db.changelog-master.yaml
@@ -250,3 +250,6 @@ databaseChangeLog:
   - include:
       file: 082-org-slug-uniqueness.yaml
       relativeToChangelogFile: true
+  - include:
+      file: 083-mcp-tool-sets.yaml
+      relativeToChangelogFile: true

--- a/backend/lib/noizu_prompt_lingua/mcp/tool_sets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/tool_sets.ex
@@ -1,0 +1,407 @@
+defmodule NoizuPromptLingua.MCP.ToolSets do
+  @moduledoc """
+  Context for durable MCP tool sets (`Schema.MCPToolSet`, PRD-N2 §4.1): CRUD +
+  deactivate + clone, request-path lookup, and the `to_overrides/1` pure
+  translator from the closed-vocabulary `config` jsonb to normalized override
+  ops.
+
+  N2a seams (deliberately thin — both FLIP at N2b, one-line wraps):
+
+    * `get_for_request/2` returns `%MCPToolSet{} | nil`; at PRD-3 time it
+      returns the assembled lib toolset.
+    * `assemble_custom/2` returns a plain effective-view map; at N2b it builds
+      `%Noizu.MCP.Toolset.Custom{}` via `to_overrides/1`.
+    * `to_overrides/1` elements are `%{op | target | value}` maps; at N2b they
+      wrap into `%Noizu.MCP.Toolset.Override{}`.
+
+  Every write fires `MCP.Server.notify_toolset_changed/0` (best-effort, N1
+  wiring) so live connections re-list before serving a stale set.
+  """
+
+  import Ecto.Query, only: [from: 2]
+  require Logger
+
+  alias NoizuPromptLingua.MCP.Server
+  alias NoizuPromptLingua.MCP.Toolsets.Profiles
+  alias NoizuPromptLingua.Organizations.SlugBackfill
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.MCPToolSet
+
+  @doc """
+  Create a set. `opts[:actor_id]` is stamped into `settings.updated_by`
+  (in-row audit, mirroring the carry_audit precedent — no new audit table).
+  """
+  def create(attrs, opts \\ []) do
+    %MCPToolSet{}
+    |> MCPToolSet.changeset(stamp_actor(attrs, opts))
+    |> Repo.insert()
+    |> notify_on_ok(fn set -> "tool_set.created slug=#{set.slug} org=#{set.organization_id}" end)
+  end
+
+  @doc """
+  Partial update: config/settings/display_name/description/expires_at/is_active
+  only — identity fields (slug/org/project/group/source) are create-only (see
+  `Schema.MCPToolSet.changeset/3`).
+  """
+  def update(set_or_id, attrs, opts \\ [])
+
+  def update(%MCPToolSet{} = tool_set, attrs, opts) do
+    tool_set
+    |> MCPToolSet.changeset(stamp_actor(attrs, opts), :update)
+    |> Repo.update()
+    |> notify_on_ok(fn set -> "tool_set.updated slug=#{set.slug} org=#{set.organization_id}" end)
+  end
+
+  def update(id, attrs, opts) when is_binary(id) do
+    case get(id) do
+      nil -> {:error, :not_found}
+      tool_set -> update(tool_set, attrs, opts)
+    end
+  end
+
+  @doc "Soft-kill (R8): `is_active: false`. Deactivated sets vanish from the request path."
+  def deactivate(set_or_id, opts \\ [])
+
+  def deactivate(%MCPToolSet{} = tool_set, opts) do
+    tool_set
+    |> MCPToolSet.changeset(stamp_actor(%{"is_active" => false}, opts), :update)
+    |> Repo.update()
+    |> notify_on_ok(fn set ->
+      "tool_set.deactivated slug=#{set.slug} org=#{set.organization_id}"
+    end)
+  end
+
+  def deactivate(id, opts) when is_binary(id) do
+    case get(id) do
+      nil -> {:error, :not_found}
+      tool_set -> deactivate(tool_set, opts)
+    end
+  end
+
+  @doc """
+  Clone a profile slug or an existing set into a new, fully editable row.
+
+    * from a profile — `source: "clone"`, `source_profile` = the slug, and a
+      deep-copied allowlist config `%{"groups" => %{g => %{"enabled" => true}}}`
+      over the profile's expanded groups (FR-2A-7).
+    * from a set — `source: "clone"` with the set's config deep-copied and
+      provenance in `settings.cloned_from` (open question 4; `source_profile`
+      stays nil).
+
+  The clone's slug auto-suggests `<source-slug>-copy`, suffixing `-2`, `-3`, …
+  on collision within the org. Required attrs: `organization_id` (plus optional
+  `project_id`/`group_id`/`display_name`/`description`/`expires_at`).
+  """
+  def clone(source, attrs, opts \\ [])
+
+  def clone(source, attrs, opts) when is_binary(source) do
+    case Profiles.get(source) do
+      nil ->
+        {:error, :unknown_profile}
+
+      profile ->
+        config = %{"groups" => Map.new(profile.groups, fn g -> {g, %{"enabled" => true}} end)}
+
+        source
+        |> clone_attrs(attrs, config)
+        |> Map.merge(%{
+          "source" => "clone",
+          "source_profile" => source,
+          "settings" => %{}
+        })
+        |> create_from_clone(opts, source)
+    end
+  end
+
+  def clone(%MCPToolSet{} = source, attrs, opts) do
+    source.slug
+    |> clone_attrs(attrs, deep_copy(source.config))
+    |> Map.merge(%{
+      "source" => "clone",
+      "source_profile" => nil,
+      "settings" => %{"cloned_from" => source.slug}
+    })
+    |> create_from_clone(opts, source.slug)
+  end
+
+  def clone(_, _, _), do: {:error, :invalid_source}
+
+  defp create_from_clone(attrs, opts, source_slug) do
+    attrs =
+      attrs
+      |> Map.put("slug", suggest_slug(attrs["organization_id"], attrs["slug"]))
+      |> stamp_actor(opts)
+
+    %MCPToolSet{}
+    |> MCPToolSet.changeset(attrs)
+    |> Repo.insert()
+    |> notify_on_ok(fn set ->
+      "tool_set.cloned slug=#{set.slug} from=#{source_slug} org=#{set.organization_id}"
+    end)
+  end
+
+  # Merge caller attrs over clone defaults; caller-provided display fields and
+  # audience shape win, the derived "<slug>-copy" naming is a fallback only.
+  defp clone_attrs(source_slug, attrs, config) do
+    attrs = Map.new(attrs, fn {k, v} -> {to_string(k), v} end)
+
+    %{
+      "organization_id" => Map.get(attrs, "organization_id"),
+      "project_id" => Map.get(attrs, "project_id"),
+      "group_id" => Map.get(attrs, "group_id"),
+      "slug" => "#{source_slug}-copy",
+      "display_name" => Map.get(attrs, "display_name") || "#{source_slug} copy",
+      "description" => Map.get(attrs, "description"),
+      "config" => config,
+      "expires_at" => Map.get(attrs, "expires_at")
+    }
+  end
+
+  # First free "<base>-copy" / "<base>-copy-N" slug within the org.
+  defp suggest_slug(nil, _base), do: nil
+
+  defp suggest_slug(org_id, base) do
+    candidate = SlugBackfill.slugify(base) || "set-copy"
+    taken = org_slugs(org_id)
+    suggest(candidate, taken, 1)
+  end
+
+  defp suggest(candidate, taken, 1) do
+    if MapSet.member?(taken, candidate), do: suggest(candidate, taken, 2), else: candidate
+  end
+
+  defp suggest(base, taken, n) do
+    candidate = "#{base}-#{n}"
+
+    if MapSet.member?(taken, candidate) do
+      suggest(base, taken, n + 1)
+    else
+      candidate
+    end
+  end
+
+  # Every slug in the org (all shapes, active or not — the namespace is
+  # org-wide per R4).
+  defp org_slugs(org_id) do
+    Repo.all(
+      from(s in MCPToolSet,
+        where: s.organization_id == ^org_id,
+        select: s.slug
+      )
+    )
+    |> MapSet.new()
+  end
+
+  @doc "Active sets for an org, every audience shape, oldest first."
+  def list_for_org(org_id) when is_binary(org_id) do
+    Repo.all(
+      from(s in MCPToolSet,
+        where: s.organization_id == ^org_id and s.is_active == true,
+        order_by: [asc: s.inserted_at, asc: s.slug]
+      )
+    )
+  end
+
+  def list_for_org(_), do: []
+
+  def get(id) when is_binary(id), do: Repo.get(MCPToolSet, id)
+  def get(_), do: nil
+
+  @doc """
+  Resolve by (organization_id, slug) — the org-addressed URL form. Slug
+  matching is normalized case-insensitively, mirroring
+  `MCPCustomScopes.get_by_org_and_slug/2`; a slug can never resolve outside its
+  org. Not active-filtered (admin path — the request path uses
+  `get_for_request/2`).
+  """
+  def get_by_org_and_slug(org_id, slug) when is_binary(slug) do
+    Repo.get_by(MCPToolSet, organization_id: org_id, slug: normalize_slug(slug))
+  end
+
+  def get_by_org_and_slug(_, _), do: nil
+
+  @doc """
+  Request-path lookup (active-only + unexpired): nil for inactive sets, expired
+  sets, and sets of other orgs (AC-2A-8). THIN in N2a — returns
+  `%MCPToolSet{} | nil`; the return type flips to the assembled lib toolset at
+  PRD-3 time.
+  """
+  def get_for_request(org_id, slug) when is_binary(slug) do
+    case get_by_org_and_slug(org_id, slug) do
+      %MCPToolSet{is_active: true, expires_at: nil} = tool_set ->
+        tool_set
+
+      %MCPToolSet{is_active: true, expires_at: expires_at} = tool_set ->
+        if DateTime.compare(expires_at, DateTime.utc_now()) == :gt do
+          tool_set
+        else
+          nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  def get_for_request(_, _), do: nil
+
+  @doc """
+  Effective view for serving — THIN in N2a (normalized config + overrides +
+  defaulted settings); at N2b this returns `%Noizu.MCP.Toolset.Custom{}` built
+  via `to_overrides/1` (FR-2B-4). `ctx` is unused in N2a and kept for the
+  signature seam.
+  """
+  def assemble_custom(%MCPToolSet{} = tool_set, _ctx \\ nil) do
+    settings = tool_set.settings || %{}
+
+    %{
+      slug: tool_set.slug,
+      display_name: tool_set.display_name || tool_set.slug,
+      source: tool_set.source,
+      source_profile: tool_set.source_profile,
+      is_active: tool_set.is_active,
+      config: tool_set.config,
+      overrides: to_overrides(tool_set.config),
+      settings: %{
+        "allow_api_keys" => Map.get(settings, "allow_api_keys", true),
+        "description_verbosity" => Map.get(settings, "description_verbosity"),
+        "instructions" => Map.get(settings, "instructions")
+      }
+    }
+  end
+
+  @doc """
+  Pure translator (FR-2A-4): valid config map → normalized override ops, one
+  per configured change, stable order (groups sorted → tools sorted → args
+  sorted; within a tool: enabled ops, name, description; within an arg, PRD-1
+  §4.5 vocabulary order: prune_enum, hide_field, rename_field, pin_default,
+  set_arg_description).
+
+    * tool `enabled: false` ⇒ `:set_visible false` + `:set_callable false`
+      (explicit `enabled: true` is the default state — no ops)
+    * tool `name` / `description` ⇒ `:set_name` / `:set_description`
+    * arg `enum_remove` / `hide` / `rename` / `default` / `description` ⇒
+      `:prune_enum` / `:hide_field` / `:rename_field` / `:pin_default` /
+      `:set_arg_description`
+
+  Group-level `enabled` is include-metadata (the N2b allowlist), not an
+  override op. Purity: no DB/ETS/env access; same input ⇒ same output. N2b
+  wraps each element into `%Noizu.MCP.Toolset.Override{}`.
+  """
+  def to_overrides(config) when is_map(config) do
+    config
+    |> Map.get("groups", %{})
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.flat_map(fn {group_id, group_cfg} ->
+      tools = group_cfg |> Map.get("tools", %{}) |> Enum.sort_by(&elem(&1, 0))
+
+      Enum.flat_map(tools, fn {tool_name, tool_cfg} ->
+        tool_ops(group_id, tool_name, tool_cfg) ++ arg_ops(group_id, tool_name, tool_cfg)
+      end)
+    end)
+  end
+
+  def to_overrides(_), do: []
+
+  defp tool_ops(group_id, tool_name, tool_cfg) do
+    target = %{group: group_id, tool: tool_name}
+
+    enabled_ops =
+      case Map.get(tool_cfg, "enabled") do
+        false ->
+          [
+            %{op: :set_visible, target: target, value: false},
+            %{op: :set_callable, target: target, value: false}
+          ]
+
+        _ ->
+          []
+      end
+
+    name_ops =
+      case Map.get(tool_cfg, "name") do
+        nil -> []
+        name -> [%{op: :set_name, target: target, value: name}]
+      end
+
+    description_ops =
+      case Map.get(tool_cfg, "description") do
+        nil -> []
+        description -> [%{op: :set_description, target: target, value: description}]
+      end
+
+    enabled_ops ++ name_ops ++ description_ops
+  end
+
+  defp arg_ops(group_id, tool_name, tool_cfg) do
+    args = tool_cfg |> Map.get("args", %{}) |> Enum.sort_by(&elem(&1, 0))
+
+    Enum.flat_map(args, fn {arg_name, arg_cfg} ->
+      target = %{group: group_id, tool: tool_name, arg: arg_name}
+
+      []
+      |> append_op(Map.get(arg_cfg, "enum_remove"), :prune_enum, target)
+      |> append_op(Map.get(arg_cfg, "hide"), :hide_field, target)
+      |> append_op(Map.get(arg_cfg, "rename"), :rename_field, target)
+      |> append_op(Map.get(arg_cfg, "default"), :pin_default, target)
+      |> append_op(Map.get(arg_cfg, "description"), :set_arg_description, target)
+    end)
+  end
+
+  defp append_op(ops, nil, _op, _target), do: ops
+  defp append_op(ops, value, op, target), do: ops ++ [%{op: op, target: target, value: value}]
+
+  # ---- helpers ----
+
+  defp get_attr(attrs, key) when is_map(attrs) do
+    Map.get(attrs, key, Map.get(attrs, Atom.to_string(key)))
+  end
+
+  defp deep_copy(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_atom(k) -> {Atom.to_string(k), deep_copy(v)}
+      {k, v} -> {k, deep_copy(v)}
+    end)
+  end
+
+  defp deep_copy(other), do: other
+
+  defp normalize_slug(slug) when is_binary(slug) do
+    slug |> String.trim() |> String.downcase()
+  end
+
+  # In-row audit stamp (carry_audit precedent): record the acting user in the
+  # row's settings jsonb. No new audit table (PRD open question, out of scope).
+  defp stamp_actor(attrs, opts) do
+    case Keyword.get(opts, :actor_id) do
+      nil ->
+        attrs
+
+      actor_id when is_binary(actor_id) ->
+        settings =
+          attrs
+          |> get_attr(:settings)
+          |> Kernel.||(%{})
+          |> stringify_map()
+          |> Map.put("updated_by", actor_id)
+
+        Map.new(attrs, fn {k, v} -> {to_string(k), v} end)
+        |> Map.put("settings", settings)
+    end
+  end
+
+  defp stringify_map(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  # Best-effort write-path propagation (N1 wiring): bump ToolsetCache +
+  # broadcast tools/list_changed on every NPL MCP server. A failure here must
+  # never fail the write (mirror of MCPCustomScopes.bump_cache_on_ok).
+  defp notify_on_ok({:ok, tool_set} = ok, event_fun) do
+    Logger.info("[ToolSets] #{event_fun.(tool_set)}")
+    Server.notify_toolset_changed()
+    ok
+  end
+
+  defp notify_on_ok(other, _event_fun), do: other
+end

--- a/backend/lib/noizu_prompt_lingua/mcp/toolsets/profiles.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/toolsets/profiles.ex
@@ -1,0 +1,165 @@
+defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
+  @moduledoc """
+  The 5 built-in capability profiles as pure DATA (PRD-N2 FR-2A-8, Decision 4).
+
+  Profiles are VIRTUAL: never backed by `mcp_tool_sets` rows and never seeded —
+  their slugs are reserved (see `NoizuPromptLingua.Schema.MCPToolSet`) so no set
+  can shadow them. `full` is exactly `MCPServers.customizable()`; the four
+  capability profiles (`agent-ops`, `pm-dev`, `content`, `comms`) derive their
+  group membership from the compile-time `@profile_groups` annotation registry
+  below — membership is CODE, immutable, and a new domain group auto-joins the
+  profiles listed in its annotation (a brand-new group id needs one
+  `@profile_groups` entry).
+
+  N2a ships profiles as DATA only. N2b (gated on lib PRD-3/PRD-4) adds
+  `custom/1`, which turns a profile into an immutable
+  `%Noizu.MCP.Toolset.Custom{}` — the seam is deliberately not built here.
+
+  The `browser` group participates in `full` (it is in `customizable()`) but
+  carries no capability-profile annotation, so it appears only in `full`.
+  """
+
+  alias NoizuPromptLingua.MCPServers
+
+  @profile_slugs ~w(full agent-ops pm-dev content comms)
+
+  @profile_meta %{
+    "full" => %{
+      label: "Full Access",
+      description: "Every customizable MCP group — the complete surface."
+    },
+    "agent-ops" => %{
+      label: "Agent Operations",
+      description: "Org, project, session, notification and memory tooling for autonomous agents."
+    },
+    "pm-dev" => %{
+      label: "Project Management & Dev",
+      description:
+        "Tickets, review, GitHub, instructions, sessions and projects for PM/dev workflows."
+    },
+    "content" => %{
+      label: "Content",
+      description:
+        "Artifacts, assets, wiki, markdown, market, campaigns, customers and unicode tooling."
+    },
+    "comms" => %{
+      label: "Communications",
+      description: "Chat, notifications, pubsub, personas, memory and wiki tooling."
+    }
+  }
+
+  # Decision 4 annotation DSL: group_id => [profile_slug]. The registry is the
+  # single source of profile membership (excluding `full`, which is always the
+  # whole customizable registry). Compile-validated below — an unknown group id
+  # or unknown profile slug FAILS COMPILATION (D4: compile-time checks where
+  # config must not boot).
+  @profile_groups %{
+    "organizations" => ["full", "agent-ops"],
+    "sessions" => ["full", "agent-ops", "pm-dev"],
+    "projects" => ["full", "agent-ops", "pm-dev"],
+    "notifications" => ["full", "agent-ops", "comms"],
+    "memory" => ["full", "agent-ops", "comms"],
+    "tickets" => ["full", "pm-dev"],
+    "review" => ["full", "pm-dev"],
+    "github" => ["full", "pm-dev"],
+    "instructions" => ["full", "pm-dev"],
+    "artifacts" => ["full", "content"],
+    "assets" => ["full", "content"],
+    "wiki" => ["full", "content", "comms"],
+    "markdown" => ["full", "content"],
+    "market" => ["full", "content"],
+    "campaigns" => ["full", "content"],
+    "customers" => ["full", "content"],
+    "unicode" => ["full", "content"],
+    "chat" => ["full", "comms"],
+    "pubsub" => ["full", "comms"],
+    "personas" => ["full", "comms"]
+  }
+
+  defp customizable_ids, do: MCPServers.customizable() |> Enum.map(& &1.id)
+
+  @doc """
+  Validate a `@profile_groups`-shaped registry against the customizable group
+  ids and the profile slug list. Raises ArgumentError naming the first offender.
+  Called from this module's body at compile time (Decision 4) and by the
+  negative compile-check test.
+  """
+  def validate_registry!(registry, valid_group_ids, valid_slugs) when is_map(registry) do
+    Enum.each(registry, fn {group_id, slugs} ->
+      unless group_id in valid_group_ids do
+        raise ArgumentError,
+              "Profiles @profile_groups: unknown MCP group id #{inspect(group_id)} — " <>
+                "must be one of MCPServers.customizable() ids"
+      end
+
+      Enum.each(List.wrap(slugs), fn slug ->
+        unless slug in valid_slugs do
+          raise ArgumentError,
+                "Profiles @profile_groups: unknown profile slug #{inspect(slug)} for group " <>
+                  "#{inspect(group_id)} — must be one of #{inspect(valid_slugs)}"
+        end
+      end)
+    end)
+
+    :ok
+  end
+
+  # Compile-time registry validation (Decision 4): raising from @after_compile
+  # fails the compilation of this module, so a bad annotation can never boot
+  # (D4: compile-time checks where config must not boot). Module-body local
+  # calls cannot resolve own functions, hence the hook.
+  @after_compile __MODULE__
+
+  def __after_compile__(_env, _bytecode) do
+    validate_registry!(@profile_groups, customizable_ids(), @profile_slugs)
+  end
+
+  @doc "The 5 profile slugs, canonical order. Feeds the reserved-slug list in the MCPToolSet changeset."
+  def slugs, do: @profile_slugs
+
+  @doc """
+  Profile DATA for `slug`: `%{slug, label, description, groups}` with `groups`
+  the expanded MCP group-id list (`full` = `MCPServers.customizable()`). nil for
+  unknown slugs.
+  """
+  def get(slug) when slug in @profile_slugs do
+    %{slug: slug}
+    |> Map.merge(Map.fetch!(@profile_meta, slug))
+    |> Map.put(:groups, groups_for(slug))
+  end
+
+  def get(_), do: nil
+
+  @doc "All 5 profiles as DATA, canonical order."
+  def all, do: Enum.map(@profile_slugs, &get/1)
+
+  @doc """
+  Expanded group ids for a profile slug: `full` = `MCPServers.customizable()`
+  (registry order); capability profiles = every group annotated with that slug
+  (annotation order). Unknown slug => [].
+  """
+  def groups_for("full"), do: customizable_ids()
+
+  def groups_for(slug) when is_binary(slug) do
+    Enum.flat_map(@profile_groups, fn {group_id, slugs} ->
+      if slug in slugs, do: [group_id], else: []
+    end)
+  end
+
+  def groups_for(_), do: []
+
+  @doc """
+  Inverse of the annotation registry: group_id => [profile_slug], `full`
+  prepended (it covers every customizable group). Unknown / non-customizable
+  group => [].
+  """
+  def groups_for_tool(group_id) do
+    slugs =
+      case Map.fetch(@profile_groups, group_id) do
+        {:ok, slugs} -> ["full" | Enum.reject(slugs, &(&1 == "full"))]
+        :error -> ["full"]
+      end
+
+    if group_id in customizable_ids(), do: slugs, else: []
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/schema/mcp_tool_set.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/mcp_tool_set.ex
@@ -1,0 +1,435 @@
+defmodule NoizuPromptLingua.Schema.MCPToolSet do
+  @moduledoc """
+  A named, durable MCP tool set (`mcp_tool_sets`, Liquibase 083) — the N2a
+  sibling of `MCPCustomScope` with a CLOSED operation vocabulary `config` jsonb
+  (1:1 with the lib PRD-1 §4.5 override ops) and a whitelisted `settings` jsonb.
+
+  Audience shapes (FR-2A-6, exactly one per row):
+
+    * org-set     — `project_id` nil, `group_id` nil
+    * project-set — `project_id` set, `group_id` nil
+    * group-set   — `group_id` set (an authz `groups` row id), `project_id` nil
+
+  `(organization_id, slug)` is one org-wide namespace across all shapes (R4).
+  The 5 profile slugs (`Toolsets.Profiles.slugs/0`) plus `"root"` are reserved —
+  profiles are virtual and must never be shadowable by a row (FR-2A-9).
+
+  `config` is validated STRUCTURALLY in N2a: unknown keys anywhere in the tree
+  are rejected, but tool/arg NAMES are not checked against the live catalog —
+  full compile-validation arrives at N4b (`Validator.compile/3`), and the read
+  side degrades per D5 (unknown tool/field dropped + warned, never a 500).
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias NoizuPromptLingua.MCP.Toolsets.Profiles
+  alias NoizuPromptLingua.Organizations.SlugBackfill
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.Authz.Group
+
+  @sources ~w(custom clone)
+
+  # Closed vocabulary (FR-2A-3). Group level: enabled/tools. Tool level:
+  # enabled/name/description/args. Arg level: enum_remove/hide/rename/default/
+  # description. 1:1 with the lib PRD-1 §4.5 ops — see
+  # `NoizuPromptLingua.MCP.ToolSets.to_overrides/1` for the op mapping.
+  @group_keys ~w(enabled tools)
+  @tool_keys ~w(enabled name description args)
+  @arg_keys ~w(enum_remove hide rename default description)
+
+  # Settings whitelist (FR-2A-5) governs CLIENT-supplied keys. `cloned_from`
+  # (clone provenance, open question 4) and `updated_by` (in-row audit stamp)
+  # are RESERVED SYSTEM keys — written only by the MCP.ToolSets context, not
+  # validated here.
+  @settings_system_keys ~w(cloned_from updated_by)
+  @settings_keys ~w(allow_api_keys description_verbosity instructions)
+  @verbosity ~w(full concise minimal)
+
+  @slug_format ~r/^[a-z0-9][a-z0-9-]{0,63}$/
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+
+  schema "mcp_tool_sets" do
+    field :organization_id, :binary_id
+    field :project_id, :binary_id
+    field :group_id, :binary_id
+    field :slug, :string
+    field :display_name, :string
+    field :description, :string
+    field :source, :string, default: "custom"
+    field :source_profile, :string
+    field :config, :map, default: %{}
+    field :settings, :map, default: %{}
+    field :expires_at, :utc_datetime_usec
+    field :is_active, :boolean, default: true
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "Valid `source` values."
+  def sources, do: @sources
+
+  @doc "Reserved set slugs: the 5 profile slugs + \"root\" (FR-2A-2 / FR-2A-9)."
+  def reserved_slugs, do: Profiles.slugs() ++ ["root"]
+
+  @doc """
+  Builds a changeset. `action` (:create default) controls which fields are
+  writable: identity fields (`organization_id`, `project_id`, `group_id`,
+  `slug`, `source`, `source_profile`) are create-only — updates may change
+  config/settings/display_name/description/expires_at/is_active only.
+  """
+  def changeset(tool_set, attrs, action \\ :create)
+
+  def changeset(tool_set, attrs, :create) do
+    tool_set
+    |> cast(attrs, [
+      :organization_id,
+      :project_id,
+      :group_id,
+      :slug,
+      :display_name,
+      :description,
+      :source,
+      :source_profile,
+      :config,
+      :settings,
+      :expires_at,
+      :is_active
+    ])
+    |> update_change(:slug, &derive_slug/1)
+    |> fallback_slug_from_display_name()
+    |> common_validation()
+    |> validate_clone_invariant()
+  end
+
+  def changeset(tool_set, attrs, :update) do
+    tool_set
+    |> cast(attrs, [
+      :display_name,
+      :description,
+      :config,
+      :settings,
+      :expires_at,
+      :is_active
+    ])
+    |> common_validation()
+  end
+
+  # Slug: slugify the incoming value; when absent, fall back to slugifying the
+  # display name (AC-2A-2 "unsluggable display name ⇒ slugified"). Still
+  # required — neither source yielding a slug is an error.
+  defp derive_slug(nil), do: nil
+  defp derive_slug(slug) when is_binary(slug), do: SlugBackfill.slugify(slug)
+  defp derive_slug(_), do: nil
+
+  defp fallback_slug_from_display_name(changeset) do
+    if is_nil(get_field(changeset, :slug)) do
+      case SlugBackfill.slugify(get_field(changeset, :display_name)) do
+        nil -> changeset
+        slug -> put_change(changeset, :slug, slug)
+      end
+    else
+      changeset
+    end
+  end
+
+  defp common_validation(changeset) do
+    changeset
+    |> validate_required([:organization_id, :slug])
+    |> validate_format(:slug, @slug_format)
+    |> validate_length(:slug, max: 64)
+    |> validate_length(:display_name, max: 200)
+    |> validate_inclusion(:source, @sources)
+    |> validate_exclusion(:slug, reserved_slugs())
+    |> validate_change(:config, &validate_config/2)
+    |> validate_change(:settings, &validate_settings/2)
+    |> validate_shape()
+    # Friendly duplicate error lands on :slug (the field an admin edits);
+    # field order decides attribution. The named constraint backstops races.
+    |> unsafe_validate_unique([:slug, :organization_id], Repo)
+    |> unique_constraint(:slug, name: :mcp_tool_sets_org_slug_key)
+  end
+
+  # source == "clone" must carry provenance: source_profile (cloned from a
+  # profile) or settings["cloned_from"] (cloned from a set — open question 4).
+  defp validate_clone_invariant(changeset) do
+    if get_field(changeset, :source) == "clone" do
+      cloned_from = get_in(get_field(changeset, :settings) || %{}, ["cloned_from"])
+
+      if is_nil(get_field(changeset, :source_profile)) and blank?(cloned_from) do
+        add_error(changeset, :source, "clone sets require source_profile or settings.cloned_from")
+      else
+        changeset
+      end
+    else
+      changeset
+    end
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
+
+  # Exactly one audience shape per row (FR-2A-6): org / project / group.
+  # Group-sets additionally require the group_id to reference an existing authz
+  # `groups` row (the N3 group gate resolves membership against it).
+  defp validate_shape(changeset) do
+    project_id = get_field(changeset, :project_id)
+    group_id = get_field(changeset, :group_id)
+
+    changeset
+    |> reject_both_shapes(project_id, group_id)
+    |> validate_group_exists(group_id)
+  end
+
+  defp reject_both_shapes(changeset, project_id, group_id)
+       when not is_nil(project_id) and not is_nil(group_id) do
+    add_error(changeset, :project_id, "project and group audiences are mutually exclusive")
+  end
+
+  defp reject_both_shapes(changeset, _project_id, _group_id), do: changeset
+
+  defp validate_group_exists(changeset, group_id) when not is_nil(group_id) do
+    if Repo.get(Group, group_id) do
+      changeset
+    else
+      add_error(changeset, :group_id, "does not exist")
+    end
+  end
+
+  defp validate_group_exists(changeset, _), do: changeset
+
+  # ---- config: closed-vocabulary structural validation (FR-2A-3) ----
+
+  defp validate_config(:config, value) when is_map(value),
+    do: do_validate_config(stringify(value))
+
+  defp validate_config(:config, _), do: [config: "must be an object"]
+
+  defp do_validate_config(config) do
+    unknown_keys_errors(:config, "config", config, ["groups"]) ++
+      case Map.get(config, "groups") do
+        nil ->
+          []
+
+        groups when is_map(groups) ->
+          Enum.flat_map(groups, fn {group_id, group_cfg} ->
+            validate_group(group_id, group_cfg)
+          end)
+
+        _ ->
+          [config: "groups: must be an object"]
+      end
+  end
+
+  defp validate_group(group_id, group_cfg) when is_map(group_cfg) do
+    prefix = "groups.#{group_id}"
+
+    unknown_keys_errors(:config, prefix, group_cfg, @group_keys) ++
+      validate_group_enabled(prefix, group_cfg) ++
+      validate_tools(prefix, Map.get(group_cfg, "tools"))
+  end
+
+  defp validate_group(group_id, _), do: [config: "groups.#{group_id}: must be an object"]
+
+  defp validate_group_enabled(prefix, group_cfg) do
+    case Map.get(group_cfg, "enabled") do
+      nil -> []
+      value when is_boolean(value) -> []
+      _ -> [config: "#{prefix}.enabled: must be a boolean"]
+    end
+  end
+
+  defp validate_tools(_prefix, nil), do: []
+
+  defp validate_tools(prefix, tools) when is_map(tools) do
+    Enum.flat_map(tools, fn {tool_name, tool_cfg} ->
+      validate_tool(prefix, tool_name, tool_cfg)
+    end)
+  end
+
+  defp validate_tools(prefix, _), do: [config: "#{prefix}.tools: must be an object"]
+
+  defp validate_tool(prefix, tool_name, tool_cfg) when is_map(tool_cfg) do
+    tool_path = "#{prefix}.tools.#{tool_name}"
+
+    unknown_keys_errors(:config, tool_path, tool_cfg, @tool_keys) ++
+      validate_tool_scalars(tool_path, tool_cfg) ++
+      validate_args(tool_path, Map.get(tool_cfg, "args"))
+  end
+
+  defp validate_tool(_prefix, tool_name, _), do: [config: "tools.#{tool_name}: must be an object"]
+
+  defp validate_tool_scalars(tool_path, tool_cfg) do
+    boolean_errors(tool_path, "enabled", Map.get(tool_cfg, "enabled")) ++
+      string_errors(tool_path, "name", Map.get(tool_cfg, "name")) ++
+      string_errors(tool_path, "description", Map.get(tool_cfg, "description"))
+  end
+
+  defp validate_args(_tool_path, nil), do: []
+
+  defp validate_args(tool_path, args) when is_map(args) do
+    renames = arg_renames(args)
+
+    Enum.flat_map(args, fn {arg_name, arg_cfg} ->
+      validate_arg("#{tool_path}.args", arg_name, arg_cfg, args)
+    end) ++ duplicate_rename_errors(tool_path, renames)
+  end
+
+  defp validate_args(tool_path, _), do: [config: "#{tool_path}.args: must be an object"]
+
+  defp validate_arg(args_path, arg_name, arg_cfg, args) when is_map(arg_cfg) do
+    arg_path = "#{args_path}.#{arg_name}"
+
+    unknown_keys_errors(:config, arg_path, arg_cfg, @arg_keys) ++
+      validate_enum_remove(arg_path, Map.get(arg_cfg, "enum_remove")) ++
+      boolean_errors(arg_path, "hide", Map.get(arg_cfg, "hide")) ++
+      validate_rename(arg_path, arg_name, Map.get(arg_cfg, "rename"), args) ++
+      validate_default(arg_path, Map.get(arg_cfg, "default")) ++
+      string_errors(arg_path, "description", Map.get(arg_cfg, "description"))
+  end
+
+  defp validate_arg(args_path, arg_name, _, _),
+    do: [config: "#{args_path}.#{arg_name}: must be an object"]
+
+  defp validate_enum_remove(_arg_path, nil), do: []
+
+  defp validate_enum_remove(arg_path, values) do
+    if is_list(values) and Enum.all?(values, &scalar?/1) do
+      []
+    else
+      [config: "#{arg_path}.enum_remove: must be a list of scalars"]
+    end
+  end
+
+  defp validate_rename(arg_path, arg_name, rename, args)
+
+  defp validate_rename(_arg_path, _arg_name, nil, _args), do: []
+
+  defp validate_rename(arg_path, arg_name, rename, args) when is_binary(rename) do
+    cond do
+      rename == "" ->
+        [config: "#{arg_path}.rename: must be a non-empty string"]
+
+      # The rename target collides with another arg of the SAME tool (the
+      # renamed arg itself is fine; a rename onto an existing sibling is not).
+      Map.has_key?(args, rename) and rename != arg_name ->
+        [config: "#{arg_path}.rename: collides with existing arg #{inspect(rename)}"]
+
+      true ->
+        []
+    end
+  end
+
+  defp validate_rename(arg_path, _arg_name, _, _args),
+    do: [config: "#{arg_path}.rename: must be a non-empty string"]
+
+  defp validate_default(_arg_path, nil), do: []
+
+  defp validate_default(arg_path, value) do
+    if scalar?(value) do
+      []
+    else
+      [config: "#{arg_path}.default: must be a scalar"]
+    end
+  end
+
+  # Two args renamed onto the same target also collide.
+  defp duplicate_rename_errors(tool_path, renames) do
+    {_, dupes} =
+      Enum.reduce(renames, {MapSet.new(), []}, fn {_arg, target}, {seen, dupes} ->
+        if MapSet.member?(seen, target) do
+          {seen, [target | dupes]}
+        else
+          {MapSet.put(seen, target), dupes}
+        end
+      end)
+
+    Enum.map(dupes, fn target ->
+      {:config, "#{tool_path}.args: multiple renames collide on #{inspect(target)}"}
+    end)
+  end
+
+  defp arg_renames(args) do
+    args
+    |> Enum.flat_map(fn {arg_name, arg_cfg} ->
+      rename = if is_map(arg_cfg), do: Map.get(arg_cfg, "rename")
+      if is_binary(rename) and rename != "", do: [{arg_name, rename}], else: []
+    end)
+  end
+
+  defp unknown_keys_errors(field, path, cfg, allowed) do
+    cfg
+    |> Map.keys()
+    |> Enum.reject(&(&1 in allowed))
+    |> Enum.map(fn key -> {field, "#{path}: unknown key #{inspect(key)}"} end)
+  end
+
+  defp boolean_errors(_path, _key, nil), do: []
+
+  defp boolean_errors(path, key, value) do
+    if is_boolean(value), do: [], else: [config: "#{path}.#{key}: must be a boolean"]
+  end
+
+  defp string_errors(_path, _key, nil), do: []
+
+  defp string_errors(path, key, value) do
+    if is_binary(value), do: [], else: [config: "#{path}.#{key}: must be a string"]
+  end
+
+  defp scalar?(value) when is_binary(value) or is_number(value) or is_boolean(value), do: true
+  defp scalar?(_), do: false
+
+  # ---- settings whitelist (FR-2A-5) ----
+
+  defp validate_settings(:settings, value) when is_map(value),
+    do: do_validate_settings(stringify(value))
+
+  defp validate_settings(:settings, _), do: [settings: "must be an object"]
+
+  defp do_validate_settings(settings) do
+    settings = Map.drop(settings, @settings_system_keys)
+
+    unknown_keys_errors(:settings, "settings", settings, @settings_keys) ++
+      validate_allow_api_keys(Map.get(settings, "allow_api_keys")) ++
+      validate_verbosity(Map.get(settings, "description_verbosity")) ++
+      validate_instructions(Map.get(settings, "instructions"))
+  end
+
+  defp validate_allow_api_keys(nil), do: []
+
+  defp validate_allow_api_keys(value) do
+    if is_boolean(value), do: [], else: [settings: "settings.allow_api_keys: must be a boolean"]
+  end
+
+  defp validate_verbosity(nil), do: []
+
+  defp validate_verbosity(value) when is_binary(value) do
+    if value in @verbosity,
+      do: [],
+      else: [
+        settings: "settings.description_verbosity: must be one of: #{Enum.join(@verbosity, ", ")}"
+      ]
+  end
+
+  defp validate_verbosity(_), do: [settings: "settings.description_verbosity: must be a string"]
+
+  defp validate_instructions(nil), do: []
+
+  defp validate_instructions(value) do
+    if is_binary(value), do: [], else: [settings: "settings.instructions: must be a string"]
+  end
+
+  # jsonb maps arrive from clients in either key spelling; canonical storage is
+  # string-keyed (mirrors MCPCustomScopes normalize behavior).
+  defp stringify(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), stringify(value)}
+      {key, value} when is_binary(key) -> {key, stringify(value)}
+      pair -> pair
+    end)
+  end
+
+  defp stringify(other), do: other
+end

--- a/backend/test/noizu_prompt_lingua/mcp/tool_sets_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/tool_sets_test.exs
@@ -1,0 +1,669 @@
+defmodule NoizuPromptLingua.MCP.ToolSetsTest do
+  @moduledoc """
+  N2a storage matrix (PRD-N2 AC-2A-2 … AC-2A-8): MCPToolSet changeset rules
+  (slugify, reserved slugs, org-wide uniqueness, closed-vocabulary config,
+  settings whitelist, shape invariants), context CRUD/deactivate/clone,
+  request-path scoping, and the to_overrides translation table.
+  """
+  use NoizuPromptLingua.DataCase
+  @moduletag :db
+
+  alias NoizuPromptLingua.MCP.ToolSets
+  alias NoizuPromptLingua.Schema.MCPToolSet
+
+  @valid_config %{
+    "groups" => %{
+      "tickets" => %{
+        "enabled" => true,
+        "tools" => %{
+          "Tickets_Create" => %{
+            "enabled" => true,
+            "name" => "create_ticket",
+            "args" => %{"priority" => %{"enum_remove" => ["urgent"]}}
+          }
+        }
+      }
+    }
+  }
+
+  # PRD-N2 §4.1 example config — the to_overrides fixture (AC-2A-4).
+  @example_config %{
+    "groups" => %{
+      "tickets" => %{
+        "enabled" => true,
+        "tools" => %{
+          "Tickets_Create" => %{
+            "enabled" => true,
+            "name" => "create_ticket",
+            "description" => "Create a ticket",
+            "args" => %{
+              "priority" => %{"enum_remove" => ["urgent"]},
+              "internal_field" => %{"hide" => true},
+              "assignee" => %{"rename" => "owner"},
+              "mode" => %{"default" => "fast"},
+              "notes" => %{"description" => "Free-form notes"}
+            }
+          }
+        }
+      }
+    }
+  }
+
+  setup do
+    {:ok, org_id: insert_org(), other_org_id: insert_org()}
+  end
+
+  # ---- changeset: slugs (AC-2A-2) ----
+
+  describe "changeset slug handling" do
+    test "slugifies messy slugs", %{org_id: org_id} do
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, slug: "My Tool Set!"))
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :slug) == "my-tool-set"
+    end
+
+    test "derives slug from display name when slug absent", %{org_id: org_id} do
+      attrs = base_attrs(org_id) |> Map.drop(["slug"]) |> Map.put("display_name", "Release Ops")
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, attrs)
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :slug) == "release-ops"
+    end
+
+    test "requires a slug when neither slug nor display name yields one", %{org_id: org_id} do
+      attrs = base_attrs(org_id) |> Map.drop(["slug", "display_name"])
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset, :slug)
+    end
+
+    test "rejects the 5 profile slugs and root as reserved", %{org_id: org_id} do
+      for slug <- ["full", "agent-ops", "pm-dev", "content", "comms", "root"] do
+        changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, slug: slug))
+        refute changeset.valid?, "expected #{inspect(slug)} to be reserved"
+        assert "is reserved" in errors_on(changeset, :slug)
+      end
+    end
+
+    test "caps slugs at the 64-char column limit" do
+      # slugify always normalizes into the ^[a-z0-9][a-z0-9-]{0,63}$ charset,
+      # so the format validator is defense-in-depth; the observable boundary is
+      # the 64-char cap.
+      long = String.duplicate("abcdefgh", 10)
+
+      changeset =
+        MCPToolSet.changeset(%MCPToolSet{}, base_attrs(Ecto.UUID.generate(), slug: long))
+
+      assert String.length(Ecto.Changeset.get_field(changeset, :slug)) == 64
+    end
+
+    test "org-wide (org, slug) uniqueness across shapes (R4)", %{
+      org_id: org_id,
+      other_org_id: other_org_id
+    } do
+      {:ok, _} = ToolSets.create(base_attrs(org_id, slug: "dupe"))
+
+      # Same slug, project shape, same org => rejected (org-wide namespace).
+      {:error, changeset} =
+        ToolSets.create(
+          base_attrs(org_id, slug: "dupe")
+          |> Map.put("project_id", Ecto.UUID.generate())
+        )
+
+      assert "has already been taken" in errors_on(changeset, :slug)
+
+      # Same slug, other org => fine.
+      assert {:ok, _} = ToolSets.create(base_attrs(other_org_id, slug: "dupe"))
+    end
+
+    test "requires organization_id", %{org_id: _org_id} do
+      changeset =
+        MCPToolSet.changeset(
+          %MCPToolSet{},
+          base_attrs(Ecto.UUID.generate()) |> Map.drop(["organization_id"])
+        )
+
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset, :organization_id)
+    end
+  end
+
+  # ---- changeset: closed vocabulary (AC-2A-3) ----
+
+  describe "changeset config validation" do
+    test "accepts the §4.1 example config", %{org_id: org_id} do
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: @example_config))
+      assert changeset.valid?
+    end
+
+    test "rejects unknown tool-level keys with a named error", %{org_id: org_id} do
+      config =
+        put_in(@valid_config, ["groups", "tickets", "tools", "Tickets_Create", "visible"], true)
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/unknown key "visible"/)
+    end
+
+    test "rejects legacy-vocabulary keys (name_override, arg_overrides, enum)", %{org_id: org_id} do
+      for {path_key, value} <- [
+            {"name_override", "x"},
+            {"arg_overrides", %{}}
+          ] do
+        config =
+          put_in(@valid_config, ["groups", "tickets", "tools", "Tickets_Create", path_key], value)
+
+        changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+        refute changeset.valid?, "expected #{path_key} to be rejected"
+        assert error_mentions(changeset, :config, ~r/unknown key/)
+      end
+
+      config =
+        put_in(
+          @valid_config,
+          ["groups", "tickets", "tools", "Tickets_Create", "args", "priority", "enum"],
+          ["a"]
+        )
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/unknown key "enum"/)
+    end
+
+    test "rejects unknown group-level and top-level keys", %{org_id: org_id} do
+      config = put_in(@valid_config, ["groups", "tickets", "kind"], "weird")
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/unknown key "kind"/)
+
+      config = Map.put(@valid_config, "presets", %{})
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/unknown key "presets"/)
+    end
+
+    test "rejects non-boolean enabled/hide", %{org_id: org_id} do
+      config =
+        put_in(@valid_config, ["groups", "tickets", "tools", "Tickets_Create", "enabled"], "yes")
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/\.enabled: must be a boolean/)
+
+      config =
+        put_in(
+          @valid_config,
+          ["groups", "tickets", "tools", "Tickets_Create", "args", "priority", "hide"],
+          1
+        )
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/\.hide: must be a boolean/)
+    end
+
+    test "rejects enum_remove that is not a list of scalars", %{org_id: org_id} do
+      for bad <- ["urgent", ["urgent", %{}], 42] do
+        config =
+          put_in(
+            @valid_config,
+            ["groups", "tickets", "tools", "Tickets_Create", "args", "priority", "enum_remove"],
+            bad
+          )
+
+        changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+        refute changeset.valid?
+        assert error_mentions(changeset, :config, ~r/enum_remove: must be a list of scalars/)
+      end
+    end
+
+    test "rejects rename colliding with another arg of the same tool", %{org_id: org_id} do
+      config =
+        put_in(
+          @valid_config,
+          ["groups", "tickets", "tools", "Tickets_Create", "args", "assignee"],
+          %{"rename" => "priority"}
+        )
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/collides with existing arg "priority"/)
+    end
+
+    test "rejects two renames colliding on the same target", %{org_id: org_id} do
+      config =
+        put_in(@valid_config, ["groups", "tickets", "tools", "Tickets_Create", "args"], %{
+          "a" => %{"rename" => "same"},
+          "b" => %{"rename" => "same"}
+        })
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/multiple renames collide on "same"/)
+    end
+
+    test "rejects non-map groups/tools/args containers", %{org_id: org_id} do
+      config = Map.put(@valid_config, "groups", ["tickets"])
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/groups: must be an object/)
+
+      config = put_in(@valid_config, ["groups", "tickets", "tools"], 42)
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, config: config))
+      refute changeset.valid?
+      assert error_mentions(changeset, :config, ~r/\.tools: must be an object/)
+    end
+  end
+
+  # ---- changeset: settings whitelist (AC-2A-5) ----
+
+  describe "changeset settings whitelist" do
+    test "accepts the v1 keys with type checks", %{org_id: org_id} do
+      settings = %{
+        "allow_api_keys" => false,
+        "description_verbosity" => "concise",
+        "instructions" => "Be terse."
+      }
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, settings: settings))
+      assert changeset.valid?
+    end
+
+    test "rejects unknown/misspelled keys and bad types", %{org_id: org_id} do
+      changeset =
+        MCPToolSet.changeset(
+          %MCPToolSet{},
+          base_attrs(org_id, settings: %{"persona" => "dark"})
+        )
+
+      refute changeset.valid?
+      assert error_mentions(changeset, :settings, ~r/unknown key "persona"/)
+
+      changeset =
+        MCPToolSet.changeset(
+          %MCPToolSet{},
+          base_attrs(org_id, settings: %{"description_verbosity" => "verbose"})
+        )
+
+      refute changeset.valid?
+
+      changeset =
+        MCPToolSet.changeset(
+          %MCPToolSet{},
+          base_attrs(org_id, settings: %{"allow_api_keys" => "false"})
+        )
+
+      refute changeset.valid?
+
+      changeset =
+        MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, settings: %{"instructions" => 42}))
+
+      refute changeset.valid?
+    end
+  end
+
+  # ---- shape invariants (AC-2A-2 / FR-2A-6) ----
+
+  describe "changeset shape invariants" do
+    test "org-set (neither project nor group) is valid", %{org_id: org_id} do
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id))
+      assert changeset.valid?
+    end
+
+    test "project and group audiences are mutually exclusive", %{org_id: org_id} do
+      {:ok, group_id} = insert_group()
+
+      attrs =
+        base_attrs(org_id)
+        |> Map.put("project_id", Ecto.UUID.generate())
+        |> Map.put("group_id", group_id)
+
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, attrs)
+      refute changeset.valid?
+
+      assert "project and group audiences are mutually exclusive" in errors_on(
+               changeset,
+               :project_id
+             )
+    end
+
+    test "group-set requires an existing authz group", %{org_id: org_id} do
+      attrs = base_attrs(org_id) |> Map.put("group_id", Ecto.UUID.generate())
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, attrs)
+      refute changeset.valid?
+      assert "does not exist" in errors_on(changeset, :group_id)
+
+      {:ok, group_id} = insert_group()
+      attrs = base_attrs(org_id) |> Map.put("group_id", group_id)
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "clone source requires provenance", %{org_id: org_id} do
+      attrs = base_attrs(org_id) |> Map.put("source", "clone")
+      changeset = MCPToolSet.changeset(%MCPToolSet{}, attrs)
+      refute changeset.valid?
+
+      attrs =
+        base_attrs(org_id) |> Map.put("source", "clone") |> Map.put("source_profile", "pm-dev")
+
+      assert MCPToolSet.changeset(%MCPToolSet{}, attrs).valid?
+
+      attrs =
+        base_attrs(org_id)
+        |> Map.put("source", "clone")
+        |> Map.put("settings", %{"cloned_from" => "some-set"})
+
+      assert MCPToolSet.changeset(%MCPToolSet{}, attrs).valid?
+    end
+  end
+
+  # ---- context CRUD + request path (AC-2A-8) ----
+
+  describe "context" do
+    test "create persists defaults and stamps actor", %{org_id: org_id} do
+      {:ok, set} = ToolSets.create(base_attrs(org_id), actor_id: "user-1")
+
+      assert %MCPToolSet{} = set
+      assert set.source == "custom"
+      assert set.is_active
+      assert set.config == %{}
+      assert set.settings["updated_by"] == "user-1"
+    end
+
+    test "update changes mutable fields only; identity fields are create-only", %{org_id: org_id} do
+      {:ok, set} = ToolSets.create(base_attrs(org_id, slug: "mutable"))
+
+      {:ok, updated} =
+        ToolSets.update(set, %{
+          "display_name" => "Renamed",
+          "config" => @valid_config,
+          "slug" => "hijack",
+          "organization_id" => Ecto.UUID.generate()
+        })
+
+      assert updated.display_name == "Renamed"
+      assert updated.config["groups"]["tickets"]
+      assert updated.slug == "mutable"
+      assert updated.organization_id == org_id
+    end
+
+    test "deactivate soft-kills; request path drops, admin path still resolves", %{org_id: org_id} do
+      {:ok, set} = ToolSets.create(base_attrs(org_id, slug: "killable"))
+
+      assert {:ok, %{is_active: false}} = ToolSets.deactivate(set)
+      assert ToolSets.get_for_request(org_id, "killable") == nil
+      assert %MCPToolSet{} = ToolSets.get_by_org_and_slug(org_id, "killable")
+    end
+
+    test "get_by_org_and_slug normalizes case and never leaks across orgs", %{
+      org_id: org_id,
+      other_org_id: other_org_id
+    } do
+      {:ok, _} = ToolSets.create(base_attrs(org_id, slug: "scoped-set"))
+
+      assert %MCPToolSet{} = ToolSets.get_by_org_and_slug(org_id, "Scoped-Set")
+      assert ToolSets.get_by_org_and_slug(other_org_id, "scoped-set") == nil
+      assert ToolSets.get_by_org_and_slug(other_org_id, "missing") == nil
+    end
+
+    test "get_for_request drops expired sets and other-org sets", %{
+      org_id: org_id,
+      other_org_id: other_org_id
+    } do
+      past = DateTime.add(DateTime.utc_now(), -60, :second)
+      future = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+      {:ok, _} =
+        ToolSets.create(base_attrs(org_id, slug: "expired") |> Map.put("expires_at", past))
+
+      {:ok, _} =
+        ToolSets.create(base_attrs(org_id, slug: "live") |> Map.put("expires_at", future))
+
+      {:ok, _} = ToolSets.create(base_attrs(other_org_id, slug: "elsewhere"))
+
+      assert ToolSets.get_for_request(org_id, "expired") == nil
+      assert %MCPToolSet{} = ToolSets.get_for_request(org_id, "live")
+      assert ToolSets.get_for_request(org_id, "elsewhere") == nil
+    end
+
+    test "list_for_org returns active sets only, scoped to the org", %{
+      org_id: org_id,
+      other_org_id: other_org_id
+    } do
+      {:ok, kept} = ToolSets.create(base_attrs(org_id, slug: "kept"))
+      {:ok, dropped} = ToolSets.create(base_attrs(org_id, slug: "dropped"))
+      {:ok, _} = ToolSets.create(base_attrs(other_org_id, slug: "foreign"))
+      {:ok, _} = ToolSets.deactivate(dropped)
+
+      slugs = ToolSets.list_for_org(org_id) |> Enum.map(& &1.slug)
+      assert slugs == [kept.slug]
+    end
+  end
+
+  # ---- clone (AC-2A-6) ----
+
+  describe "clone/2" do
+    test "from a profile: allowlist config, provenance, auto slug", %{org_id: org_id} do
+      {:ok, clone} = ToolSets.clone("pm-dev", %{"organization_id" => org_id})
+
+      assert clone.source == "clone"
+      assert clone.source_profile == "pm-dev"
+      assert clone.slug == "pm-dev-copy"
+      assert clone.display_name == "pm-dev copy"
+      assert clone.is_active
+
+      enabled_groups = clone.config["groups"]
+
+      assert MapSet.new(Map.keys(enabled_groups)) ==
+               MapSet.new(NoizuPromptLingua.MCP.Toolsets.Profiles.groups_for("pm-dev"))
+
+      assert Enum.all?(enabled_groups, fn {_g, cfg} -> cfg == %{"enabled" => true} end)
+    end
+
+    test "from a profile: slug auto-suggest skips taken slugs", %{org_id: org_id} do
+      {:ok, first} = ToolSets.clone("pm-dev", %{"organization_id" => org_id})
+      assert first.slug == "pm-dev-copy"
+
+      {:ok, second} = ToolSets.clone("pm-dev", %{"organization_id" => org_id})
+      assert second.slug == "pm-dev-copy-2"
+
+      {:ok, third} = ToolSets.clone("pm-dev", %{"organization_id" => org_id})
+      assert third.slug == "pm-dev-copy-3"
+    end
+
+    test "from a set: config deep-copied, provenance in settings.cloned_from, independent", %{
+      org_id: org_id
+    } do
+      {:ok, source} = ToolSets.create(base_attrs(org_id, slug: "origin", config: @valid_config))
+
+      {:ok, clone} = ToolSets.clone(source, %{"organization_id" => org_id})
+
+      assert clone.source == "clone"
+      assert is_nil(clone.source_profile)
+      assert clone.settings["cloned_from"] == "origin"
+      assert clone.config == source.config
+
+      # Mutating the clone never touches the source.
+      {:ok, _} = ToolSets.update(clone, %{"config" => %{"groups" => %{}}})
+      refreshed_source = ToolSets.get(source.id)
+      assert refreshed_source.config == source.config
+    end
+
+    test "unknown profile and missing org are errors", %{org_id: org_id} do
+      assert {:error, :unknown_profile} =
+               ToolSets.clone("no-such-profile", %{"organization_id" => org_id})
+
+      assert {:error, %Ecto.Changeset{}} = ToolSets.clone("pm-dev", %{})
+    end
+  end
+
+  # ---- to_overrides (AC-2A-4) ----
+
+  describe "to_overrides/1" do
+    test "translates the §4.1 example into the PRD-1 §4.5 vocabulary" do
+      ops = ToolSets.to_overrides(@example_config)
+
+      assert ops == [
+               %{
+                 op: :set_name,
+                 target: %{group: "tickets", tool: "Tickets_Create"},
+                 value: "create_ticket"
+               },
+               %{
+                 op: :set_description,
+                 target: %{group: "tickets", tool: "Tickets_Create"},
+                 value: "Create a ticket"
+               },
+               %{
+                 op: :rename_field,
+                 target: %{group: "tickets", tool: "Tickets_Create", arg: "assignee"},
+                 value: "owner"
+               },
+               %{
+                 op: :hide_field,
+                 target: %{group: "tickets", tool: "Tickets_Create", arg: "internal_field"},
+                 value: true
+               },
+               %{
+                 op: :pin_default,
+                 target: %{group: "tickets", tool: "Tickets_Create", arg: "mode"},
+                 value: "fast"
+               },
+               %{
+                 op: :set_arg_description,
+                 target: %{group: "tickets", tool: "Tickets_Create", arg: "notes"},
+                 value: "Free-form notes"
+               },
+               %{
+                 op: :prune_enum,
+                 target: %{group: "tickets", tool: "Tickets_Create", arg: "priority"},
+                 value: ["urgent"]
+               }
+             ]
+    end
+
+    test "enabled: false yields set_visible + set_callable; enabled: true yields nothing" do
+      config = %{
+        "groups" => %{
+          "tickets" => %{
+            "tools" => %{
+              "Tickets_A" => %{"enabled" => false},
+              "Tickets_B" => %{"enabled" => true}
+            }
+          }
+        }
+      }
+
+      assert ToolSets.to_overrides(config) == [
+               %{op: :set_visible, target: %{group: "tickets", tool: "Tickets_A"}, value: false},
+               %{op: :set_callable, target: %{group: "tickets", tool: "Tickets_A"}, value: false}
+             ]
+    end
+
+    test "empty/nil-ish config yields no ops" do
+      assert ToolSets.to_overrides(%{}) == []
+      assert ToolSets.to_overrides(%{"groups" => %{}}) == []
+      assert ToolSets.to_overrides(nil) == []
+    end
+
+    test "pure and deterministic (two calls, identical term)" do
+      assert ToolSets.to_overrides(@example_config) == ToolSets.to_overrides(@example_config)
+
+      # Same input in a differently-keyed map (insertion order differs) yields
+      # the identical term.
+      reordered =
+        Map.update!(@example_config, "groups", fn groups ->
+          Enum.reverse(groups) |> Map.new()
+        end)
+
+      assert ToolSets.to_overrides(reordered) == ToolSets.to_overrides(@example_config)
+    end
+  end
+
+  # ---- assemble_custom (N2a thin seam) ----
+
+  describe "assemble_custom/2" do
+    test "returns the effective view with defaulted settings", %{org_id: org_id} do
+      {:ok, set} =
+        ToolSets.create(
+          base_attrs(org_id, slug: "assembled", config: @valid_config)
+          |> Map.put("settings", %{"instructions" => "hi"})
+        )
+
+      view = ToolSets.assemble_custom(set)
+
+      assert view.slug == "assembled"
+      assert view.source == "custom"
+      assert view.config == @valid_config
+      assert view.overrides == ToolSets.to_overrides(@valid_config)
+      assert view.settings["allow_api_keys"] == true
+      assert view.settings["instructions"] == "hi"
+    end
+  end
+
+  # ---- helpers ----
+
+  defp base_attrs(org_id, overrides \\ []) do
+    Map.merge(
+      %{
+        "organization_id" => org_id,
+        "slug" => "set-#{System.unique_integer([:positive])}",
+        "display_name" => "Test Set"
+      },
+      Map.new(overrides, fn {k, v} -> {to_string(k), v} end)
+    )
+  end
+
+  defp errors_on(changeset, field) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r/%\{(\w+)\}/, msg, fn _, key ->
+        value =
+          Enum.find_value(opts, fn
+            {k, v} when is_atom(k) ->
+              if Atom.to_string(k) == key, do: v, else: nil
+
+            _ ->
+              nil
+          end)
+
+        if is_nil(value), do: key, else: to_string(value)
+      end)
+    end)
+    |> Map.get(field, [])
+  end
+
+  defp error_mentions(changeset, field, regex) do
+    errors_on(changeset, field) |> Enum.any?(&Regex.match?(regex, &1))
+  end
+
+  defp insert_org do
+    %{rows: [[raw]]} =
+      NoizuPromptLingua.Repo.query!(
+        "INSERT INTO organizations (id, slug, name, inserted_at, updated_at) " <>
+          "VALUES (gen_random_uuid(), $1, $2, now(), now()) RETURNING id",
+        ["n2ats-#{System.unique_integer([:positive])}", "N2a ToolSets Test Org"]
+      )
+
+    Ecto.UUID.load!(raw)
+  end
+
+  defp insert_group do
+    # Seed migrated DBs already carry the role groups (owner/admin/lead/member/
+    # viewer, name unique) — reuse one; insert only on a bare DB.
+    case NoizuPromptLingua.Repo.query!("SELECT id FROM groups WHERE name = 'member' LIMIT 1", []) do
+      %{rows: [[raw]]} ->
+        {:ok, Ecto.UUID.load!(raw)}
+
+      %{rows: []} ->
+        %{rows: [[raw]]} =
+          NoizuPromptLingua.Repo.query!(
+            "INSERT INTO groups (id, name, display_name, created_at, updated_at) " <>
+              "VALUES (gen_random_uuid(), 'member', 'Member', now(), now()) RETURNING id",
+            []
+          )
+
+        {:ok, Ecto.UUID.load!(raw)}
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua/mcp/toolsets/profiles_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/toolsets/profiles_test.exs
@@ -1,0 +1,173 @@
+defmodule NoizuPromptLingua.MCP.Toolsets.ProfilesTest do
+  @moduledoc """
+  N2a profiles-as-data matrix (PRD-N2 AC-2A-7): the 5 profile slugs, expanded
+  group lists vs. the MCPServers registry, annotation-registry inverse
+  consistency, and the compile-time registry validation (negative compile-check
+  via `Code.compile_string`).
+
+  No DB — the registry is pure code (Decision 4).
+  """
+  use ExUnit.Case, async: true
+
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.MCP.Toolsets.Profiles
+
+  @customizable_ids Enum.map(MCPServers.customizable(), & &1.id)
+
+  # R1 profile memberships (PRD-N2 FR-2A-8), sorted for order-insensitive
+  # comparison; `full` is asserted exact (== customizable, registry order).
+  @r1 %{
+    "agent-ops" => ~w(organizations sessions projects notifications memory),
+    "pm-dev" => ~w(projects tickets review github instructions sessions),
+    "content" => ~w(artifacts assets wiki markdown market campaigns customers unicode),
+    "comms" => ~w(chat notifications pubsub personas memory wiki)
+  }
+
+  describe "slugs" do
+    test "the 5 canonical slugs in order" do
+      assert Profiles.slugs() == ["full", "agent-ops", "pm-dev", "content", "comms"]
+    end
+
+    test "get/1 returns DATA for each slug and nil for unknown" do
+      for slug <- Profiles.slugs() do
+        profile = Profiles.get(slug)
+        assert profile.slug == slug
+        assert is_binary(profile.label) and profile.label != ""
+        assert is_binary(profile.description) and profile.description != ""
+        assert profile.groups != []
+      end
+
+      assert Profiles.get("nope") == nil
+      assert Profiles.get("root") == nil
+    end
+
+    test "all/0 covers every slug" do
+      assert Enum.map(Profiles.all(), & &1.slug) == Profiles.slugs()
+    end
+  end
+
+  describe "group expansion" do
+    test "full == MCPServers.customizable() (21 ids, registry order)" do
+      assert Profiles.groups_for("full") == @customizable_ids
+      assert length(@customizable_ids) == 21
+      refute "root" in Profiles.groups_for("full")
+    end
+
+    test "each R1 capability profile matches its membership list" do
+      for {slug, expected} <- @r1 do
+        assert Enum.sort(Profiles.groups_for(slug)) == Enum.sort(expected),
+               "profile #{slug} expansion drifted from the R1 list"
+
+        # Full is a strict superset of every capability profile.
+        assert Profiles.groups_for(slug) -- Profiles.groups_for("full") == []
+      end
+    end
+
+    test "every expanded group id resolves in the @servers registry" do
+      for slug <- Profiles.slugs(), group_id <- Profiles.groups_for(slug) do
+        assert group_id in @customizable_ids,
+               "#{slug} expands to unknown group #{inspect(group_id)}"
+      end
+    end
+
+    test "browser participates only in full (no capability annotation)" do
+      assert "browser" in Profiles.groups_for("full")
+
+      for slug <- @r1 |> Map.keys() do
+        refute "browser" in Profiles.groups_for(slug)
+      end
+    end
+  end
+
+  describe "annotation inverse (groups_for_tool/1)" do
+    test "inverse is consistent with the forward expansion" do
+      for slug <- Profiles.slugs(), group_id <- Profiles.groups_for(slug) do
+        assert slug in Profiles.groups_for_tool(group_id)
+      end
+    end
+
+    test "every customizable group resolves (full covers the unannotated)" do
+      for group_id <- @customizable_ids do
+        assert "full" in Profiles.groups_for_tool(group_id)
+      end
+    end
+
+    test "unknown groups resolve to nothing" do
+      assert Profiles.groups_for_tool("root") == []
+      assert Profiles.groups_for_tool("not-a-group") == []
+      assert Profiles.groups_for_tool(nil) == []
+    end
+
+    test "capability slugs follow the annotations" do
+      assert Profiles.groups_for_tool("tickets") == ["full", "pm-dev"]
+      assert Profiles.groups_for_tool("wiki") == ["full", "content", "comms"]
+      assert Profiles.groups_for_tool("browser") == ["full"]
+    end
+  end
+
+  describe "compile-time registry validation (Decision 4 / AC-2A-7)" do
+    test "the shipped registry validates" do
+      assert Profiles.validate_registry!(
+               Enum.map(@customizable_ids, &{&1, ["full"]}) |> Map.new(),
+               @customizable_ids,
+               Profiles.slugs()
+             ) == :ok
+    end
+
+    test "an unknown group id raises" do
+      assert_raise ArgumentError, ~r/unknown MCP group id "bogus-group"/, fn ->
+        Profiles.validate_registry!(
+          %{"bogus-group" => ["full"]},
+          @customizable_ids,
+          Profiles.slugs()
+        )
+      end
+    end
+
+    test "an unknown profile slug raises" do
+      assert_raise ArgumentError, ~r/unknown profile slug "freelance"/, fn ->
+        Profiles.validate_registry!(
+          %{"tickets" => ["freelance"]},
+          @customizable_ids,
+          Profiles.slugs()
+        )
+      end
+    end
+
+    # Negative compile-check: a fixture module carrying a bad @profile_groups
+    # annotation fails COMPILATION, mirroring the shipped after_compile check.
+    # Module-body raises surface as the ORIGINAL ArgumentError (not wrapped in
+    # CompileError) under Code.compile_string on this Elixir. Note:
+    # compile_string does NOT interpolate, so the unique suffix is interpolated
+    # into the source BEFORE compile_string sees it.
+    test "a fixture module with an unknown group fails to compile" do
+      assert_raise ArgumentError, ~r/unknown MCP group id "phantom"/, fn ->
+        fixture("""
+        defmodule N2aBadGroupRegistry_#{:erlang.unique_integer([:positive])} do
+          _ = NoizuPromptLingua.MCP.Toolsets.Profiles.validate_registry!(
+                %{"phantom" => ["full"]},
+                NoizuPromptLingua.MCPServers.customizable() |> Enum.map(& &1.id),
+                NoizuPromptLingua.MCP.Toolsets.Profiles.slugs()
+              )
+        end
+        """)
+      end
+    end
+
+    test "a fixture module with an unknown slug fails to compile" do
+      assert_raise ArgumentError, ~r/unknown profile slug "phantom-slug"/, fn ->
+        fixture("""
+        defmodule N2aBadSlugRegistry_#{:erlang.unique_integer([:positive])} do
+          _ = NoizuPromptLingua.MCP.Toolsets.Profiles.validate_registry!(
+                %{"tickets" => ["phantom-slug"]},
+                NoizuPromptLingua.MCPServers.customizable() |> Enum.map(& &1.id),
+                NoizuPromptLingua.MCP.Toolsets.Profiles.slugs()
+              )
+        end
+        """)
+      end
+    end
+  end
+
+  defp fixture(source), do: Code.compile_string(source)
+end

--- a/backend/test/support/mcp_tool_set_test_schema.ex
+++ b/backend/test/support/mcp_tool_set_test_schema.ex
@@ -1,0 +1,58 @@
+defmodule NoizuPromptLingua.McpToolSetTestSchema do
+  @moduledoc """
+  Idempotently ensures the Liquibase 083 `mcp_tool_sets` table exists in the
+  test DB (self-contained suite pattern). Mirrors the 083 DDL minus FK
+  constraints — the suite exercises app-level rules, not FK enforcement — and
+  keeps the named unique constraint `mcp_tool_sets_org_slug_key` the changeset
+  references.
+  """
+  alias NoizuPromptLingua.Repo
+
+  def ensure! do
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      """
+      CREATE TABLE IF NOT EXISTS mcp_tool_sets (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid NOT NULL,
+        project_id uuid,
+        group_id uuid,
+        slug varchar(64) NOT NULL,
+        display_name varchar(200),
+        description text,
+        source varchar(20) NOT NULL DEFAULT 'custom',
+        source_profile varchar(64),
+        config jsonb NOT NULL DEFAULT '{}'::jsonb,
+        settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+        expires_at timestamptz,
+        is_active boolean NOT NULL DEFAULT true,
+        inserted_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT mcp_tool_sets_org_slug_key UNIQUE (organization_id, slug),
+        CONSTRAINT mcp_tool_sets_source_check CHECK (source IN ('custom', 'clone'))
+      )
+      """,
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE INDEX IF NOT EXISTS mcp_tool_sets_org_idx ON mcp_tool_sets (organization_id)",
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE INDEX IF NOT EXISTS mcp_tool_sets_proj_idx ON mcp_tool_sets (project_id)",
+      []
+    )
+
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "CREATE INDEX IF NOT EXISTS mcp_tool_sets_group_idx ON mcp_tool_sets (group_id)",
+      []
+    )
+
+    :ok
+  end
+end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -36,6 +36,9 @@ NoizuPromptLingua.MarketingSignupTestSchema.ensure!()
 # Ensure the custom MCP include scope table exists for custom gateway/catalog tests.
 NoizuPromptLingua.MCPCustomScopeTestSchema.ensure!()
 
+# Ensure the Liquibase 083 mcp_tool_sets table exists for the tool-sets suites.
+NoizuPromptLingua.McpToolSetTestSchema.ensure!()
+
 # Ensure the W4 MCP entity tables (Liquibase 019: mcp_prompts, mcp_prompt_versions,
 # mcp_resources, mcp_resource_templates) exist for the mcp-entities suites. Idempotent.
 NoizuPromptLingua.McpEntitiesTestSchema.ensure!()


### PR DESCRIPTION
## Summary

Implements **N2a only** of [PRD-N2-storage-providers.md](../blob/feat/n2a-tool-sets-storage/project-management/PRDs/PRD-N2-storage-providers.md) — storage/schema/context/profile-data on hex 0.1.5, zero lib deps, `mix.exs` untouched. N2b sections are NOT in this PR (gated on lib PRD-4). Staged-validation gap per PRD §8 applies: set configs get structural validation only until N4b `Validator.compile/3`; read-side D5 covers the gap.

- **083 migration** (`db/changelog/083-mcp-tool-sets.yaml` + master registration): `mcp_tool_sets` per FR-2A-1 DDL (org-wide `(organization_id, slug)` unique across shapes — R4; FKs to `organizations`/`projects`/`groups`; `source` CHECK; 3 indexes).
- **`Schema.MCPToolSet`**: slugify via `SlugBackfill.slugify/1` (+ display-name fallback), reserved slugs (`full|agent-ops|pm-dev|content|comms` + `root`), org-wide unique (friendly `:slug` error + named-constraint backstop), closed-vocabulary `config` validation (unknown keys rejected at every level; rename collisions; type checks — no live-catalog validation, that's N4b), settings whitelist, shape invariants (org/project/group XOR; group-set requires existing authz `groups` row), clone provenance invariant. Identity fields (slug/org/project/group/source/source_profile) are create-only.
- **`MCP.ToolSets` context**: `create/update/deactivate/clone/list_for_org/get_by_org_and_slug/get_for_request (active + expires_at)/assemble_custom (thin seam)/to_overrides (pure)`. `clone/2` from profile (allowlist config, `source_profile`) or set (deep-copied config, `settings.cloned_from`), slug auto-suggest `<slug>-copy(-N)`. All write paths fire `MCP.Server.notify_toolset_changed/0` (N1 wiring intact, best-effort) + Logger event; actor stamping rides `settings.updated_by` in-row (carry_audit precedent — no new audit table).
- **`MCP.Toolsets.Profiles`**: 5 profiles as DATA + `@profile_groups` annotation registry (Q2 Decision-4 DSL). `full` == `MCPServers.customizable()` (21); registry compile-validated via `@after_compile` (unknown group/slug fails compilation); `browser` is `full`-only by design.

## Test evidence

- New scoped suites: **53/53 green** — `backend/test/noizu_prompt_lingua/mcp/tool_sets_test.exs` (changeset matrices AC-2A-2/3/5, clone AC-2A-6, get_for_request scoping AC-2A-8, to_overrides purity+vocabulary AC-2A-4) and `.../mcp/toolsets/profiles_test.exs` (AC-2A-7 incl. negative `Code.compile_string` fixture checks).
- Adjacent suites (cache/key-toolsets/custom-key/session-manifest/scope-packaging/effective-toolset/custom-gateway): **107 passed**.
- Migration AC-2A-1 proven with real Liquibase on a cloned scratch DB: standalone changelog `update` (table + unique constraint + 3 FKs + CHECK + 3 indexes) → `rollback-count 1` (all objects dropped) → re-`update` (clean). Full-changelog replay onto the stale test-DB changelog state fails at `001-enums` — the pre-existing fresh-DB gap (per plan; not chased). Repo pattern kept: suite DDL self-contained via `McpToolSetTestSchema.ensure!` (FK-less, app-level rules).
- `mix compile --force`: zero warnings in the new/edited files (pre-existing warnings in untouched files unchanged). `mix format` applied to all touched files.

## Deviations (all flagged for PRD review)

1. **FR-2A-6 "group-id registry check" not implementable as written**: `group_id` is a uuid FK to authz `groups` (DDL in FR-2A-1 + N3's `active_member?/3` group gate both require it), so it can never hold a string registry id. Implemented the satisfiable reading: group-set requires an EXISTING authz `groups` row. PRD correction suggested.
2. **Settings whitelist vs. system keys**: PRD puts `cloned_from` in settings (open question 4) and in-row audit needs `updated_by`; both are RESERVED SYSTEM keys exempt from the caller-facing 3-key whitelist (context-stamped only).
3. **`to_overrides` determinism**: explicit tool `enabled: true` emits no ops (explicit default); group-level `enabled` is include-metadata for the N2b allowlist, not an override op (can't expand without the catalog). Stable order = sorted group/tool/arg keys + fixed per-level op order.
4. **`update` also accepts `expires_at`** (operational need for time-limited sets) beyond the PRD's config/settings/display_name/description/is_active list; identity fields stay create-only.
5. **Negative compile-check asserts `ArgumentError`** — Elixir 1.20 surfaces module-body raises unwrapped through `Code.compile_string`; the compilation still fails (that's the guarantee under test).
6. Branch named `feat/n2a-tool-sets-storage` (per directive) vs PRD's `feat/n2a-storage`.

## Open questions from PRD §10 relevant to N2a

- **Q1 project-set FK semantics**: FK kept as specified; suites run FK-less (repo pattern), so TRP-backed `projects` rows are unverified — resolver-time validation lands at N3 as the PRD anticipates.
- **Q2 `description_verbosity`**: implemented `full | concise | minimal` as proposed.
- **Q4 clone provenance**: `settings.cloned_from` implemented (with the whitelist exemption above).
- Q3 is N2b scope.

Do NOT merge before N1 per the gate order — not merging from this PR.