### PR TITLE
N4a: tool-set admin CRUD + frontend (contract-first, hex 0.1.5)

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/tool_sets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/tool_sets.ex
@@ -107,7 +107,7 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
         |> Map.merge(%{
           "source" => "clone",
           "source_profile" => source,
-          "settings" => %{}
+          "settings" => Map.merge(caller_settings(attrs), %{})
         })
         |> create_from_clone(opts, source)
     end
@@ -119,7 +119,7 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
     |> Map.merge(%{
       "source" => "clone",
       "source_profile" => nil,
-      "settings" => %{"cloned_from" => source.slug}
+      "settings" => Map.merge(caller_settings(attrs), %{"cloned_from" => source.slug})
     })
     |> create_from_clone(opts, source.slug)
   end
@@ -157,6 +157,16 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
     }
   end
 
+  # Caller-supplied settings (N4a in-row audit seeds `_audit`) merged UNDER the
+  # clone-provenance keys, which always win.
+  defp caller_settings(attrs) do
+    attrs
+    |> Map.new(fn {k, v} -> {to_string(k), v} end)
+    |> Map.get("settings")
+    |> Kernel.||(%{})
+    |> stringify_map()
+  end
+
   # First free "<base>-copy" / "<base>-copy-N" slug within the org.
   defp suggest_slug(nil, _base), do: nil
 
@@ -192,17 +202,31 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
     |> MapSet.new()
   end
 
-  @doc "Active sets for an org, every audience shape, oldest first."
-  def list_for_org(org_id) when is_binary(org_id) do
-    Repo.all(
-      from(s in MCPToolSet,
-        where: s.organization_id == ^org_id and s.is_active == true,
-        order_by: [asc: s.inserted_at, asc: s.slug]
-      )
-    )
+  @doc """
+  Sets for an org, every audience shape, oldest first. Active-only by default
+  (the request path's universe); `opts[:include_inactive]` adds deactivated
+  rows — the admin index needs those (FR-4-3: deactivated sets remain listable).
+  """
+  def list_for_org(org_id, opts \\ [])
+
+  def list_for_org(org_id, opts) when is_binary(org_id) do
+    query =
+      if Keyword.get(opts, :include_inactive, false) do
+        from(s in MCPToolSet,
+          where: s.organization_id == ^org_id,
+          order_by: [asc: s.inserted_at, asc: s.slug]
+        )
+      else
+        from(s in MCPToolSet,
+          where: s.organization_id == ^org_id and s.is_active == true,
+          order_by: [asc: s.inserted_at, asc: s.slug]
+        )
+      end
+
+    Repo.all(query)
   end
 
-  def list_for_org(_), do: []
+  def list_for_org(_, _), do: []
 
   def get(id) when is_binary(id), do: Repo.get(MCPToolSet, id)
   def get(_), do: nil

--- a/backend/lib/noizu_prompt_lingua/schema/mcp_tool_set.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/mcp_tool_set.ex
@@ -39,10 +39,10 @@ defmodule NoizuPromptLingua.Schema.MCPToolSet do
   @arg_keys ~w(enum_remove hide rename default description)
 
   # Settings whitelist (FR-2A-5) governs CLIENT-supplied keys. `cloned_from`
-  # (clone provenance, open question 4) and `updated_by` (in-row audit stamp)
-  # are RESERVED SYSTEM keys — written only by the MCP.ToolSets context, not
-  # validated here.
-  @settings_system_keys ~w(cloned_from updated_by)
+  # (clone provenance, open question 4), `updated_by` (in-row audit stamp) and
+  # `_audit` (bounded mutation trail, PRD-N4 §4.1) are RESERVED SYSTEM keys —
+  # written only by the MCP.ToolSets context / admin controller, not validated.
+  @settings_system_keys ~w(cloned_from updated_by _audit)
   @settings_keys ~w(allow_api_keys description_verbosity instructions)
   @verbosity ~w(full concise minimal)
 

--- a/backend/lib/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller.ex
@@ -1,0 +1,511 @@
+defmodule NoizuPromptLinguaWeb.ToolSetProfilesController do
+  @moduledoc """
+  Org-admin management for MCP tool sets (PRD-N4 §4.1, N4a scope): list the 5
+  built-in profiles (read-only DATA, R1) next to the org's own sets, and
+  create / update / deactivate / clone sets through `MCP.ToolSets`.
+
+  Contract-first on pinned hex noizu_mcp 0.1.5 — no lib calls. Structural
+  validation only (the N2a changeset is the single authority, FR-4-3); the
+  validate dry-run + effective-catalog preview are N4b (gated on lib PRD-3).
+
+    # N4b: dry-run Validator.compile/3 seam — `POST .../tool-sets/validate`
+    # (candidate config → issues) lands with the PRD-3 gate.
+
+  Every mutation records in-row provenance under `settings["_audit"]`
+  (bounded, last 20 — the `MCPCustomScopes.carry_audit` precedent; NPL has no
+  dedicated audit table) plus a structured Logger event. Audit failure NEVER
+  fails the mutation (log-only path, FR-4-5).
+  """
+  use NoizuPromptLinguaWeb, :controller
+
+  require Logger
+
+  alias NoizuPromptLingua.Guardian
+  alias NoizuPromptLingua.MCP.ToolSets
+  alias NoizuPromptLingua.MCP.Toolsets.Profiles
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.Authz.Group
+  alias NoizuPromptLingua.Schema.MCPToolSet
+  alias NoizuPromptLingua.Tools.Catalog
+  alias NoizuPromptLingua.Authz.ScopedMemberships
+
+  # Reserved settings keys preserved across updates (never client-writable).
+  @system_keys ~w(cloned_from updated_by _audit)
+
+  # In-row audit trail bound (PRD-N4 §4.1: last 20).
+  @audit_max 20
+
+  @doc """
+  GET /api/v1/organizations/:org_id/tool-sets — built-in profiles (from DATA,
+  never rows) + the org's sets (active AND deactivated, FR-4-3) with shape,
+  digest and group-set member counts.
+  """
+  def index(conn, %{"org_id" => org_id}) do
+    counts = group_tool_counts()
+
+    json(conn, %{
+      profiles: Enum.map(Profiles.all(), &profile_view(&1, counts)),
+      sets:
+        org_id
+        |> ToolSets.list_for_org(include_inactive: true)
+        |> Enum.map(&set_view/1)
+    })
+  end
+
+  @doc """
+  GET .../tool-sets/:slug — resolves built-in profile slugs to their read-only
+  view (with a structural preview over the registry) and anything else to the
+  org's row (404 for foreign slugs — no cross-org read, FR-4-1).
+  """
+  def show(conn, %{"org_id" => org_id, "slug" => slug}) do
+    counts = group_tool_counts()
+
+    cond do
+      profile = Profiles.get(slug) ->
+        view =
+          profile
+          |> profile_view(counts)
+          |> Map.put(:preview, profile_preview(profile, counts))
+
+        json(conn, %{profile: view})
+
+      tool_set = ToolSets.get_by_org_and_slug(org_id, slug) ->
+        view =
+          tool_set
+          |> set_view(with_audit: true)
+          |> Map.put(:preview, structural_preview(tool_set, counts))
+          # The edit form needs the full config; the list view carries only the
+          # digest.
+          |> Map.put(:config, tool_set.config)
+
+        json(conn, %{tool_set: view})
+
+      true ->
+        not_found(conn)
+    end
+  end
+
+  @doc """
+  POST .../tool-sets — create a custom set. Organization, source and
+  provenance are controller-owned (`source: "custom"`; cloning is the clone
+  route's job). Identity fields (project/group audience) ride the create
+  changeset. 201 + set_view, or 422 + changeset field errors.
+  """
+  def create(conn, %{"org_id" => org_id} = params) do
+    actor_id = current_user_id(conn)
+    body = set_params(params)
+
+    attrs =
+      body
+      |> Map.put("organization_id", org_id)
+      |> Map.drop(["source", "source_profile", "settings"])
+
+    settings = audit_settings(%{}, Map.get(body, "settings"), "create", actor_id)
+
+    case ToolSets.create(Map.put(attrs, "settings", settings), actor_id: actor_id) do
+      {:ok, tool_set} ->
+        audit_log("create", tool_set.slug, actor_id, "ok")
+
+        conn
+        |> put_status(:created)
+        |> json(%{tool_set: set_view(tool_set, with_audit: true)})
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        audit_log("create", attrs["slug"] || attrs["display_name"], actor_id, "error")
+        changeset_error(conn, cs)
+    end
+  end
+
+  @doc """
+  PATCH .../tool-sets/:slug — partial update of config/settings/display_name/
+  description/expires_at/is_active. Profile slugs are rejected controller-side
+  (FR-4-4). Deactivated sets reactivate via `is_active: true`.
+  """
+  def update(conn, %{"org_id" => org_id, "slug" => slug} = params) do
+    with {:ok, actor_id} <- require_actor(conn),
+         :ok <- reject_profile_slug(slug),
+         {:ok, tool_set} <- load_set(org_id, slug) do
+      submitted =
+        params
+        |> set_params()
+        |> Map.take([
+          "display_name",
+          "description",
+          "config",
+          "settings",
+          "expires_at",
+          "is_active"
+        ])
+
+      if submitted == %{} do
+        json(conn, %{tool_set: set_view(tool_set)})
+      else
+        attrs = Map.delete(submitted, "settings")
+
+        settings =
+          audit_settings(tool_set.settings, Map.get(submitted, "settings"), "update", actor_id)
+
+        case ToolSets.update(tool_set, Map.put(attrs, "settings", settings), actor_id: actor_id) do
+          {:ok, updated} ->
+            audit_log("update", updated.slug, actor_id, "ok")
+            json(conn, %{tool_set: set_view(updated, with_audit: true)})
+
+          {:error, %Ecto.Changeset{} = cs} ->
+            audit_log("update", slug, actor_id, "error")
+            changeset_error(conn, cs)
+        end
+      end
+    else
+      {:error, :read_only_profile} -> read_only(conn)
+      {:error, :not_found} -> not_found(conn)
+    end
+  end
+
+  @doc """
+  POST .../tool-sets/:slug/deactivate — soft-kill (R8), idempotent. The set
+  drops out of the request path (`get_for_request/2`, AC-2A-8) but stays
+  listable in the index with `is_active: false`.
+  """
+  def deactivate(conn, %{"org_id" => org_id, "slug" => slug}) do
+    with {:ok, actor_id} <- require_actor(conn),
+         :ok <- reject_profile_slug(slug),
+         {:ok, tool_set} <- load_set(org_id, slug) do
+      settings = audit_settings(tool_set.settings, nil, "deactivate", actor_id)
+
+      # Routed through update/3 (the context deactivate/2 wrapper cannot carry
+      # the audited settings) — same changeset, same notify-on-ok path.
+      case ToolSets.update(tool_set, %{"is_active" => false, "settings" => settings},
+             actor_id: actor_id
+           ) do
+        {:ok, updated} ->
+          audit_log("deactivate", updated.slug, actor_id, "ok")
+          json(conn, %{tool_set: set_view(updated, with_audit: true)})
+
+        {:error, %Ecto.Changeset{} = cs} ->
+          audit_log("deactivate", slug, actor_id, "error")
+          changeset_error(conn, cs)
+      end
+    else
+      {:error, :read_only_profile} -> read_only(conn)
+      {:error, :not_found} -> not_found(conn)
+    end
+  end
+
+  @doc """
+  POST .../tool-sets/clone — `{source: profile_slug | set_slug, ...attrs}` →
+  201 + new editable set (FR-2A-7 semantics: allowlist config deep-copied from
+  the profile, provenance recorded, slug auto-suggested `<source>-copy`).
+  Validation of the copied config is N4b machinery.
+  """
+  def clone(conn, %{"org_id" => org_id} = params) do
+    with {:ok, actor_id} <- require_actor(conn),
+         {:ok, source, source_slug} <- resolve_source(org_id, params) do
+      # `source` rides at the top level (PRD §4.1) while the create attrs may
+      # sit under the `tool_set` wrapper — merge both views. Organization is
+      # controller-owned (path-resolved UUID).
+      body =
+        params
+        |> set_params()
+        |> Map.put("source", params["source"] || set_params(params)["source"])
+        |> Map.put("organization_id", org_id)
+        |> Map.delete("settings")
+
+      settings = audit_settings(%{}, Map.get(set_params(params), "settings"), "clone", actor_id)
+
+      case ToolSets.clone(source, Map.put(body, "settings", settings), actor_id: actor_id) do
+        {:ok, tool_set} ->
+          audit_log("clone", tool_set.slug, actor_id, "ok")
+
+          conn
+          |> put_status(:created)
+          |> json(%{tool_set: set_view(tool_set, with_audit: true)})
+
+        {:error, %Ecto.Changeset{} = cs} ->
+          audit_log("clone", source_slug, actor_id, "error")
+          changeset_error(conn, cs)
+
+        {:error, other} ->
+          audit_log("clone", source_slug, actor_id, "error")
+          conn |> put_status(:unprocessable_entity) |> json(%{error: inspect(other)})
+      end
+    else
+      {:error, :not_found} -> not_found(conn, "source tool set not found")
+    end
+  end
+
+  # ---- params ----
+
+  # Accept a `tool_set` (or `set`) wrapper or a flat body, string-keyed.
+  defp set_params(%{"tool_set" => attrs}) when is_map(attrs), do: stringify(attrs)
+  defp set_params(%{"set" => attrs}) when is_map(attrs), do: stringify(attrs)
+  defp set_params(attrs) when is_map(attrs), do: stringify(attrs)
+
+  defp stringify(map) do
+    Map.new(map, fn
+      {k, v} when is_atom(k) -> {Atom.to_string(k), v}
+      {k, v} -> {k, v}
+    end)
+  end
+
+  defp resolve_source(org_id, params) do
+    source = params["source"] || set_params(params)["source"]
+
+    cond do
+      not is_binary(source) or source == "" ->
+        {:error, :not_found}
+
+      is_binary(source) and not is_nil(Profiles.get(source)) ->
+        {:ok, source, source}
+
+      tool_set = ToolSets.get_by_org_and_slug(org_id, source) ->
+        {:ok, tool_set, source}
+
+      true ->
+        {:error, :not_found}
+    end
+  end
+
+  defp load_set(org_id, slug) do
+    case ToolSets.get_by_org_and_slug(org_id, slug) do
+      nil -> {:error, :not_found}
+      tool_set -> {:ok, tool_set}
+    end
+  end
+
+  defp reject_profile_slug(slug) do
+    if slug in Profiles.slugs() or slug in MCPToolSet.reserved_slugs() do
+      {:error, :read_only_profile}
+    else
+      :ok
+    end
+  end
+
+  # ---- audit (FR-4-5) ----
+
+  # Final settings for a mutation: when the client submits `settings` it
+  # replaces the editable keys (system keys survive from the row), when it
+  # does not the row's settings ride along unchanged — either way the audit
+  # entry is appended (bounded trail). System keys are never client-writable.
+  defp audit_settings(current, provided, action, actor_id) do
+    trail =
+      case Map.get(current || %{}, "_audit") do
+        entries when is_list(entries) -> Enum.take(entries, -(@audit_max - 1))
+        _ -> []
+      end
+
+    entry = %{
+      "at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "actor" => actor_id,
+      "action" => action
+    }
+
+    base =
+      if is_map(provided) do
+        (current || %{})
+        |> Map.take(@system_keys)
+        |> Map.merge(stringify(provided))
+      else
+        stringify(current || %{})
+      end
+
+    Map.put(base, "_audit", trail ++ [entry])
+  rescue
+    _ ->
+      %{
+        "_audit" => [
+          %{
+            "at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+            "actor" => actor_id,
+            "action" => action
+          }
+        ]
+      }
+  end
+
+  # Structured Logger event with the same fields as the in-row provenance.
+  # Best-effort: a logging failure must never fail the mutation (FR-4-5).
+  defp audit_log(action, target, actor_id, result) do
+    Logger.info("mcp_tool_set #{action} slug=#{target}",
+      event: [:mcp_tool_set, :mutation],
+      action: action,
+      target: target,
+      actor: actor_id,
+      result: result
+    )
+  rescue
+    _ -> :ok
+  end
+
+  # ---- views ----
+
+  defp profile_view(profile, counts) do
+    %{
+      slug: profile.slug,
+      display_name: profile.label,
+      description: profile.description,
+      groups: profile.groups,
+      group_count: length(profile.groups),
+      tool_count: profile.groups |> Enum.map(&Map.get(counts, &1, 0)) |> Enum.sum(),
+      cloneable: true,
+      editable: false,
+      is_profile: true,
+      is_active: true
+    }
+  end
+
+  # Structural preview over the registry for a profile: what a clone would
+  # start from. NOT an effective-catalog preview — that is N4b (D1).
+  defp profile_preview(profile, counts) do
+    %{
+      groups:
+        Map.new(profile.groups, fn group_id ->
+          {group_id,
+           %{
+             enabled: true,
+             tool_count: Map.get(counts, group_id, 0),
+             overridden_tools: 0,
+             override_ops: 0
+           }}
+        end),
+      total_override_ops: 0
+    }
+  end
+
+  defp set_view(tool_set, opts \\ []) do
+    settings = tool_set.settings || %{}
+
+    view = %{
+      id: tool_set.id,
+      slug: tool_set.slug,
+      display_name: tool_set.display_name || tool_set.slug,
+      description: tool_set.description,
+      shape: shape_of(tool_set),
+      project_id: tool_set.project_id,
+      group_id: tool_set.group_id,
+      source: tool_set.source,
+      source_profile: tool_set.source_profile,
+      is_active: tool_set.is_active,
+      expires_at: to_iso8601(tool_set.expires_at),
+      config_digest: digest(tool_set.config),
+      # Live count for group sets (org members carrying the group's role);
+      # nil otherwise. Computed per request — fine at admin scale (PRD §10.3).
+      member_count: member_count(tool_set),
+      settings: Map.take(settings, ~w(allow_api_keys description_verbosity instructions)),
+      updated_by: Map.get(settings, "updated_by"),
+      updated_at: to_iso8601(tool_set.updated_at),
+      # N3 seam: the gateway/set URL builders land with PRD-N3.
+      urls: %{mcp: nil, admin: nil}
+    }
+
+    if Keyword.get(opts, :with_audit, false) do
+      Map.put(view, :audit, Map.get(settings, "_audit", []))
+    else
+      view
+    end
+  end
+
+  # Structural preview for a stored set: per-group registry tool counts +
+  # override-op census computed from the row's config. No lib, no catalog
+  # compile (N4b's D1-correct preview replaces this at the flip).
+  defp structural_preview(tool_set, counts) do
+    groups = Map.get(tool_set.config || %{}, "groups", %{})
+
+    group_previews =
+      Map.new(groups, fn {group_id, group_cfg} ->
+        tools = Map.get(group_cfg || %{}, "tools", %{})
+
+        {group_id,
+         %{
+           enabled: Map.get(group_cfg || %{}, "enabled", true),
+           tool_count: Map.get(counts, group_id, 0),
+           overridden_tools: map_size(tools),
+           override_ops: length(ToolSets.to_overrides(%{"groups" => %{group_id => group_cfg}}))
+         }}
+      end)
+
+    %{groups: group_previews, total_override_ops: length(ToolSets.to_overrides(tool_set.config))}
+  end
+
+  defp shape_of(%MCPToolSet{group_id: gid}) when is_binary(gid), do: "group"
+  defp shape_of(%MCPToolSet{project_id: pid}) when is_binary(pid), do: "project"
+  defp shape_of(%MCPToolSet{}), do: "org"
+
+  # Group-set audience size: org members whose membership row carries the
+  # set's group (role). via ScopedMemberships.list_for_resource/3 (PRD §10.3).
+  defp member_count(%MCPToolSet{group_id: gid, organization_id: org_id})
+       when is_binary(gid) and is_binary(org_id) do
+    case Repo.get(Group, gid) do
+      nil ->
+        nil
+
+      group ->
+        org_members = ScopedMemberships.list_for_resource("organization", org_id)
+        Enum.count(org_members, &(&1.role == group.name))
+    end
+  end
+
+  defp member_count(_), do: nil
+
+  # Per-group tool counts, enumerated from each group's MCP server module
+  # (MCPServers.server_module/1 — the root server catalog only carries core
+  # groups). Computed once per index/show call; admin scale (PRD §10.3).
+  defp group_tool_counts do
+    Map.new(MCPServers.customizable(), fn group ->
+      case MCPServers.server_module(group.id) do
+        nil ->
+          {group.id, 0}
+
+        module ->
+          {group.id, length(Catalog.specs(module))}
+      end
+    end)
+  end
+
+  defp digest(config) when is_map(config) do
+    :crypto.hash(:sha256, Jason.encode!(config))
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 12)
+  end
+
+  defp digest(_), do: nil
+
+  defp to_iso8601(nil), do: nil
+  defp to_iso8601(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  defp to_iso8601(_), do: nil
+
+  # ---- auth helpers (mcp_endpoints_controller pattern) ----
+
+  defp require_actor(conn) do
+    case current_user_id(conn) do
+      nil -> {:error, :not_found}
+      id -> {:ok, id}
+    end
+  end
+
+  defp current_user_id(conn) do
+    case Guardian.Plug.current_resource(conn) do
+      %{user: {:ref, _, id}} when is_binary(id) -> id
+      %{user: %{id: id}} when is_binary(id) -> id
+      _ -> nil
+    end
+  end
+
+  defp not_found(conn, msg \\ "tool set not found"),
+    do: conn |> put_status(:not_found) |> json(%{error: msg})
+
+  defp read_only(conn),
+    do:
+      conn
+      |> put_status(:unprocessable_entity)
+      |> json(%{
+        error: "built-in profiles are read-only; clone one to customize",
+        code: "profile_read_only"
+      })
+
+  defp changeset_error(conn, cs) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{errors: Ecto.Changeset.traverse_errors(cs, fn {msg, _} -> msg end)})
+  end
+end

--- a/backend/lib/noizu_prompt_lingua_web/router.ex
+++ b/backend/lib/noizu_prompt_lingua_web/router.ex
@@ -462,6 +462,21 @@ defmodule NoizuPromptLinguaWeb.Router do
     resources "/members", MembershipController, only: [:index, :show, :create, :update, :delete]
   end
 
+  # N4a: MCP tool-set admin (PRD-N4 §4.1) — built-in profiles (read-only, R1)
+  # next to the org's own sets; create/update/deactivate/clone through
+  # MCP.ToolSets. Org-admin gated; serving gateway lands at N3.
+  # N4b: `POST .../tool-sets/validate` (Validator.compile/3 dry-run) lands with
+  # the PRD-3 gate — see the seam marker in ToolSetProfilesController.
+  scope "/api/v1/organizations/:org_id", NoizuPromptLinguaWeb do
+    pipe_through [:api, :authenticated, :org_admin]
+    post "/tool-sets/clone", ToolSetProfilesController, :clone
+    get "/tool-sets", ToolSetProfilesController, :index
+    post "/tool-sets", ToolSetProfilesController, :create
+    get "/tool-sets/:slug", ToolSetProfilesController, :show
+    patch "/tool-sets/:slug", ToolSetProfilesController, :update
+    post "/tool-sets/:slug/deactivate", ToolSetProfilesController, :deactivate
+  end
+
   # Browser feature: controller-connected status + captured screenshots/videos.
   scope "/api/v1/organizations/:org_id", NoizuPromptLinguaWeb do
     pipe_through [:api, :authenticated, :org_viewer]
@@ -533,8 +548,14 @@ defmodule NoizuPromptLinguaWeb.Router do
     # D3: per-scope client permissions — client universe + per-client
     # toolset_config jsonb (F2 EffectiveToolset cascade layer 3).
     get "/mcp-custom-scopes/:slug/clients", AdminController, :list_scope_clients
-    get "/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config", AdminController, :show_client_toolset_config
-    put "/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config", AdminController, :update_client_toolset_config
+
+    get "/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config",
+        AdminController,
+        :show_client_toolset_config
+
+    put "/mcp-custom-scopes/:slug/clients/:kind/:id/toolset_config",
+        AdminController,
+        :update_client_toolset_config
 
     # D3: ACL group admin (F1 NoizuPromptLingua.Acl context) — group CRUD +
     # membership. DELETE groups is a soft archive; member refs are ERP refs

--- a/backend/test/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller_test.exs
@@ -1,0 +1,497 @@
+defmodule NoizuPromptLinguaWeb.ToolSetProfilesControllerTest do
+  @moduledoc """
+  N4a controller contract (PRD-N4 AC-N4-1..5): org-admin auth matrix, index
+  composition (profiles from DATA + org sets with shape/member counts), CRUD
+  happy paths + structural rejections, built-in immutability, clone semantics
+  (profile + set sources, slug reservation), and the in-row `_audit` trail.
+  """
+
+  use NoizuPromptLinguaWeb.ConnCase
+  @moduletag :capture_log
+
+  alias NoizuPromptLingua.Authz.ScopedMemberships
+  alias NoizuPromptLingua.MCP.ToolSets
+
+  @base "/api/v1/organizations"
+
+  @valid_config %{
+    "groups" => %{
+      "tickets" => %{
+        "enabled" => true,
+        "tools" => %{"Tickets_Create" => %{"name" => "create_ticket"}}
+      }
+    }
+  }
+
+  setup %{conn: conn} do
+    %{user: user, access_token: token} = setup_user_and_token()
+    conn = authenticated_conn(conn, token)
+    org_id = create_org(conn, "n4a")
+
+    {:ok, conn: conn, user: user, org_id: org_id, base: "#{@base}/#{org_id}/tool-sets"}
+  end
+
+  # ---- AC-N4-1: auth matrix ----
+
+  describe "auth matrix" do
+    test "unauthenticated request -> 401", %{base: base} do
+      assert json_response(get(build_conn(), base), 401)
+    end
+
+    test "non-member -> 403", %{base: base} do
+      %{access_token: token} = setup_user_and_token()
+      assert json_response(get(authenticated_conn(build_conn(), token), base), 403)
+    end
+
+    test "viewer-role member -> 403 (below the admin bar)", %{base: base, org_id: org_id} do
+      %{access_token: token, user: viewer} = setup_user_and_token()
+      {:ok, _} = ScopedMemberships.add_member("organization", org_id, viewer.id, "viewer")
+
+      assert json_response(get(authenticated_conn(build_conn(), token), base), 403)
+    end
+
+    test "cross-org slug -> 404 even for an admin of the querying org", %{
+      conn: conn,
+      base: base
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      other_org = create_org(conn, "n4a-other")
+
+      conn
+      |> get("#{@base}/#{other_org}/tool-sets/#{body["tool_set"]["slug"]}")
+      |> json_response(404)
+    end
+  end
+
+  # ---- AC-N4-2: index composition ----
+
+  describe "index" do
+    test "lists the 5 built-in profiles from DATA, read-only + cloneable", %{
+      conn: conn,
+      base: base
+    } do
+      %{"profiles" => profiles} = conn |> get(base) |> json_response(200)
+
+      assert length(profiles) == 5
+      slugs = Enum.map(profiles, & &1["slug"])
+      assert slugs == ~w(full agent-ops pm-dev content comms)
+
+      full = Enum.find(profiles, &(&1["slug"] == "full"))
+      assert full["cloneable"] == true
+      assert full["editable"] == false
+      assert full["is_profile"] == true
+      assert full["group_count"] == 21
+      assert length(full["groups"]) == 21
+      assert full["tool_count"] > 0
+    end
+
+    test "lists org sets with shape and live member_count for group sets", %{
+      conn: conn,
+      base: base,
+      org_id: org_id
+    } do
+      group_id = insert_group("member")
+      %{user: m1} = setup_user_and_token()
+      %{user: m2} = setup_user_and_token()
+      {:ok, _} = ScopedMemberships.add_member("organization", org_id, m1.id, "member")
+      {:ok, _} = ScopedMemberships.add_member("organization", org_id, m2.id, "member")
+
+      conn
+      |> post(base, %{tool_set: valid_attrs()})
+      |> json_response(201)
+
+      conn
+      |> post(base, %{
+        tool_set: valid_attrs(%{"slug" => "proj-set", "project_id" => Ecto.UUID.generate()})
+      })
+      |> json_response(201)
+
+      group_set =
+        (conn
+         |> post(base, %{tool_set: valid_attrs(%{"slug" => "alpha-set", "group_id" => group_id})})
+         |> json_response(201))["tool_set"]
+
+      %{"sets" => sets} = conn |> get(base) |> json_response(200)
+      by_slug = Map.new(sets, &{&1["slug"], &1})
+
+      assert by_slug["release-ops"]["shape"] == "org"
+      assert by_slug["release-ops"]["member_count"] == nil
+      assert by_slug["proj-set"]["shape"] == "project"
+      assert by_slug["alpha-set"]["shape"] == "group"
+      assert by_slug["alpha-set"]["group_id"] == group_id
+      assert by_slug["alpha-set"]["member_count"] == 2
+    end
+
+    test "deactivated set remains listed with is_active false (FR-4-3)", %{
+      conn: conn,
+      base: base
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+      conn |> post("#{base}/#{slug}/deactivate") |> json_response(200)
+
+      %{"sets" => sets} = conn |> get(base) |> json_response(200)
+      listed = Enum.find(sets, &(&1["slug"] == slug))
+
+      assert listed
+      assert listed["is_active"] == false
+    end
+  end
+
+  # ---- AC-N4-3: CRUD ----
+
+  describe "create" do
+    test "creates a set -> 201 + view", %{conn: conn, base: base} do
+      %{"tool_set" => tool_set} =
+        conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+
+      assert tool_set["slug"] == "release-ops"
+      assert tool_set["display_name"] == "Release Ops"
+      assert tool_set["shape"] == "org"
+      assert tool_set["is_active"] == true
+      assert tool_set["source"] == "custom"
+      assert tool_set["source_profile"] == nil
+      assert tool_set["settings"]["allow_api_keys"] == true
+      assert tool_set["settings"]["description_verbosity"] == "concise"
+      assert is_binary(tool_set["config_digest"])
+      assert String.length(tool_set["config_digest"]) == 12
+    end
+
+    test "duplicate slug -> 422 with slug field error", %{conn: conn, base: base} do
+      conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+
+      %{"errors" => errors} =
+        conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(422)
+
+      assert errors["slug"]
+    end
+
+    test "reserved profile slug -> 422 (changeset backstop)", %{conn: conn, base: base} do
+      %{"errors" => errors} =
+        conn
+        |> post(base, %{tool_set: valid_attrs(%{"slug" => "full"})})
+        |> json_response(422)
+
+      assert errors["slug"]
+    end
+
+    test "unknown config vocabulary key -> 422 (structural only)", %{conn: conn, base: base} do
+      bad_config =
+        put_in(@valid_config, ["groups", "tickets", "tools", "Tickets_Create", "wibble"], true)
+
+      %{"errors" => errors} =
+        conn
+        |> post(base, %{tool_set: valid_attrs(%{"config" => bad_config})})
+        |> json_response(422)
+
+      assert Enum.any?(errors["config"], &(&1 =~ "unknown key"))
+    end
+
+    test "unknown settings key -> 422", %{conn: conn, base: base} do
+      attrs =
+        valid_attrs(%{"settings" => %{"allow_api_keys" => true, "mystery_key" => 1}})
+
+      %{"errors" => errors} = conn |> post(base, %{tool_set: attrs}) |> json_response(422)
+
+      assert Enum.any?(errors["settings"], &(&1 =~ "unknown key"))
+    end
+  end
+
+  describe "show" do
+    test "returns the row with structural preview + audit trail", %{conn: conn, base: base} do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+
+      %{"tool_set" => tool_set} =
+        conn |> get("#{base}/#{slug}") |> json_response(200)
+
+      assert tool_set["slug"] == slug
+      preview = tool_set["preview"]
+      assert preview["groups"]["tickets"]["tool_count"] > 0
+      assert preview["groups"]["tickets"]["overridden_tools"] == 1
+      assert preview["groups"]["tickets"]["override_ops"] == 1
+      assert preview["total_override_ops"] == 1
+      assert [%{"action" => "create"}] = tool_set["audit"]
+    end
+
+    test "profile slugs resolve to the read-only profile view + preview", %{
+      conn: conn,
+      base: base
+    } do
+      %{"profile" => profile} = conn |> get("#{base}/full") |> json_response(200)
+
+      assert profile["is_profile"] == true
+      assert profile["group_count"] == 21
+      assert profile["preview"]["groups"]["tickets"]["overridden_tools"] == 0
+    end
+
+    test "unknown slug -> 404", %{conn: conn, base: base} do
+      assert json_response(get(conn, "#{base}/never-existed"), 404)
+    end
+  end
+
+  describe "update" do
+    test "partial update applies; unsubmitted fields untouched", %{conn: conn, base: base} do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+
+      %{"tool_set" => updated} =
+        conn
+        |> patch("#{base}/#{slug}", %{tool_set: %{"display_name" => "Renamed"}})
+        |> json_response(200)
+
+      assert updated["display_name"] == "Renamed"
+
+      %{"tool_set" => shown} = conn |> get("#{base}/#{slug}") |> json_response(200)
+      assert shown["config_digest"] == body["tool_set"]["config_digest"]
+      assert shown["settings"]["description_verbosity"] == "concise"
+    end
+
+    test "settings update preserves system keys and appends audit", %{
+      conn: conn,
+      base: base,
+      user: user
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+
+      conn
+      |> patch("#{base}/#{slug}", %{tool_set: %{"settings" => %{"allow_api_keys" => false}}})
+      |> json_response(200)
+
+      %{"tool_set" => shown} = conn |> get("#{base}/#{slug}") |> json_response(200)
+
+      assert shown["settings"]["allow_api_keys"] == false
+      assert shown["updated_by"] == user.id
+      assert length(shown["audit"]) == 2
+      assert List.last(shown["audit"])["action"] == "update"
+    end
+
+    test "re-activates a deactivated set via is_active (FR-4-3)", %{
+      conn: conn,
+      base: base,
+      org_id: org_id
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+      conn |> post("#{base}/#{slug}/deactivate") |> json_response(200)
+      assert ToolSets.get_for_request(org_id, slug) == nil
+
+      conn
+      |> patch("#{base}/#{slug}", %{tool_set: %{"is_active" => true}})
+      |> json_response(200)
+
+      assert ToolSets.get_for_request(org_id, slug)
+    end
+
+    test "profile slug -> 422 profile_read_only (FR-4-4)", %{conn: conn, base: base} do
+      %{"code" => code} =
+        conn
+        |> patch("#{base}/full", %{tool_set: %{"display_name" => "Nope"}})
+        |> json_response(422)
+
+      assert code == "profile_read_only"
+    end
+
+    test "update with no recognized fields returns the row unchanged", %{conn: conn, base: base} do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+
+      %{"tool_set" => tool_set} =
+        conn |> patch("#{base}/#{slug}", %{tool_set: %{}}) |> json_response(200)
+
+      assert tool_set["slug"] == slug
+    end
+  end
+
+  describe "deactivate" do
+    test "soft-kills the set; idempotent; serving path loses it (AC-2A-8)", %{
+      conn: conn,
+      base: base,
+      org_id: org_id
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+
+      %{"tool_set" => tool_set} =
+        conn |> post("#{base}/#{slug}/deactivate") |> json_response(200)
+
+      assert tool_set["is_active"] == false
+      assert ToolSets.get_for_request(org_id, slug) == nil
+
+      conn |> post("#{base}/#{slug}/deactivate") |> json_response(200)
+    end
+
+    test "profile slug -> 422 profile_read_only", %{conn: conn, base: base} do
+      %{"code" => code} = conn |> post("#{base}/agent-ops/deactivate") |> json_response(422)
+
+      assert code == "profile_read_only"
+    end
+
+    test "unknown slug -> 404", %{conn: conn, base: base} do
+      assert json_response(post(conn, "#{base}/never-existed/deactivate"), 404)
+    end
+  end
+
+  # ---- clone ----
+
+  describe "clone" do
+    test "from a profile: deep-copied allowlist, provenance, auto-slug", %{
+      conn: conn,
+      base: base,
+      org_id: org_id
+    } do
+      %{"tool_set" => tool_set} =
+        conn |> post("#{base}/clone", %{source: "full"}) |> json_response(201)
+
+      assert tool_set["slug"] == "full-copy"
+      assert tool_set["source"] == "clone"
+      assert tool_set["source_profile"] == "full"
+      assert tool_set["is_active"] == true
+
+      stored = ToolSets.get_by_org_and_slug(org_id, "full-copy")
+      assert stored.source_profile == "full"
+      assert map_size(stored.config["groups"]) == 21
+      # FR-2A-7 allowlist shape: every expanded group enabled.
+      assert Enum.all?(Map.values(stored.config["groups"]), &(&1 == %{"enabled" => true}))
+    end
+
+    test "from a profile twice: slug suffixes -copy-2 (org-wide namespace)", %{
+      conn: conn,
+      base: base
+    } do
+      conn |> post("#{base}/clone", %{source: "content"}) |> json_response(201)
+
+      %{"tool_set" => second} =
+        conn |> post("#{base}/clone", %{source: "content"}) |> json_response(201)
+
+      assert second["slug"] == "content-copy-2"
+    end
+
+    test "from a set: config deep-copied, cloned_from provenance", %{
+      conn: conn,
+      base: base,
+      org_id: org_id
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      source = body["tool_set"]
+
+      %{"tool_set" => clone} =
+        conn
+        |> post("#{base}/clone", %{
+          source: source["slug"],
+          tool_set: %{"display_name" => "My copy"}
+        })
+        |> json_response(201)
+
+      assert clone["config_digest"] == source["config_digest"]
+      assert clone["source"] == "clone"
+      assert clone["source_profile"] == nil
+
+      stored = ToolSets.get_by_org_and_slug(org_id, clone["slug"])
+      assert stored.settings["cloned_from"] == source["slug"]
+      assert stored.config == @valid_config
+    end
+
+    test "clone carries caller settings + audit without clobbering provenance", %{
+      conn: conn,
+      base: base,
+      org_id: org_id
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      source_slug = body["tool_set"]["slug"]
+
+      %{"tool_set" => clone} =
+        conn
+        |> post("#{base}/clone", %{
+          source: source_slug,
+          tool_set: %{"settings" => %{"instructions" => "Be terse"}}
+        })
+        |> json_response(201)
+
+      assert clone["settings"]["instructions"] == "Be terse"
+      assert [%{"action" => "clone"}] = clone["audit"]
+
+      # Provenance survives next to the caller settings (system keys win).
+      stored = ToolSets.get_by_org_and_slug(org_id, clone["slug"])
+      assert stored.settings["cloned_from"] == source_slug
+      assert stored.settings["instructions"] == "Be terse"
+      assert [%{"action" => "clone"} | _] = stored.settings["_audit"]
+    end
+
+    test "unknown source -> 404", %{conn: conn, base: base} do
+      assert json_response(post(conn, "#{base}/clone", %{source: "nope"}), 404)
+    end
+  end
+
+  # ---- AC-N4-5: audit ----
+
+  describe "audit trail" do
+    test "records actor + action per mutation and stays bounded at 20", %{
+      conn: conn,
+      base: base,
+      user: user
+    } do
+      body = conn |> post(base, %{tool_set: valid_attrs()}) |> json_response(201)
+      slug = body["tool_set"]["slug"]
+
+      # 25 sequential mutations: 1 create + 25 updates -> trail capped at 20.
+      Enum.each(1..25, fn n ->
+        conn
+        |> patch("#{base}/#{slug}", %{tool_set: %{"description" => "v#{n}"}})
+        |> json_response(200)
+      end)
+
+      %{"tool_set" => shown} = conn |> get("#{base}/#{slug}") |> json_response(200)
+
+      assert length(shown["audit"]) == 20
+      assert Enum.all?(shown["audit"], &(&1["actor"] == user.id))
+      assert List.last(shown["audit"])["action"] == "update"
+      # Older entries rotated off (bounded, last 20).
+      assert shown["description"] == "v25"
+    end
+  end
+
+  # ---- fixtures ----
+
+  defp create_org(conn, prefix) do
+    slug = "#{prefix}-#{System.unique_integer([:positive])}"
+
+    conn
+    |> post(@base, %{organization: %{slug: slug, name: "N4a #{prefix} org"}})
+    |> json_response(201)
+    |> get_in(["organization", "id"])
+  end
+
+  defp valid_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "slug" => "release-ops",
+        "display_name" => "Release Ops",
+        "description" => "Release tooling",
+        "config" => @valid_config,
+        "settings" => %{"allow_api_keys" => true, "description_verbosity" => "concise"}
+      },
+      overrides
+    )
+  end
+
+  defp insert_group(name) do
+    # `groups.name` is a postgres enum (role_name_enum) — only seeded role
+    # groups exist, so reuse one instead of inserting (N2a tool_sets helper).
+    case NoizuPromptLingua.Repo.query!("SELECT id FROM groups WHERE name = $1 LIMIT 1", [name]) do
+      %{rows: [[raw]]} ->
+        Ecto.UUID.load!(raw)
+
+      %{rows: []} ->
+        %{rows: [[raw]]} =
+          NoizuPromptLingua.Repo.query!(
+            "INSERT INTO groups (id, name, display_name, created_at, updated_at) " <>
+              "VALUES (gen_random_uuid(), 'member', 'Member', now(), now()) RETURNING id",
+            []
+          )
+
+        Ecto.UUID.load!(raw)
+    end
+  end
+end

--- a/frontend/src/app/app/admin/mcp-config/[kind]/[id]/page.tsx
+++ b/frontend/src/app/app/admin/mcp-config/[kind]/[id]/page.tsx
@@ -12,6 +12,7 @@ import ClientPermissionsEditor, {
 } from '@/components/mcp-config/ClientPermissionsEditor';
 import { putClientToolsetConfig } from '@/lib/acl-api';
 import { canonicalToolName } from '@/lib/tool-overrides';
+import ToolSetEditor from '@/components/mcp-config/ToolSetEditor';
 
 // W7 — per-item client permission editor for the MCP Config hub.
 //   /app/admin/mcp-config/api-key/:id      → legacy API key (row uuid)
@@ -28,10 +29,22 @@ type ClientKind = 'api-key' | 'oauth-client';
 
 const KINDS: ClientKind[] = ['api-key', 'oauth-client'];
 
+/**
+ * N4a: `kind=tool-set` branches to the dedicated tool-set editor before any
+ * client-permissions state loads; the remaining kinds keep the original body.
+ */
 export default function ClientPermissionsPage() {
   const params = useParams<{ kind: string; id: string }>();
-  const kind = (params?.kind ?? '') as ClientKind;
+  const kind = params?.kind ?? '';
   const id = decodeURIComponent(params?.id ?? '');
+
+  if (kind === 'tool-set') {
+    return <ToolSetEditor slug={id} />;
+  }
+  return <ClientPermissionsInner kind={kind as ClientKind} id={id} />;
+}
+
+function ClientPermissionsInner({ kind, id }: { kind: ClientKind; id: string }) {
   const validKind = KINDS.includes(kind);
 
   const [catalog, setCatalog] = useState<ClientPermissionsCatalogGroup[]>([]);

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import {
   api,
@@ -34,6 +34,14 @@ import {
   type ScopeClient,
 } from '@/lib/acl-api';
 import { wireGroupHasMember } from '@/lib/acl-convert';
+import { useOrg } from '@/context/org';
+import {
+  cloneToolSet,
+  deactivateToolSet,
+  listToolSets,
+  updateToolSet,
+  type ToolSetIndex,
+} from '@/lib/acl-api';
 import McpEndpointSetupPopunder from '@/components/mcp-endpoint-setup-popunder';
 import { ToolOverrideFields } from '@/components/kit/tool-overrides-editor';
 import {
@@ -1033,6 +1041,8 @@ function AdminMcpCustomScopesInner() {
           </section>
         )}
 
+        <ToolSetsSection />
+
         <SlideOverSidebar
           open={sidebarOpen}
           onClose={() => setSidebarOpen(false)}
@@ -1056,5 +1066,203 @@ function AdminMcpCustomScopesInner() {
         )}
       </main>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// N4a — Tool-Sets section (PRD-N4 §4.2): built-in profiles (read-only,
+// cloneable) next to the org's durable tool sets. Sibling section to Scopes;
+// editing happens on the kind=tool-set config page.
+// ---------------------------------------------------------------------------
+
+function shapeBadge(shape: string) {
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        border: '1px solid var(--border)',
+        borderRadius: 999,
+        padding: '1px 8px',
+        color: 'var(--text-2)',
+      }}
+    >
+      {shape}
+    </span>
+  );
+}
+
+function ToolSetsSection() {
+  const router = useRouter();
+  const { currentOrg, organizations, switchOrg } = useOrg();
+  const orgId = currentOrg?.id ?? null;
+  const [index, setIndex] = useState<ToolSetIndex | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      setIndex(await listToolSets(orgId));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to load tool sets');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function clone(source: string) {
+    if (!orgId) return;
+    try {
+      const created = await cloneToolSet(orgId, source);
+      toast.success(`Cloned to "${created.slug}"`);
+      router.push(`/app/admin/mcp-config/tool-set/${encodeURIComponent(created.slug)}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Clone failed');
+    }
+  }
+
+  async function deactivate(slug: string) {
+    if (!orgId) return;
+    try {
+      await deactivateToolSet(orgId, slug);
+      toast.success(`Tool set "${slug}" deactivated`);
+      void load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Deactivate failed');
+    }
+  }
+
+  async function reactivate(slug: string) {
+    if (!orgId) return;
+    try {
+      await updateToolSet(orgId, slug, { is_active: true });
+      toast.success(`Tool set "${slug}" re-activated`);
+      void load();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Re-activate failed');
+    }
+  }
+
+  return (
+    <section className="dash-panel">
+      <div className="dash-panel__head">
+        <h2 className="dash-panel__title">
+          Tool Sets
+          {organizations.length > 1 && (
+            <select
+              aria-label="Organization"
+              value={orgId ?? ''}
+              onChange={(e) => switchOrg(e.target.value)}
+              style={{ marginLeft: 10, fontSize: 12 }}
+            >
+              {organizations.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name ?? o.slug}
+                </option>
+              ))}
+            </select>
+          )}
+        </h2>
+        <Link className="sg-btn sg-btn--outline sg-btn--sm" href="/app/admin/mcp-config/tool-set/new">
+          New tool set
+        </Link>
+      </div>
+      <p className="sg-page-intro">
+        Built-in capability profiles are read-only — clone one to customize. Org tool sets drive the
+        serving path once the tool-set gateway lands.
+      </p>
+
+      {!orgId ? (
+        <p className="sg-page-intro">Select an organization to manage tool sets.</p>
+      ) : loading && !index ? (
+        <p className="sg-page-intro">Loading…</p>
+      ) : (
+        <>
+          <h3 style={{ margin: '0.75rem 0 0.5rem', fontSize: 12, fontWeight: 700, color: 'var(--text-2)' }}>
+            Built-in profiles
+          </h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {(index?.profiles ?? []).map((p) => (
+              <div
+                key={p.slug}
+                style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-3)' }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600 }}>
+                    {p.display_name} <span className="font-mono" style={{ fontSize: 11, color: 'var(--text-3)' }}>{p.slug}</span>
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--text-2)' }}>{p.description}</div>
+                </div>
+                <span className="dash-badge">{p.group_count} groups</span>
+                <span className="dash-badge">{p.tool_count} tools</span>
+                <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={() => clone(p.slug)}>
+                  Clone
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <h3 style={{ margin: '1rem 0 0.5rem', fontSize: 12, fontWeight: 700, color: 'var(--text-2)' }}>
+            Org tool sets
+          </h3>
+          {(index?.sets ?? []).length === 0 ? (
+            <p className="sg-page-intro">No tool sets yet — clone a profile or create a new one.</p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {(index?.sets ?? []).map((s) => (
+                <div
+                  key={s.id}
+                  style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', border: '1px solid var(--border)', borderRadius: 8, opacity: s.is_active ? 1 : 0.6 }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 600 }}>
+                      {s.display_name}
+                      <span className="font-mono" style={{ fontSize: 11, color: 'var(--text-3)', marginLeft: 6 }}>{s.slug}</span>
+                      {!s.is_active && (
+                        <span style={{ fontSize: 10, color: 'var(--text-3)', marginLeft: 6 }}>(deactivated)</span>
+                      )}
+                    </div>
+                    <div style={{ fontSize: 11, color: 'var(--text-2)' }}>
+                      {s.source === 'clone' && s.source_profile ? `clone of ${s.source_profile}` : s.source}
+                      {s.member_count !== null ? ` · ${s.member_count} members` : ''}
+                    </div>
+                  </div>
+                  {shapeBadge(s.shape)}
+                  {s.config_digest && (
+                    <span className="font-mono" style={{ fontSize: 10, color: 'var(--text-3)' }} title="config digest">
+                      {s.config_digest.slice(0, 8)}
+                    </span>
+                  )}
+                  <Link
+                    className="sg-btn sg-btn--outline sg-btn--sm"
+                    href={`/app/admin/mcp-config/tool-set/${encodeURIComponent(s.slug)}`}
+                  >
+                    Edit
+                  </Link>
+                  <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={() => clone(s.slug)}>
+                    Clone
+                  </button>
+                  {s.is_active ? (
+                    <button type="button" className="sg-btn sg-btn--danger sg-btn--sm" onClick={() => deactivate(s.slug)}>
+                      Deactivate
+                    </button>
+                  ) : (
+                    <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={() => reactivate(s.slug)}>
+                      Re-activate
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </section>
   );
 }

--- a/frontend/src/components/kit/tool-overrides-editor.tsx
+++ b/frontend/src/components/kit/tool-overrides-editor.tsx
@@ -292,3 +292,449 @@ export default function ToolOverridesEditor({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// N4a — closed-vocabulary tool-set overrides editor (PRD-N4 §4.2).
+//
+// `ToolSetOverridesEditor` mirrors the ToolOverridesEditor visual grammar but
+// emits exactly the PRD-N2 §4.1 tool-set jsonb shape (`ToolSetConfig` from
+// `@/lib/acl-api`): group include = key presence, per-tool enabled/name/
+// description, per-arg enum_remove/hide/rename/default/description. Unknown
+// keys are impossible by construction — every write goes through the typed
+// patch helpers below. Pure controlled, host owns persistence.
+// ---------------------------------------------------------------------------
+
+import type {
+  ToolSetArgConfig,
+  ToolSetConfig,
+  ToolSetGroupConfig,
+  ToolSetToolConfig,
+} from '@/lib/acl-api';
+
+interface ToolSetOverridesEditorProps {
+  groups: ToolOverridesGroup[];
+  /** Full tool-set config; groups/tools/args keys are read/written here. */
+  value: ToolSetConfig;
+  /** Emits the full next config (pure controlled). */
+  onChange: (next: ToolSetConfig) => void;
+  readOnly?: boolean;
+}
+
+/** Drop keys whose value is absent/empty so stored configs stay minimal. */
+function pruneEmpty<T extends Record<string, unknown>>(obj: T): T {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    if (typeof v === 'string' && v === '') continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    if (typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0) continue;
+    out[k] = v;
+  }
+  return out as T;
+}
+
+function patchArg(
+  args: Record<string, ToolSetArgConfig> | undefined,
+  argName: string,
+  patch: Partial<ToolSetArgConfig>,
+): Record<string, ToolSetArgConfig> {
+  const next: Record<string, ToolSetArgConfig> = { ...(args ?? {}) };
+  const merged = pruneEmpty({ ...(next[argName] ?? {}), ...patch }) as ToolSetArgConfig;
+  if (Object.keys(merged).length === 0) delete next[argName];
+  else next[argName] = merged;
+  return next;
+}
+
+function patchToolCfg(
+  tools: Record<string, ToolSetToolConfig> | undefined,
+  toolName: string,
+  patch: Partial<ToolSetToolConfig>,
+): Record<string, ToolSetToolConfig> {
+  const next: Record<string, ToolSetToolConfig> = { ...(tools ?? {}) };
+  const merged = pruneEmpty({ ...(next[toolName] ?? {}), ...patch }) as ToolSetToolConfig;
+  const { args, ...rest } = merged as ToolSetToolConfig & { args?: unknown };
+  if (args === undefined) delete (rest as Record<string, unknown>).args;
+  const pruned = pruneEmpty(rest) as ToolSetToolConfig;
+  if (args !== undefined) pruned.args = args as ToolSetToolConfig['args'];
+  if (Object.keys(pruned).length === 0) delete next[toolName];
+  else next[toolName] = pruned;
+  return next;
+}
+
+/**
+ * Single-tool closed-vocabulary fields (enabled/name/description + per-arg
+ * enum_remove/hide/rename/default/description rows). Exported for embedding.
+ */
+export function ToolSetOverrideFields({
+  tool,
+  entry,
+  onEntry,
+  readOnly = false,
+  idPrefix,
+}: {
+  tool: ToolOverridesTool;
+  entry: ToolSetToolConfig;
+  onEntry: (next: ToolSetToolConfig) => void;
+  readOnly?: boolean;
+  idPrefix: string;
+}) {
+  const [newArg, setNewArg] = useState('');
+  const [newEnum, setNewEnum] = useState('');
+  const knownArgs = tool.parameters ?? [];
+  const argCfg = entry.args ?? {};
+  const extraArgs = Object.keys(argCfg).filter((arg) => !knownArgs.some((p) => p.name === arg));
+  const argRows = [
+    ...knownArgs.map((p) => ({ name: p.name })),
+    ...extraArgs.map((name) => ({ name })),
+  ];
+
+  function updateArgs(args: Record<string, ToolSetArgConfig>) {
+    onEntry(Object.keys(args).length === 0 ? { ...entry, args: undefined } : { ...entry, args });
+  }
+
+  function addEnumValue(arg: string) {
+    const value = newEnum.trim();
+    if (!value) return;
+    const current = argCfg[arg]?.enum_remove ?? [];
+    if (current.some((v) => String(v) === value)) return;
+    updateArgs(patchArg(argCfg, arg, { enum_remove: [...current, value] }));
+    setNewEnum('');
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} aria-label={`Tool-set overrides for ${tool.name}`}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <label htmlFor={`${idPrefix}-enabled`} style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>
+          Enabled
+        </label>
+        <input
+          id={`${idPrefix}-enabled`}
+          type="checkbox"
+          checked={entry.enabled !== false}
+          disabled={readOnly}
+          onChange={(e) => onEntry(patchToolCfg({ t: entry }, 't', { enabled: e.target.checked ? undefined : false }).t ?? {})}
+        />
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-name`} style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>
+          Name override
+        </label>
+        <input
+          id={`${idPrefix}-name`}
+          value={entry.name ?? ''}
+          placeholder={canonicalToolName(tool.name)}
+          readOnly={readOnly}
+          onChange={(e) => onEntry(patchToolCfg({ t: entry }, 't', { name: e.target.value }).t ?? {})}
+          style={{ width: '100%', fontFamily: 'monospace', fontSize: 12 }}
+        />
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-desc`} style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>
+          Description override
+        </label>
+        <textarea
+          id={`${idPrefix}-desc`}
+          value={entry.description ?? ''}
+          placeholder={tool.description}
+          readOnly={readOnly}
+          rows={2}
+          onChange={(e) => onEntry(patchToolCfg({ t: entry }, 't', { description: e.target.value }).t ?? {})}
+          style={{ width: '100%', fontSize: 12 }}
+        />
+      </div>
+      {argRows.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-2)' }}>Argument overrides</span>
+          {argRows.map((arg) => {
+            const cfg = argCfg[arg.name] ?? {};
+            return (
+              <div
+                key={arg.name}
+                style={{ border: '1px solid var(--border)', borderRadius: 6, padding: 8, display: 'flex', flexDirection: 'column', gap: 6 }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span className="font-mono" style={{ flex: 1, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={arg.name}>
+                    {arg.name}
+                  </span>
+                  <label style={{ fontSize: 10, color: 'var(--text-2)', display: 'flex', alignItems: 'center', gap: 4 }}>
+                    hide
+                    <input
+                      type="checkbox"
+                      checked={cfg.hide === true}
+                      disabled={readOnly}
+                      aria-label={`Hide argument ${arg.name} of ${tool.name}`}
+                      onChange={(e) => updateArgs(patchArg(argCfg, arg.name, { hide: e.target.checked ? true : undefined }))}
+                    />
+                  </label>
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <input
+                    aria-label={`Rename argument ${arg.name} of ${tool.name}`}
+                    value={cfg.rename ?? ''}
+                    placeholder="rename to"
+                    readOnly={readOnly}
+                    onChange={(e) => updateArgs(patchArg(argCfg, arg.name, { rename: e.target.value }))}
+                    style={{ flex: 1, fontFamily: 'monospace', fontSize: 11 }}
+                  />
+                  <input
+                    aria-label={`Default value for argument ${arg.name} of ${tool.name}`}
+                    value={cfg.default === undefined ? '' : String(cfg.default)}
+                    placeholder="pin default"
+                    readOnly={readOnly}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      updateArgs(patchArg(argCfg, arg.name, { default: raw === '' ? undefined : raw }));
+                    }}
+                    style={{ flex: 1, fontSize: 11 }}
+                  />
+                </div>
+                <input
+                  aria-label={`Description for argument ${arg.name} of ${tool.name}`}
+                  value={cfg.description ?? ''}
+                  placeholder="argument description"
+                  readOnly={readOnly}
+                  onChange={(e) => updateArgs(patchArg(argCfg, arg.name, { description: e.target.value }))}
+                  style={{ width: '100%', fontSize: 11 }}
+                />
+                {(cfg.enum_remove?.length ?? 0) > 0 && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                    {(cfg.enum_remove ?? []).map((v) => (
+                      <span
+                        key={String(v)}
+                        style={{ fontSize: 10, fontFamily: 'monospace', border: '1px solid var(--border)', borderRadius: 999, padding: '1px 8px', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                      >
+                        {String(v)}
+                        {!readOnly && (
+                          <button
+                            type="button"
+                            aria-label={`Keep enum value ${String(v)} for ${arg.name}`}
+                            onClick={() =>
+                              updateArgs(
+                                patchArg(argCfg, arg.name, {
+                                  enum_remove: (cfg.enum_remove ?? []).filter((x) => x !== v),
+                                }),
+                              )
+                            }
+                            style={{ cursor: 'pointer', border: 'none', background: 'none', color: 'var(--text-3)', padding: 0 }}
+                          >
+                            ×
+                          </button>
+                        )}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {!readOnly && (
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <input
+                      aria-label={`Enum value to remove from ${arg.name} of ${tool.name}`}
+                      value={newEnum}
+                      placeholder="enum value to remove"
+                      onChange={(e) => setNewEnum(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          addEnumValue(arg.name);
+                        }
+                      }}
+                      style={{ flex: 1, fontFamily: 'monospace', fontSize: 11 }}
+                    />
+                    <button
+                      type="button"
+                      className="sg-btn sg-btn--outline sg-btn--sm"
+                      disabled={!newEnum.trim()}
+                      onClick={() => addEnumValue(arg.name)}
+                    >
+                      Remove value
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {!readOnly && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            aria-label="New argument name"
+            value={newArg}
+            placeholder="add argument by name"
+            onChange={(e) => setNewArg(e.target.value)}
+            style={{ flex: '0 0 180px', fontFamily: 'monospace', fontSize: 12 }}
+          />
+          <button
+            type="button"
+            className="sg-btn sg-btn--outline sg-btn--sm"
+            disabled={!newArg.trim() || argRows.some((r) => r.name === newArg.trim())}
+            onClick={() => {
+              const name = newArg.trim();
+              if (!name) return;
+              updateArgs(patchArg(argCfg, name, {}));
+              setNewArg('');
+            }}
+          >
+            Add argument
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Group-include grid + per-tool closed-vocabulary override rows for a tool
+ * set. Group include = presence of `value.groups[group]` (the N2a allowlist
+ * semantics); the group-level `enabled` flag is preserved, never written.
+ */
+export function ToolSetOverridesEditor({
+  groups,
+  value,
+  onChange,
+  readOnly = false,
+}: ToolSetOverridesEditorProps) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const groupsCfg = value.groups ?? {};
+
+  function toggleGroup(groupId: string, include: boolean) {
+    const next: Record<string, ToolSetGroupConfig> = { ...groupsCfg };
+    if (include) next[groupId] = next[groupId] ?? {};
+    else delete next[groupId];
+    onChange({ ...value, groups: next });
+  }
+
+  function updateTool(groupId: string, toolName: string, entry: ToolSetToolConfig | undefined) {
+    const groupCfg = groupsCfg[groupId] ?? {};
+    const tools: Record<string, ToolSetToolConfig> = { ...(groupCfg.tools ?? {}) };
+    // An entry that carries only args (no tool-level fields) must survive —
+    // emptiness is judged on the whole entry, args included.
+    if (entry === undefined || Object.keys(entry).length === 0) {
+      delete tools[toolName];
+    } else {
+      tools[toolName] = entry;
+    }
+    onChange({
+      ...value,
+      groups: { ...groupsCfg, [groupId]: { ...groupCfg, tools } },
+    });
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }} role="group" aria-label="Tool-set overrides">
+      {groups.map((group) => {
+        const included = groupsCfg[group.group] !== undefined;
+        const groupCfg = groupsCfg[group.group] ?? {};
+        const tools = groupCfg.tools ?? {};
+        const overriddenCount = group.tools.filter((t) => {
+          const key = canonicalToolName(t.name);
+          return Object.keys(tools[key] ?? {}).length > 0;
+        }).length;
+        return (
+          <section
+            key={group.group}
+            aria-label={`Tool-set group ${group.group}`}
+            style={{
+              borderRadius: 6,
+              border: included ? '1px solid var(--accent)' : '1px solid var(--border)',
+              background: included ? 'var(--accent-dim)' : 'var(--bg-3)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '8px 12px',
+                borderBottom: '1px solid var(--border)',
+                background: 'var(--bg-2)',
+                fontSize: 12,
+                fontWeight: 600,
+                color: 'var(--text-0)',
+              }}
+            >
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <input
+                  type="checkbox"
+                  checked={included}
+                  disabled={readOnly}
+                  aria-label={`Include group ${group.group}`}
+                  onChange={(e) => toggleGroup(group.group, e.target.checked)}
+                />
+                {group.label ?? group.group}
+              </label>
+              <span style={{ fontWeight: 400, fontSize: 10, color: 'var(--text-3)', marginLeft: 'auto' }}>
+                {included ? `${overriddenCount}/${group.tools.length} overridden` : `${group.tools.length} tools`}
+              </span>
+            </div>
+            {included && (
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                {group.tools.map((tool) => {
+                  const toolKey = canonicalToolName(tool.name);
+                  const expanded = open[`${group.group}/${toolKey}`] ?? false;
+                  const entry = tools[toolKey] ?? {};
+                  const edited = Object.keys(entry).length > 0;
+                  return (
+                    <div key={tool.name} style={{ borderBottom: '1px solid var(--border)' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 12px', background: 'var(--bg-2)' }}>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 10, color: 'var(--text-2)' }}>
+                          <input
+                            type="checkbox"
+                            checked={entry.enabled !== false}
+                            disabled={readOnly}
+                            aria-label={`Enable tool ${tool.name}`}
+                            onChange={(e) =>
+                              updateTool(group.group, toolKey, {
+                                ...entry,
+                                enabled: e.target.checked ? undefined : false,
+                              })
+                            }
+                          />
+                          on
+                        </label>
+                        <span
+                          title={tool.name}
+                          className="font-mono"
+                          style={{ flex: 1, fontSize: 11, color: entry.enabled === false ? 'var(--text-3)' : 'var(--text-0)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        >
+                          {tool.name}
+                          {edited && (
+                            <span
+                              title="Has overrides"
+                              style={{ marginLeft: 6, fontSize: 9, padding: '1px 5px', borderRadius: 8, background: 'var(--accent)', color: 'var(--bg-1)', verticalAlign: 'middle' }}
+                            >
+                              edited
+                            </span>
+                          )}
+                        </span>
+                        <button
+                          type="button"
+                          className="sg-btn sg-btn--outline sg-btn--sm"
+                          aria-expanded={expanded}
+                          onClick={() => setOpen((cur) => ({ ...cur, [`${group.group}/${toolKey}`]: !expanded }))}
+                        >
+                          {expanded ? 'Hide' : 'Overrides'}
+                        </button>
+                      </div>
+                      {expanded && (
+                        <div style={{ padding: '8px 12px 12px' }}>
+                          <ToolSetOverrideFields
+                            idPrefix={`tse-${group.group}-${toolKey}`}
+                            tool={tool}
+                            entry={entry}
+                            onEntry={(next) => updateTool(group.group, toolKey, next)}
+                            readOnly={readOnly}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/mcp-config/ToolSetEditor.tsx
+++ b/frontend/src/components/mcp-config/ToolSetEditor.tsx
@@ -1,0 +1,445 @@
+'use client';
+
+/**
+ * N4a — `kind=tool-set` detail page for /app/admin/mcp-config (PRD-N4 §4.2).
+ *
+ * Create/edit form for a durable MCP tool set: identity, audience shape
+ * (org/project/group — fixed at creation per the N2a changeset), settings
+ * (allow_api_keys, description_verbosity, instructions), and the group-include
+ * + closed-vocabulary overrides editor (`ToolSetOverridesEditor`).
+ *
+ * Built-in profile slugs render read-only with a Clone action (R1). The
+ * validate dry-run button is disabled until N4b lands the backend endpoint.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { api, type McpCustomGroup } from '@/lib/api';
+import {
+  cloneToolSet,
+  createToolSet,
+  deactivateToolSet,
+  getToolSet,
+  updateToolSet,
+  type DescriptionVerbosity,
+  type ToolSetConfig,
+  type ToolSetProfileView,
+  type ToolSetSettings,
+  type ToolSetShape,
+  type ToolSetView,
+} from '@/lib/acl-api';
+import { ToolSetOverridesEditor } from '@/components/kit/tool-overrides-editor';
+import { useOrg } from '@/context/org';
+
+// Authz role groups are global (role_name_enum) — a group-set audience picks
+// one of these; custom roles beyond the enum are a future surface.
+const GROUP_ROLES = ['owner', 'admin', 'lead', 'member', 'viewer'] as const;
+
+interface ToolSetFormState {
+  slug: string;
+  display_name: string;
+  description: string;
+  shape: ToolSetShape;
+  project_id: string;
+  group_id: string;
+  config: ToolSetConfig;
+  settings: ToolSetSettings;
+}
+
+function blankForm(): ToolSetFormState {
+  return {
+    slug: '',
+    display_name: '',
+    description: '',
+    shape: 'org',
+    project_id: '',
+    group_id: '',
+    config: { groups: {} },
+    settings: { allow_api_keys: true, description_verbosity: 'full', instructions: '' },
+  };
+}
+
+export default function ToolSetEditor({ slug }: { slug: string }) {
+  const isNew = slug === 'new';
+  const router = useRouter();
+  const { currentOrg, projects, refreshProjects } = useOrg();
+  const orgId = currentOrg?.id ?? null;
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [profile, setProfile] = useState<ToolSetProfileView | null>(null);
+  const [view, setView] = useState<ToolSetView | null>(null);
+  const [catalog, setCatalog] = useState<McpCustomGroup[]>([]);
+  const [form, setForm] = useState<ToolSetFormState>(blankForm);
+
+  const patch = (p: Partial<ToolSetFormState>) => setForm((cur) => ({ ...cur, ...p }));
+
+  const load = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      if (isNew) {
+        setProfile(null);
+        setView(null);
+        setForm(blankForm());
+      } else {
+        const res = await getToolSet(orgId, slug);
+        if (res.profile) {
+          setProfile(res.profile);
+          setView(null);
+        } else if (res.tool_set) {
+          const t = res.tool_set;
+          setProfile(null);
+          setView(t);
+          setForm({
+            slug: t.slug,
+            display_name: t.display_name ?? '',
+            description: t.description ?? '',
+            shape: t.shape,
+            project_id: t.project_id ?? '',
+            group_id: t.group_id ?? '',
+            config: t.config ?? { groups: {} },
+            settings: {
+              allow_api_keys: t.settings?.allow_api_keys ?? true,
+              description_verbosity: t.settings?.description_verbosity ?? 'full',
+              instructions: t.settings?.instructions ?? '',
+            },
+          });
+        } else {
+          toast.error('Tool set not found');
+        }
+      }
+      const cat = await api.adminMcpCustomScopeCatalog();
+      setCatalog(cat.groups ?? []);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to load tool set');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, isNew, slug]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (orgId) void refreshProjects();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId]);
+
+  async function save() {
+    if (!orgId) return;
+    setSaving(true);
+    try {
+      if (isNew) {
+        const attrs = {
+          slug: form.slug || undefined,
+          display_name: form.display_name || undefined,
+          description: form.description || undefined,
+          project_id: form.shape === 'project' ? form.project_id : undefined,
+          group_id: form.shape === 'group' ? form.group_id : undefined,
+          config: form.config,
+          settings: form.settings,
+        };
+        const created = await createToolSet(orgId, attrs);
+        toast.success(`Tool set "${created.slug}" created`);
+        router.replace(`/app/admin/mcp-config/tool-set/${encodeURIComponent(created.slug)}`);
+      } else {
+        const updated = await updateToolSet(orgId, slug, {
+          display_name: form.display_name,
+          description: form.description,
+          config: form.config,
+          settings: form.settings,
+        });
+        setView(updated);
+        toast.success('Tool set saved');
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function doClone(source: string) {
+    if (!orgId) return;
+    try {
+      const created = await cloneToolSet(orgId, source);
+      toast.success(`Cloned to "${created.slug}"`);
+      router.push(`/app/admin/mcp-config/tool-set/${encodeURIComponent(created.slug)}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Clone failed');
+    }
+  }
+
+  async function doDeactivate() {
+    if (!orgId || !view) return;
+    try {
+      const updated = await deactivateToolSet(orgId, view.slug);
+      setView(updated);
+      toast.success(`Tool set "${updated.slug}" deactivated`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Deactivate failed');
+    }
+  }
+
+  async function doReactivate() {
+    if (!orgId || !view) return;
+    try {
+      const updated = await updateToolSet(orgId, view.slug, { is_active: true });
+      setView(updated);
+      toast.success(`Tool set "${updated.slug}" re-activated`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Re-activate failed');
+    }
+  }
+
+  if (!orgId) {
+    return (
+      <section className="dash-panel">
+        <p className="sg-page-intro">Select an organization to manage tool sets.</p>
+      </section>
+    );
+  }
+
+  // Built-in profile: read-only view + clone (R1 — never editable).
+  if (!isNew && profile) {
+    return (
+      <section className="dash-panel">
+        <div className="dash-panel__head">
+          <h2 className="dash-panel__title">
+            Profile: {profile.display_name}{' '}
+            <span className="dash-badge">built-in</span>
+          </h2>
+          <button type="button" className="sg-btn sg-btn--black sg-btn--sm" onClick={() => doClone(profile.slug)}>
+            Clone
+          </button>
+        </div>
+        <p className="sg-page-intro">{profile.description}</p>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', margin: '0.75rem 0' }}>
+          <span className="dash-badge">{profile.group_count} groups</span>
+          <span className="dash-badge">{profile.tool_count} tools</span>
+          <span className="dash-badge">read-only</span>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {profile.groups.map((g) => (
+            <span
+              key={g}
+              className="font-mono"
+              style={{ fontSize: 11, border: '1px solid var(--border)', borderRadius: 999, padding: '2px 10px' }}
+            >
+              {g}
+            </span>
+          ))}
+        </div>
+        <div className="modal-actions" style={{ marginTop: '1rem' }}>
+          <Link className="sg-btn sg-btn--outline" href="/app/admin/mcp-custom-scopes">
+            Back
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dash-panel">
+      <div className="dash-panel__head">
+        <h2 className="dash-panel__title">{isNew ? 'New tool set' : `Tool set: ${form.slug}`}</h2>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {!isNew && view && view.is_active && (
+            <button type="button" className="sg-btn sg-btn--danger sg-btn--sm" onClick={doDeactivate}>
+              Deactivate
+            </button>
+          )}
+          {!isNew && view && !view.is_active && (
+            <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={doReactivate}>
+              Re-activate
+            </button>
+          )}
+          {!isNew && (
+            <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={() => doClone(slug)}>
+              Clone
+            </button>
+          )}
+          <button
+            type="button"
+            className="sg-btn sg-btn--outline sg-btn--sm"
+            disabled
+            title="Validate dry-run ships with N4b (pending backend)"
+          >
+            Validate (pending N4b)
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <p className="sg-page-intro">Loading…</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {view && !view.is_active && (
+            <p className="sg-field__hint">This tool set is deactivated — it is hidden from the serving path.</p>
+          )}
+          {view && view.preview && (
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <span className="dash-badge">{Object.keys(view.preview.groups).length} groups included</span>
+              <span className="dash-badge">{view.preview.total_override_ops} override ops</span>
+              {view.member_count !== null && <span className="dash-badge">{view.member_count} members</span>}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+            <div className="sg-field" style={{ flex: '1 1 220px' }}>
+              <label htmlFor="ts-slug">Slug</label>
+              <input
+                id="ts-slug"
+                value={form.slug}
+                placeholder="auto from name"
+                disabled={!isNew}
+                onChange={(e) => patch({ slug: e.target.value })}
+                style={{ fontFamily: 'monospace' }}
+              />
+              {!isNew && <span className="sg-field__hint">Slug is immutable after creation.</span>}
+            </div>
+            <div className="sg-field" style={{ flex: '1 1 220px' }}>
+              <label htmlFor="ts-name">Display name</label>
+              <input
+                id="ts-name"
+                value={form.display_name}
+                onChange={(e) => patch({ display_name: e.target.value })}
+              />
+            </div>
+          </div>
+
+          <div className="sg-field">
+            <label htmlFor="ts-desc">Description</label>
+            <textarea id="ts-desc" rows={2} value={form.description} onChange={(e) => patch({ description: e.target.value })} />
+          </div>
+
+          <div className="sg-field">
+            <label>Audience shape</label>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+              {(['org', 'project', 'group'] as ToolSetShape[]).map((s) => (
+                <label key={s} style={{ display: 'flex', alignItems: 'center', gap: 4, textTransform: 'capitalize' }}>
+                  <input
+                    type="radio"
+                    name="ts-shape"
+                    checked={form.shape === s}
+                    disabled={!isNew}
+                    onChange={() => patch({ shape: s })}
+                  />
+                  {s}
+                </label>
+              ))}
+            </div>
+            {!isNew && <span className="sg-field__hint">Audience shape is fixed at creation (clone to change it).</span>}
+            {isNew && form.shape === 'project' && (
+              <div style={{ marginTop: 6 }}>
+                <label htmlFor="ts-project">Project</label>
+                <select id="ts-project" value={form.project_id} onChange={(e) => patch({ project_id: e.target.value })}>
+                  <option value="">— select project —</option>
+                  {projects.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {(p as { name?: string; slug?: string }).name ?? (p as { slug?: string }).slug ?? p.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {isNew && form.shape === 'group' && (
+              <div style={{ marginTop: 6 }}>
+                <label htmlFor="ts-group">Group (role)</label>
+                <select id="ts-group" value={form.group_id} onChange={(e) => patch({ group_id: e.target.value })}>
+                  <option value="">— select group —</option>
+                  {GROUP_ROLES.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+                <span className="sg-field__hint">
+                  Group sets use the role group id; members carrying the role in this org get access.
+                </span>
+              </div>
+            )}
+          </div>
+
+          <section style={{ border: '1px solid var(--border, #e5e5e5)', borderRadius: 8, padding: '0.875rem' }}>
+            <h3 style={{ margin: '0 0 0.5rem', fontSize: 13, fontWeight: 700 }}>Settings</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+                <input
+                  type="checkbox"
+                  checked={form.settings.allow_api_keys !== false}
+                  onChange={(e) => patch({ settings: { ...form.settings, allow_api_keys: e.target.checked } })}
+                />
+                Allow API-key callers
+              </label>
+              <div className="sg-field">
+                <label htmlFor="ts-verbosity">Description verbosity</label>
+                <select
+                  id="ts-verbosity"
+                  value={form.settings.description_verbosity ?? 'full'}
+                  onChange={(e) =>
+                    patch({ settings: { ...form.settings, description_verbosity: e.target.value as DescriptionVerbosity } })
+                  }
+                >
+                  <option value="full">full</option>
+                  <option value="concise">concise</option>
+                  <option value="minimal">minimal</option>
+                </select>
+              </div>
+              <div className="sg-field">
+                <label htmlFor="ts-instructions">Instructions</label>
+                <textarea
+                  id="ts-instructions"
+                  rows={3}
+                  value={form.settings.instructions ?? ''}
+                  placeholder="Extra instructions surfaced to callers of this set"
+                  onChange={(e) => patch({ settings: { ...form.settings, instructions: e.target.value } })}
+                />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 0.5rem', fontSize: 13, fontWeight: 700 }}>Groups &amp; tool overrides</h3>
+            <span className="sg-field__hint">
+              Include groups, then override tool names/descriptions, enable/disable tools, and tune arguments
+              (enum pruning, hide, rename, default, description).
+            </span>
+            <ToolSetOverridesEditor
+              groups={catalog.map((g) => ({ group: g.id, label: g.label, tools: g.tools }))}
+              value={form.config}
+              onChange={(next) => patch({ config: next })}
+            />
+          </section>
+
+          {view && (view.audit?.length ?? 0) > 0 && (
+            <section style={{ border: '1px solid var(--border, #e5e5e5)', borderRadius: 8, padding: '0.875rem' }}>
+              <h3 style={{ margin: '0 0 0.5rem', fontSize: 13, fontWeight: 700 }}>Audit trail</h3>
+              <ul style={{ margin: 0, paddingLeft: '1.1rem', fontSize: 11, color: 'var(--text-2)' }}>
+                {[...(view.audit ?? [])].reverse().map((entry, i) => (
+                  <li key={`${entry.at}-${i}`}>
+                    <span className="font-mono">{entry.at}</span> — {entry.action}
+                    {entry.actor ? ` by ${entry.actor}` : ''}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          <div className="modal-actions">
+            <Link className="sg-btn sg-btn--outline" href="/app/admin/mcp-custom-scopes">
+              Cancel
+            </Link>
+            <button type="button" className="sg-btn sg-btn--black" disabled={saving} onClick={save}>
+              {saving ? 'Saving...' : isNew ? 'Create Tool Set' : 'Save Tool Set'}
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/lib/acl-api.ts
+++ b/frontend/src/lib/acl-api.ts
@@ -281,3 +281,180 @@ export async function removeAclGroupMember(
     body: JSON.stringify({ member: refString(kind, clientId) }),
   });
 }
+
+// ---------------------------------------------------------------------------
+// MCP tool sets (PRD-N4 §4.1, N4a) — org-admin CRUD against
+// /api/v1/organizations/:org_id/tool-sets. The validate dry-run endpoint is
+// N4b (gated on lib PRD-3) and deliberately has no client fn yet.
+// ---------------------------------------------------------------------------
+
+export type ToolSetShape = 'org' | 'project' | 'group';
+export type DescriptionVerbosity = 'full' | 'concise' | 'minimal';
+
+/** Closed-vocabulary tool-set config (PRD-N2 §4.1 jsonb shape). */
+export interface ToolSetConfig {
+  groups?: Record<string, ToolSetGroupConfig>;
+}
+
+export interface ToolSetGroupConfig {
+  enabled?: boolean;
+  tools?: Record<string, ToolSetToolConfig>;
+}
+
+export interface ToolSetToolConfig {
+  enabled?: boolean;
+  name?: string;
+  description?: string;
+  args?: Record<string, ToolSetArgConfig>;
+}
+
+export interface ToolSetArgConfig {
+  enum_remove?: (string | number | boolean)[];
+  hide?: boolean;
+  rename?: string;
+  default?: string | number | boolean;
+  description?: string;
+}
+
+export interface ToolSetSettings {
+  allow_api_keys?: boolean;
+  description_verbosity?: DescriptionVerbosity;
+  instructions?: string;
+}
+
+/** A built-in capability profile, from the index `profiles` list (read-only). */
+export interface ToolSetProfileView {
+  slug: string;
+  display_name: string;
+  description: string | null;
+  groups: string[];
+  group_count: number;
+  tool_count: number;
+  cloneable: boolean;
+  editable: boolean;
+  is_profile: boolean;
+  is_active: boolean;
+}
+
+export interface ToolSetPreviewGroup {
+  enabled: boolean;
+  tool_count: number;
+  overridden_tools: number;
+  override_ops: number;
+}
+
+/** Structural preview from `show` — registry counts + override-op census. */
+export interface ToolSetStructuralPreview {
+  groups: Record<string, ToolSetPreviewGroup>;
+  total_override_ops: number;
+}
+
+export interface ToolSetAuditEntry {
+  at: string;
+  actor?: string | null;
+  action: string;
+}
+
+export interface ToolSetView {
+  id: string;
+  slug: string;
+  display_name: string;
+  description: string | null;
+  shape: ToolSetShape;
+  project_id: string | null;
+  group_id: string | null;
+  source: string;
+  source_profile: string | null;
+  is_active: boolean;
+  expires_at: string | null;
+  config_digest: string | null;
+  member_count: number | null;
+  settings: ToolSetSettings;
+  updated_by: string | null;
+  updated_at: string | null;
+  urls: { mcp: string | null; admin: string | null };
+  audit?: ToolSetAuditEntry[];
+  preview?: ToolSetStructuralPreview;
+  config?: ToolSetConfig;
+}
+
+export interface ToolSetIndex {
+  profiles: ToolSetProfileView[];
+  sets: ToolSetView[];
+}
+
+/** Attrs accepted by create/clone; update allows the same minus identity. */
+export interface ToolSetAttrs {
+  slug?: string;
+  display_name?: string;
+  description?: string;
+  project_id?: string;
+  group_id?: string;
+  config?: ToolSetConfig;
+  settings?: ToolSetSettings;
+}
+
+/** GET /api/v1/organizations/:org_id/tool-sets — profiles + org sets. */
+export async function listToolSets(orgId: string): Promise<ToolSetIndex> {
+  const res = await request<{ profiles: ToolSetProfileView[]; sets: ToolSetView[] }>(
+    `/api/v1/organizations/${encodeURIComponent(orgId)}/tool-sets`,
+  );
+  return { profiles: res.profiles ?? [], sets: res.sets ?? [] };
+}
+
+/**
+ * GET .../tool-sets/:slug — a set (with structural preview + config) or a
+ * built-in profile slug (read-only view).
+ */
+export async function getToolSet(
+  orgId: string,
+  slug: string,
+): Promise<{ tool_set?: ToolSetView; profile?: ToolSetProfileView }> {
+  return request<{ tool_set?: ToolSetView; profile?: ToolSetProfileView }>(
+    `/api/v1/organizations/${encodeURIComponent(orgId)}/tool-sets/${encodeURIComponent(slug)}`,
+  );
+}
+
+/** POST .../tool-sets — create a custom set; 422 surfaces changeset errors. */
+export async function createToolSet(orgId: string, attrs: ToolSetAttrs): Promise<ToolSetView> {
+  const res = await request<{ tool_set: ToolSetView }>(
+    `/api/v1/organizations/${encodeURIComponent(orgId)}/tool-sets`,
+    { method: 'POST', body: JSON.stringify({ tool_set: attrs }) },
+  );
+  return res.tool_set;
+}
+
+/** PATCH .../tool-sets/:slug — partial update of display fields/config/settings. */
+export async function updateToolSet(
+  orgId: string,
+  slug: string,
+  attrs: Partial<ToolSetAttrs> & { is_active?: boolean },
+): Promise<ToolSetView> {
+  const res = await request<{ tool_set: ToolSetView }>(
+    `/api/v1/organizations/${encodeURIComponent(orgId)}/tool-sets/${encodeURIComponent(slug)}`,
+    { method: 'PATCH', body: JSON.stringify({ tool_set: attrs }) },
+  );
+  return res.tool_set;
+}
+
+/** POST .../tool-sets/:slug/deactivate — soft-kill (idempotent). */
+export async function deactivateToolSet(orgId: string, slug: string): Promise<ToolSetView> {
+  const res = await request<{ tool_set: ToolSetView }>(
+    `/api/v1/organizations/${encodeURIComponent(orgId)}/tool-sets/${encodeURIComponent(slug)}/deactivate`,
+    { method: 'POST' },
+  );
+  return res.tool_set;
+}
+
+/** POST .../tool-sets/clone — clone a profile or set slug into a new set. */
+export async function cloneToolSet(
+  orgId: string,
+  source: string,
+  attrs: ToolSetAttrs = {},
+): Promise<ToolSetView> {
+  const res = await request<{ tool_set: ToolSetView }>(
+    `/api/v1/organizations/${encodeURIComponent(orgId)}/tool-sets/clone`,
+    { method: 'POST', body: JSON.stringify({ source, tool_set: attrs }) },
+  );
+  return res.tool_set;
+}


### PR DESCRIPTION
## Summary

Implements the **N4a** (non-gated) portion of [PRD-N4](https://github.com/noizu-labs-ml/NoizuPromptLingo/blob/develop.q3/project-management/PRDs/PRD-N4-admin-ui.md) — org-admin management for MCP tool sets — against pinned hex noizu_mcp 0.1.5 with **zero lib calls**. Base: origin/develop.q3 @ 32d2d27a9 (post N2a merge).

### Backend
- `ToolSetProfilesController` — index / show / create / update / deactivate / clone under `/api/v1/organizations/:org_id/tool-sets` on the `org_admin` pipeline. Auth matrix per AC-N4-1 (401 / 403 / cross-org slug ⇒ 404, no cross-org read).
- **Index** (FR-4-2): 5 built-in profiles from `Toolsets.Profiles` DATA (never rows, R1) with expanded groups (`full` = 21), per-group tool counts, `cloneable/editable` flags; org sets via `list_for_org` **including deactivated** (FR-4-3) with shape, `config_digest`, live group-set `member_count` (via `ScopedMemberships.list_for_resource/3`, PRD §10.3).
- **Show**: row + structural preview (per-group registry tool counts + override-op census — explicitly NOT the effective-catalog preview, which needs the lib at N4b/D1) + audit trail + full `config` for the edit form. Profile slugs return the read-only profile view.
- **CRUD** (FR-4-3): the N2a changeset remains the single validation authority; 422s surface changeset field errors verbatim. Deactivate is idempotent and routed through `ToolSets.update/3` so audited settings ride along; deactivated sets vanish from `get_for_request/2` (asserted) but stay listed + reactivatable via `is_active`.
- **Clone** (FR-2A-7 semantics, per lead instruction pulled into N4a): profile source deep-copies the all-enabled allowlist (`full-copy`, suffix `-copy-2` on collision); set source copies config + records `settings.cloned_from`.
- **Built-in immutability** (FR-4-4): PATCH/deactivate on profile slugs ⇒ 422 `profile_read_only` at the controller, on top of the changeset reserved-slug block.
- **Audit** (FR-4-5): bounded `settings["_audit"]` trail (last 20, `carry_audit` precedent — no audit table) + structured `[:mcp_tool_set, :mutation]` Logger event; both best-effort, never fail the mutation. `notify_toolset_changed/0` fires context-side on every write (N1 wiring).
- **N4b seam**: `POST .../tool-sets/validate` deliberately absent — marker in controller moduledoc + router comment (gated on lib PRD-3 `Validator.compile/3`).

### Frontend (contract-first, FR-4-9)
- `acl-api.ts`: `ToolSet*` wire types + 6 client fns matching the controller 1:1 (no `validateToolSet` until N4b exists).
- `ToolSetOverridesEditor` (new named export in `kit/tool-overrides-editor.tsx`; the existing scope/client editor untouched): group include toggles, per-tool enabled/name/description, per-arg enum_remove / hide / rename / default / description — emits exactly the PRD-N2 §4.1 closed vocabulary; unknown keys impossible by construction (AC-N4-8's jsonb round-trip guarantee is by construction here).
- `ToolSetEditor` (`kind=tool-set`): create/edit form — identity, org/project/group audience (fixed at creation, per changeset), settings (`allow_api_keys`, `description_verbosity full|concise|minimal` per N2a Q2 resolution, `instructions`), audit display, deactivate/reactivate/clone; **Validate button renders disabled with a pending-N4b state**.
- Tool-Sets sibling section in the MCP admin page: org selector, profile cards (group/tool counts, Clone), set rows (shape badge, digest, deactivate/reactivate/clone/edit deep links).

## Evidence

- Scoped suites: **82/82 green** — new controller suite (29: auth matrix, index composition, CRUD + structural rejections, immutability, clone semantics, audit bound) + N2a `tool_sets_test.exs` / `profiles_test.exs` (53, no regression). `MIX_TEST_PARTITION=_n4a` on a clone of the migrated test DB.
- `mix compile` clean (no warnings from touched files); `mix format` applied to all touched backend files.
- Frontend: `tsc --noEmit` clean. No frontend test runner in repo state — none added (per N4a scope).

## Deviations / decisions (flagging for review)

1. **Controller path is flat** (`controllers/tool_set_profiles_controller.ex`, module `NoizuPromptLinguaWeb.ToolSetProfilesController`) — the task brief said `controllers/mcp/…`, but PRD §4.1/§11 name the flat path and every controller in this repo is flat. PRD wins on details.
2. **Clone shipped in N4a** without the N4b validation machinery (context `clone/2` existed since N2a) — per lead instruction; validation of cloned configs lands with N4b.
3. **Three small additive storage edits** were required to wire the audit trail: `@settings_system_keys` gains `"_audit"` (the whitelist would otherwise reject the PRD §4.1 audit key); `list_for_org/2` gains `include_inactive:` (index must list deactivated sets, FR-4-3); `clone/3` honors caller `settings` merged **under** the clone-provenance keys (in-row audit written atomically with the clone). All backward-compatible; N2a suites pass unchanged.
4. **`urls: %{mcp, admin}` are `nil`** — the N3 URL builders don't exist yet; seam noted in the view.
5. **enum_remove editing is free-text tag entry**, not a picker from the tool's live enum — live enum data isn't exposed by the N4a catalog surface; the N4b effective preview is the natural home for it.
6. **Group selector lists the role groups** (`role_name_enum`: owner/admin/lead/member/viewer) — custom roles aren't creatable against the enum today; project selector wires `api.listProjects(orgId)`.
7. **AC-N4-5's Logger-failure sub-case** is covered structurally (rescue-wrapped) rather than by assertion — asserting Logger metadata isn't practical in the current test setup.
8. Frontend tests not added (no runner in repo; contract lane list untouched) — matches the N4a scope note.

## Open questions

- PRD §10.2: audit table remains open — this PR commits to the in-row `_audit` + Logger precedent (083 untouched).
- Should `show`'s `urls` stay `nil` until N3, or should the admin URL be built frontend-side and dropped from the API contract?

## Out of scope (N4b, gated on lib PRD-3)

validate dry-run endpoint + `validateToolSet` client + effective-catalog preview; disabled Validate button in the UI marks the seam.