### PR TITLE
fix: ToolProposer LLM stub seam (unblocks release)

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/tool_proposer.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/tool_proposer.ex
@@ -27,6 +27,7 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
   alias NoizuPromptLingua.Domains.MCPOverview.Store
   alias NoizuPromptLingua.Domains.MockMCP.Agent
   alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.MCPServers
   alias NoizuPromptLingua.MCP.ToolNames
   alias NoizuPromptLingua.Tools.Catalog
 
@@ -111,23 +112,17 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
   # ── Ask path ────────────────────────────────────────────────────────────────
 
   defp ask_once(messages, prefix, opts) do
-    case call_runner(messages, opts) do
-      {:ok, payload} ->
-        case classify(payload) do
-          {:questions, raw} ->
-            case build_questions(raw, prefix, opts) do
-              [] -> {:error, :llm_unavailable}
-              questions -> {:ok, {:questions, questions}}
-            end
-
-          {:proposal, %{summary: summary, tools: raw}} ->
-            finish_proposal(summary, raw)
-
-          :invalid ->
-            {:error, :llm_unavailable}
+    case classify(call_runner(messages, opts)) do
+      {:questions, raw} ->
+        case build_questions(raw, prefix, opts) do
+          [] -> {:error, :llm_unavailable}
+          questions -> {:ok, {:questions, questions}}
         end
 
-      _other ->
+      {:proposal, %{summary: summary, tools: raw}} ->
+        finish_proposal(summary, raw)
+
+      :invalid ->
         {:error, :llm_unavailable}
     end
   end
@@ -137,23 +132,22 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
   defp force_proposal(name, description, answers, shortlist, opts) do
     messages = build_messages(:force_proposal, name, description, answers, shortlist, "r2")
 
-    with {:ok, payload} <- call_runner(messages, opts),
-         {:proposal, %{summary: summary, tools: raw}} <- classify(payload) do
+    with {:proposal, %{summary: summary, tools: raw}} <-
+           classify(call_runner(messages, opts)) do
       finish_proposal(summary, raw)
     else
       {:questions, _} ->
-        strict =
-          build_messages(:strict_proposal, name, description, answers, shortlist, "r2")
+        strict = build_messages(:strict_proposal, name, description, answers, shortlist, "r2")
 
-        with {:ok, payload2} <- call_runner(strict, opts),
-             {:proposal, %{summary: summary2, tools: raw2}} <- classify(payload2) do
+        with {:proposal, %{summary: summary2, tools: raw2}} <-
+               classify(call_runner(strict, opts)) do
           finish_proposal(summary2, raw2)
         else
           _ -> {:error, :llm_unavailable}
         end
 
-    _ ->
-      {:error, :llm_unavailable}
+      _ ->
+        {:error, :llm_unavailable}
     end
   end
 
@@ -269,8 +263,18 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
     |> Map.new()
   end
 
+  # Universe = union of `Tools.Catalog.build/1` over each customizable group's
+  # server module (the same per-server catalogs membership is built from). The
+  # ROOT registry alone is NOT the universe — it carries only the root-plane
+  # subset (~35 tools) and would wrongly drop ~230 real group tools.
   defp universe_names do
-    Catalog.build()
+    MCPServers.customizable()
+    |> Enum.flat_map(fn server ->
+      case MCPServers.server_module(server.id) do
+        nil -> []
+        module -> Catalog.build(module)
+      end
+    end)
     |> Enum.map(& &1.name)
     |> MapSet.new()
   end
@@ -416,6 +420,8 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
 
   # The runner runs in a task so the `:timeout` (default 8s, NFR-2) maps a
   # hung LLM onto the llm_unavailable path instead of blocking the request.
+  # NOTE: the result (including any exit-mapped timeout) flows to `classify/1`
+  # UNWRAPPED — classify consumes the runner-result tuple directly.
   defp call_runner(messages, opts) do
     {mod, fun} = resolve_runner(opts)
     runner_opts = Keyword.take(opts, [:provider, :model, :endpoint, :api_key])
@@ -435,9 +441,11 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
   # Accepted LLM payloads (stub contract / FR-2):
   #   {"questions": [{"prompt", "kind", "options"?}]}
   #   {"summary", "tools": [{"name", "rationale"}]}
-  # Anything else — including a payload whose only extra is a "group" key on a
-  # tool — is normalized here; unknown keys (bogus group included) are simply
-  # never read, so they cannot leak into the response.
+  # Consumes the RUNNER RESULT tuple (`{:ok, text} | {:error, term()}`) —
+  # runner errors, timeouts, and unparseable/shape-invalid payloads all
+  # collapse to :invalid, which the callers map to {:error, :llm_unavailable}.
+  # A "group" key on a tool is simply never read, so an LLM-supplied group
+  # cannot leak into the response.
   defp classify({:ok, text}) when is_binary(text) do
     case text |> strip_fences() |> Jason.decode() do
       {:ok, %{"questions" => questions}} when is_list(questions) ->
@@ -452,7 +460,7 @@ defmodule NoizuPromptLingua.MCP.ToolProposer do
     end
   end
 
-  defp classify(_), do: :invalid
+  defp classify(_result), do: :invalid
 
   defp strip_fences(text) do
     text = String.trim(text)

--- a/backend/test/support/tool_proposer_llm_stub.ex
+++ b/backend/test/support/tool_proposer_llm_stub.ex
@@ -32,9 +32,32 @@ defmodule NoizuPromptLingua.TestSupport.ToolProposerLLMStub do
 
   use Agent
 
+  # Unique id per start: `start_supervised!` children live until TEST end, so
+  # re-entrant starts within one test must not collide on the child spec id
+  # (Supervisor rejects duplicates BEFORE start_link/1 runs). The name
+  # collision is then handled idempotently in start_link/1.
+  def child_spec(opts) do
+    %{
+      id: {__MODULE__, System.unique_integer([:positive])},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :temporary
+    }
+  end
+
   def start_link(opts) do
     script = Keyword.get(opts, :script, [])
-    Agent.start_link(fn -> {script, []} end, name: __MODULE__)
+
+    case Agent.start_link(fn -> {script, []} end, name: __MODULE__) do
+      {:ok, _} = ok ->
+        ok
+
+      # `start_supervised!` children live until TEST end, so re-entrant starts
+      # within one test (e.g. the multi-case loop) collide on the module name.
+      # Reuse the running agent: swap in the fresh script, keep call history.
+      {:error, {:already_started, pid}} ->
+        set_script(script)
+        {:ok, pid}
+    end
   end
 
   @doc "Runner contract entry point: `apply(mod, fun, [messages, opts])`."


### PR DESCRIPTION
Fixes the 15 test-backend smoke failures from CI run 34051954509 (all PRD-020, all one symptom: stubbed LLM responses collapsing to llm_unavailable).

Root causes confirmed locally:
- classify/1 expected the runner-result tuple ({:ok, text} | {:error, term}) but ask_once/force_proposal passed the already-unwrapped payload string, so every valid stub response hit the :invalid fallthrough (the compile gate cannot catch a clause-shape mismatch; only the tests expose it).
- The LLM stub's default child_spec used a fixed Supervisor child id, so the re-entrant start_supervised! loop in the unusable-outcomes test failed with {:already_started, pid} before start_link/1 ever ran; the stub now mints a unique child id and reuses the named agent idempotently.
- Grounding's universe set was built from the root MCP registry (~35 tools), which does not aggregate the customizable group servers, wrongly dropping ~230 real group tools; it now unions Tools.Catalog.build/1 over each customizable server module.

Verification: 52/52 green across tool_proposer_test.exs + mcp_endpoints_controller_test.exs; full hermetic MIX_ENV=test mix smoke 319/319 passed; npx tsc --noEmit exit 0. Test files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)