### PR TITLE
feat: alacarte MCP — restricted core, display styling, URL tool selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ frontend/cypress/screenshots/
 
 # Canonical worktree placement
 .claude/worktrees/
+backend/_build

--- a/.tmp/debug_out.txt
+++ b/.tmp/debug_out.txt
@@ -1,0 +1,2880 @@
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 68 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/market/tools/competitor_create.ex:68: NoizuPromptLingua.Domains.Market.Tools.CompetitorCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term(), term()} and not {:ok, term()}) or
+            ({:error, :org_not_found} and not {:ok, term(), term()})
+        )
+
+    type warning found at:
+    │
+ 39 │       {:error, :project_not_in_org} -> {:error, "Project does not belong to organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/unicode_codex/tools/overview.ex:39: NoizuPromptLingua.Domains.UnicodeCodex.Tools.Overview.call/2
+
+    warning: got "@impl true" for function init/1 but no behaviour was declared
+    │
+ 31 │   def init(opts), do: opts
+    │   ~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/plugs/api_key_auth.ex:31: NoizuPromptLinguaWeb.Plugs.ApiKeyAuth (module)
+
+    warning: got "@impl true" for function call/2 but no behaviour was declared
+    │
+ 34 │   def call(conn, _opts) do
+    │   ~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/plugs/api_key_auth.ex:34: NoizuPromptLinguaWeb.Plugs.ApiKeyAuth (module)
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 60 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/chat/tools/create_room.ex:60: NoizuPromptLingua.Domains.Chat.Tools.CreateRoom.call/2
+
+    warning: the following clause is redundant:
+
+        error ->
+
+    previous clauses have already matched on the following types:
+
+        :error
+
+    where "error" was given the type:
+
+        # type: dynamic(:error)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/repo_list.ex:36:11
+        error
+
+    type warning found at:
+    │
+ 36 │           error -> error
+    │                 ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/repo_list.ex:36:17: NoizuPromptLingua.Domains.Github.Tools.RepoList.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 60 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/campaigns/tools/domain_name_create.ex:60: NoizuPromptLingua.Domains.Campaigns.Tools.DomainNameCreate.call/2
+
+     warning: the following clause is redundant:
+
+         defp member_ref(_)
+
+     it has type:
+
+         dynamic()
+
+     previous clauses have already matched on the following types:
+
+         term()
+
+     │
+ 172 │   defp member_ref(_), do: nil
+     │        ~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/mcp_set_gateway_controller.ex:172:8: NoizuPromptLinguaWeb.MCPSetGatewayController.member_ref/1
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/pull_comment.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 34 │       {{:ok, _}, {:error, reason}} ->
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/pull_comment.ex:34:36: NoizuPromptLingua.Domains.Github.Tools.PullComment.call/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/issue_get.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 29 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/issue_get.ex:29:36: NoizuPromptLingua.Domains.Github.Tools.IssueGet.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.MCP.Resolve.scope(
+          NoizuPromptLingua.MCP.Args.get(args, :organization),
+          NoizuPromptLingua.MCP.Args.get(args, :project)
+        )
+
+    which has type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+            {:ok, nil, nil} or {:ok, not nil, term()}
+        )
+
+    type warning found at:
+    │
+ 61 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/instructions/tools/instruction_create.ex:61: NoizuPromptLingua.Domains.Instructions.Tools.InstructionCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term(), term()} and not {:ok, term()}) or
+            ({:error, :not_found} and not {:ok, %{element: term(), layers: term()}}) or
+            ({:error, :org_not_found} and not {:ok, term(), term()})
+        )
+
+    type warning found at:
+    │
+ 38 │       {:error, :project_not_in_org} -> {:error, "Project does not belong to organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/unicode_codex/tools/get.ex:38: NoizuPromptLingua.Domains.UnicodeCodex.Tools.Get.call/2
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:19
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Versioned.Descriptions.Description{})
+        # from: lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:19
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:19
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:19
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 19 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:19: Jason.Encoder.NoizuPromptLingua.Versioned.Descriptions.Description.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Descriptions.Description)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Descriptions.Description (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Descriptions.Description)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/descriptions/description.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Descriptions.Description (module)
+
+     warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 156 │   def get_branch(call_user_id, org_id, repo_ref, branch_name, opts \\ []) do
+     │                                                               ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/github/client.ex:156:63: NoizuPromptLingua.Github.Client.get_branch/5
+
+     warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 168 │   def create_branch(call_user_id, org_id, repo_ref, branch_name, from_sha, opts \\ []) do
+     │                                                                            ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/github/client.ex:168:76: NoizuPromptLingua.Github.Client.create_branch/6
+
+     warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 198 │   def get_pull(call_user_id, org_id, repo_ref, pull_number, opts \\ []) do
+     │                                                             ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/github/client.ex:198:61: NoizuPromptLingua.Github.Client.get_pull/5
+
+     warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 209 │   def create_pull(call_user_id, org_id, repo_ref, body, opts \\ []) do
+     │                                                         ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/github/client.ex:209:57: NoizuPromptLingua.Github.Client.create_pull/5
+
+     warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 220 │   def merge_pull(call_user_id, org_id, repo_ref, pull_number, body, opts \\ []) do
+     │                                                                     ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/github/client.ex:220:69: NoizuPromptLingua.Github.Client.merge_pull/6
+
+     warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 289 │   def get_issue(call_user_id, org_id, repo_ref, issue_number, opts \\ []) do
+     │                                                               ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/github/client.ex:289:63: NoizuPromptLingua.Github.Client.get_issue/5
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 77 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/market/tools/keyword_create.ex:77: NoizuPromptLingua.Domains.Market.Tools.KeywordCreate.call/2
+
+     warning: the following clause cannot match because the previous clauses already matched all possible values:
+
+         error ->
+
+     it attempts to match on the result of:
+
+         resolve_entity(org, subtree, key)
+
+     which has the already matched type:
+
+         dynamic({:error, :enoent} or {:ok, not nil})
+
+     where "error" was given the type:
+
+         # type: dynamic({:error, :enoent} or {:ok, not nil})
+         # from: lib/noizu_prompt_lingua/mcp/vfs/market.ex:397:7
+         error
+
+     type warning found at:
+     │
+ 397 │       error -> error
+     │             ~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/vfs/market.ex:397:13: NoizuPromptLingua.MCP.VFS.Market.collision_ok/3
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Credentials.UserCredential)
+    │
+ 11 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:11: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Credentials.UserCredential (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Credentials.UserCredential)
+    │
+ 11 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:11: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Credentials.UserCredential (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:34
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Users.Credentials.UserCredential{})
+        # from: lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:34
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:34
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:34
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 34 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/credentials/user_credential.ex:34: Jason.Encoder.NoizuPromptLingua.Users.Credentials.UserCredential.encode/2
+
+    warning: clauses with the same name and arity (number of arguments) should be grouped together, "def revoke_client/1" was previously defined (lib/noizu_prompt_lingua/oauth/clients.ex:41)
+    │
+ 75 │   def revoke_client(_), do: {:error, :not_found}
+    │       ~
+    │
+    └─ lib/noizu_prompt_lingua/oauth/clients.ex:75:7
+
+     warning: variable "key" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 463 │       key ->
+     │       ~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/auth_controller.ex:463:7: NoizuPromptLinguaWeb.AuthController.revoke_mcp_key/2
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:30
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Organizations.InviteToken{})
+        # from: lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:30
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:30
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:30
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 30 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:30: Jason.Encoder.NoizuPromptLingua.Organizations.InviteToken.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.InviteToken)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.InviteToken (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.InviteToken)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/invite_token.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.InviteToken (module)
+
+    warning: this clause of defp scope_error/1 is never used (or it will always fail/warn when invoked)
+    │
+ 73 │   defp scope_error(:project_not_in_org), do: "Project does not belong to this organization"
+    │        ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/tickets/tools/field_definition_create.ex:73:8: NoizuPromptLingua.Domains.Tickets.Tools.FieldDefinitionCreate.scope_error/1
+
+     warning: the following clause cannot match because the previous clauses already matched all possible values:
+
+         error ->
+
+     it attempts to match on the result of:
+
+         resolve_entity(org, subtree, key)
+
+     which has the already matched type:
+
+         dynamic({:error, :enoent} or {:ok, not nil})
+
+     where "error" was given the type:
+
+         # type: dynamic({:error, :enoent} or {:ok, not nil})
+         # from: lib/noizu_prompt_lingua/mcp/vfs/campaigns.ex:598:7
+         error
+
+     type warning found at:
+     │
+ 598 │       error -> error
+     │             ~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/vfs/campaigns.ex:598:13: NoizuPromptLingua.MCP.VFS.Campaigns.collision_ok/3
+
+     warning: the following clause will never match:
+
+         {:ok, project} ->
+
+     because it attempts to match on the result of:
+
+         NoizuPromptLingua.Projects.archive(project_id)
+
+     which has type:
+
+         dynamic({:error, :trp_unsupported_shared_key})
+
+     type warning found at:
+     │
+ 122 │         {:ok, project} ->
+     │         ~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/project_controller.ex:122: NoizuPromptLinguaWeb.ProjectController.archive/2
+
+     warning: the following clause will never match:
+
+         {:error, :not_found} ->
+
+     because it attempts to match on the result of:
+
+         NoizuPromptLingua.Projects.archive(project_id)
+
+     which has type:
+
+         dynamic({:error, :trp_unsupported_shared_key})
+
+     type warning found at:
+     │
+ 125 │         {:error, :not_found} ->
+     │         ~~~~~~~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/project_controller.ex:125: NoizuPromptLinguaWeb.ProjectController.archive/2
+
+     warning: the following clause will never match:
+
+         {:ok, project} ->
+
+     because it attempts to match on the result of:
+
+         NoizuPromptLingua.Projects.unarchive(project_id)
+
+     which has type:
+
+         dynamic({:error, :trp_unsupported_shared_key})
+
+     type warning found at:
+     │
+ 143 │         {:ok, project} ->
+     │         ~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/project_controller.ex:143: NoizuPromptLinguaWeb.ProjectController.unarchive/2
+
+     warning: the following clause will never match:
+
+         {:error, :not_found} ->
+
+     because it attempts to match on the result of:
+
+         NoizuPromptLingua.Projects.unarchive(project_id)
+
+     which has type:
+
+         dynamic({:error, :trp_unsupported_shared_key})
+
+     type warning found at:
+     │
+ 146 │         {:error, :not_found} ->
+     │         ~~~~~~~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/project_controller.ex:146: NoizuPromptLinguaWeb.ProjectController.unarchive/2
+
+     warning: the right-hand side of || will never be executed:
+
+         Exception.message(reason) || ...
+
+     because the left-hand side always evaluates to:
+
+         binary()
+
+     where "reason" was given the type:
+
+         # type: dynamic(not atom() and not binary())
+         # from: lib/noizu_prompt_lingua_web/controllers/project_controller.ex:300:19
+         reason
+
+     type warning found at:
+     │
+ 300 │   defp error_text(reason), do: Exception.message(reason) || inspect(reason)
+     │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/project_controller.ex:300: NoizuPromptLinguaWeb.ProjectController.error_text/1
+
+     warning: variable "org_id" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 115 │   defp resolve_target(org_id, project_id, "thread", message_id) do
+     │                       ~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua/domains/notifications/tools/share.ex:115:23: NoizuPromptLingua.Domains.Notifications.Tools.Share.resolve_target/4
+
+     warning: variable "project_id" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 115 │   defp resolve_target(org_id, project_id, "thread", message_id) do
+     │                               ~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua/domains/notifications/tools/share.ex:115:31: NoizuPromptLingua.Domains.Notifications.Tools.Share.resolve_target/4
+
+    warning: the following clause will never match:
+
+        {:scope, {:error, :project_not_in_org}} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:scope,
+            ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+              {:ok, nil, nil} or {:ok, not nil, term()}} and not {:scope, {:ok, term(), term()}}) or
+            ({:source, boolean()} and not {:source, true}) or
+            ({:target,
+              {:error, :not_found or :unknown_target_type} or
+                {:ok, {:dm, binary()} or {:room, term(), not false and not nil}}} and
+               not {:target, {:ok, {:dm, binary()} or {:room, term(), not false and not nil}}})
+        )
+
+    type warning found at:
+    │
+ 93 │       {:scope, {:error, :project_not_in_org}} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/notifications/tools/share.ex:93: NoizuPromptLingua.Domains.Notifications.Tools.Share.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 66 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/market/tools/keyword_research.ex:66: NoizuPromptLingua.Domains.Market.Tools.KeywordResearch.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term(), term()} and not {:ok, term()}) or
+            ({:error, :not_found} and
+               not {:ok,
+                %{
+                  layers: term(),
+                  special_usage: %{
+                    description: term(),
+                    flags: not false and not nil,
+                    id: term(),
+                    name: term(),
+                    organization_id: term(),
+                    overrides: term(),
+                    project_id: term(),
+                    references: not false and not nil,
+                    scope: term(),
+                    shadowed_by:
+                      %{
+                        id: term(),
+                        organization_id: term(),
+                        project_id: term(),
+                        scope: term(),
+                        slug: term()
+                      } or nil,
+                    slug: term(),
+                    title: term(),
+                    topics: not false and not nil
+                  }
+                }}) or ({:error, :org_not_found} and not {:ok, term(), term()})
+        )
+
+    type warning found at:
+    │
+ 35 │       {:error, :project_not_in_org} -> {:error, "Project does not belong to organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/unicode_codex/tools/special_usage_get.ex:35: NoizuPromptLingua.Domains.UnicodeCodex.Tools.SpecialUsageGet.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 55 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/wiki/tools/space_create.ex:55: NoizuPromptLingua.Domains.Wiki.Tools.SpaceCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 66 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/customers/tools/segment_create.ex:66: NoizuPromptLingua.Domains.Customers.Tools.SegmentCreate.call/2
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/sessions/session.ex:30
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Sessions.Session{})
+        # from: lib/noizu_prompt_lingua/entities/sessions/session.ex:30
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/sessions/session.ex:30
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/sessions/session.ex:30
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 30 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/sessions/session.ex:30: Jason.Encoder.NoizuPromptLingua.Sessions.Session.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Sessions.Session)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/sessions/session.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Sessions.Session (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Sessions.Session)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/sessions/session.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Sessions.Session (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/organizations/organization.ex:20
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Organizations.Organization{})
+        # from: lib/noizu_prompt_lingua/entities/organizations/organization.ex:20
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/organizations/organization.ex:20
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/organizations/organization.ex:20
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 20 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/organization.ex:20: Jason.Encoder.NoizuPromptLingua.Organizations.Organization.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Organization)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/organization.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Organization (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Organization)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/organization.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Organization (module)
+
+    warning: the following clause cannot match because the previous clauses already matched all possible values:
+
+        _ ->
+
+    it attempts to match on the result of:
+
+        cast(v)
+
+    which has the already matched type:
+
+        dynamic({:ok, term()})
+
+    type warning found at:
+    │
+ 26 │       _ -> raise ArgumentError, "Unsupported: #{inspect(v)}"
+    │         ~
+    │
+    └─ lib/supports/ecto/serialized_term.ex:26:9: NoizuPromptLingua.Ecto.SerializedTerm.cast!/1
+
+    warning: the following clause will never match:
+
+        :error ->
+
+    because it attempts to match on the result of:
+
+        load(value)
+
+    which has type:
+
+        dynamic({:error, :not_valid_base64} or {:ok, term()})
+
+    type warning found at:
+    │
+ 57 │       :error ->
+    │       ~~~~~~~~~
+    │
+    └─ lib/supports/ecto/serialized_term.ex:57: NoizuPromptLingua.Ecto.SerializedTerm.load!/1
+
+    warning: the following clause will never match:
+
+        {:error, reason} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.Domains.Markdown.view(markdown, opts)
+
+    which has type:
+
+        dynamic({:ok, %{markdown: term(), matched: term()}})
+
+    type warning found at:
+    │
+ 39 │       {:error, reason} -> {:error, reason}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/markdown/tools/view.ex:39: NoizuPromptLingua.Domains.Markdown.Tools.View.call/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/issue_comment.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 34 │       {{:ok, _}, {:error, reason}} ->
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/issue_comment.ex:34:36: NoizuPromptLingua.Domains.Github.Tools.IssueComment.call/2
+
+    warning: NoizuPromptLingua.Versioned.Names.change_versioned_name/2 is undefined or private. Did you mean:
+
+        * get_versioned_name/2
+        * get_versioned_name/3
+
+    │
+ 55 │                   NoizuPromptLingua.Versioned.Names.change_versioned_name(user.name.data, value)
+    │                                                     ~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users.ex:55:53: NoizuPromptLingua.Users.change_user/2
+
+    warning: NoizuPromptLingua.Versioned.Names.change_versioned_name/2 is undefined or private. Did you mean:
+
+        * get_versioned_name/2
+        * get_versioned_name/3
+
+    │
+ 61 │                   NoizuPromptLingua.Versioned.Names.change_versioned_name(
+    │                                                     ~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users.ex:61:53: NoizuPromptLingua.Users.change_user/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term(), term()} and not {:ok, term()}) or
+            ({:error, :org_not_found} and not {:ok, term(), term()})
+        )
+
+    type warning found at:
+    │
+ 39 │       {:error, :project_not_in_org} -> {:error, "Project does not belong to organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/unicode_codex/tools/special_usage_list.ex:39: NoizuPromptLingua.Domains.UnicodeCodex.Tools.SpecialUsageList.call/2
+
+     warning: variable "body" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 109 │   defp require_body(kind, body) when kind in ["ping", "pong"], do: :ok
+     │                           ~~~~
+     │
+     └─ lib/noizu_prompt_lingua/domains/notifications/tools/notify.ex:109:27: NoizuPromptLingua.Domains.Notifications.Tools.Notify.require_body/2
+
+    warning: the following clause will never match:
+
+        {:scope, {:error, :project_not_in_org}} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:scope,
+            ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+              {:ok, nil, nil} or {:ok, not nil, term()}} and not {:scope, {:ok, term(), term()}}) or
+            {:error, :body_required or :too_long}
+        )
+
+    type warning found at:
+    │
+ 98 │       {:scope, {:error, :project_not_in_org}} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/notifications/tools/notify.ex:98: NoizuPromptLingua.Domains.Notifications.Tools.Notify.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.MCP.Resolve.scope(
+          NoizuPromptLingua.MCP.Args.get(args, :organization),
+          NoizuPromptLingua.MCP.Args.get(args, :project)
+        )
+
+    which has type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+            {:ok, nil, nil} or {:ok, not nil, term()}
+        )
+
+    type warning found at:
+    │
+ 65 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/personas/tools/persona_create.ex:65: NoizuPromptLingua.Domains.Personas.Tools.PersonaCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.MCP.Resolve.scope(
+          NoizuPromptLingua.MCP.Args.get(args, :organization),
+          NoizuPromptLingua.MCP.Args.get(args, :project)
+        )
+
+    which has type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+            {:ok, nil, nil} or {:ok, not nil, term()}
+        )
+
+    type warning found at:
+    │
+ 64 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/tickets/tools/queue_create.ex:64: NoizuPromptLingua.Domains.Tickets.Tools.QueueCreate.call/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/issue_create.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 46 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/issue_create.ex:46:36: NoizuPromptLingua.Domains.Github.Tools.IssueCreate.call/2
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/organizations/membership.ex:24
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Organizations.Membership{})
+        # from: lib/noizu_prompt_lingua/entities/organizations/membership.ex:24
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/organizations/membership.ex:24
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/organizations/membership.ex:24
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 24 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/membership.ex:24: Jason.Encoder.NoizuPromptLingua.Organizations.Membership.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Membership)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/membership.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Membership (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Membership)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/organizations/membership.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Organizations.Membership (module)
+
+    warning: unused require Logger
+    │
+ 19 │   require Logger
+    │   ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/markdown/markdown.ex:19:3
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:25
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Authz.ScopedMemberships.ScopedMembership{})
+        # from: lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:25
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:25
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:25
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 25 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:25: Jason.Encoder.NoizuPromptLingua.Authz.ScopedMemberships.ScopedMembership.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.ScopedMemberships.ScopedMembership)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.ScopedMemberships.ScopedMembership (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.ScopedMemberships.ScopedMembership)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/scoped_memberships/scoped_membership.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.ScopedMemberships.ScopedMembership (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:20
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Authz.Policies.Policy{})
+        # from: lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:20
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:20
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:20
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 20 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:20: Jason.Encoder.NoizuPromptLingua.Authz.Policies.Policy.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Policies.Policy)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Policies.Policy (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Policies.Policy)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/policies/policy.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Policies.Policy (module)
+
+    warning: variable "json_format" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+  6 │     json_format = user_settings[:json_format] || :default
+    │     ~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/protocols/erp.ex:6:5: Jason.Encoder.Tuple.encode/2
+
+    warning: variable "json_format" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 26 │     json_format = user_settings[:json_format] || :default
+    │     ~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/protocols/erp.ex:26:5: Jason.Encoder.Tuple.encode/2
+
+    warning: incompatible types given to Jason.Encode.string/2:
+
+        Jason.Encode.string(
+          sref,
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        term(), {(none() -> term()), term()}
+
+    where "opts" was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/protocols/erp.ex:5:54
+        {_, _, user_settings} = opts
+
+    where "sref" was given the type:
+
+        # type: dynamic()
+        # from: lib/noizu_prompt_lingua/protocols/erp.ex:8:22
+        {:ok, sref} <- Noizu.EntityReference.Protocol.sref(s)
+
+    type warning found at:
+    │
+ 10 │       |> Jason.Encode.string(opts)
+    │                       ~
+    │
+    └─ lib/noizu_prompt_lingua/protocols/erp.ex:10:23: Jason.Encoder.Tuple.encode/2
+
+    warning: incompatible types given to Jason.Encode.string/2:
+
+        Jason.Encode.string(
+          sref,
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        term(), {(none() -> term()), term()}
+
+    where "opts" was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/protocols/erp.ex:25:54
+        {_, _, user_settings} = opts
+
+    where "sref" was given the type:
+
+        # type: dynamic()
+        # from: lib/noizu_prompt_lingua/protocols/erp.ex:28:22
+        {:ok, sref} <- Noizu.EntityReference.Protocol.sref(s)
+
+    type warning found at:
+    │
+ 30 │       |> Jason.Encode.string(opts)
+    │                       ~
+    │
+    └─ lib/noizu_prompt_lingua/protocols/erp.ex:30:23: Jason.Encoder.Tuple.encode/2
+
+    warning: incompatible types given to Jason.Encode.string/2:
+
+        Jason.Encode.string(
+          <<inspect(s)::binary>>,
+          opts
+        )
+
+    given types:
+
+        binary(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        term(), {(none() -> term()), term()}
+
+    where "opts" was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/protocols/erp.ex:36:27
+        {_, _, _} = opts
+
+    where "s" was given the type:
+
+        # type: dynamic({...} and not {:ref, term(), term()})
+        # from: lib/noizu_prompt_lingua/protocols/erp.ex:36:14
+        s
+
+    type warning found at:
+    │
+ 38 │     |> Jason.Encode.string(opts)
+    │                     ~
+    │
+    └─ lib/noizu_prompt_lingua/protocols/erp.ex:38:21: Jason.Encoder.Tuple.encode/2
+
+    warning: the following clause is redundant:
+
+        def encode({:ref, _, _} = s, {_, _, user_settings} = opts)
+
+    it has type:
+
+        dynamic({:ref, term(), term()}), dynamic({term(), term(), term()})
+
+    previous clauses have already matched on the following types:
+
+        {:ref, term(), term()}, {term(), term(), term()}
+        {:ref, term(), term()}, {term(), term()}
+
+    │
+ 25 │   def encode({:ref, _, _} = s, {_, _, user_settings} = opts) do
+    │       ~
+    │
+    └─ lib/noizu_prompt_lingua/protocols/erp.ex:25:7: Jason.Encoder.Tuple.encode/2
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/authz/groups/group.ex:19
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Authz.Groups.Group{})
+        # from: lib/noizu_prompt_lingua/entities/authz/groups/group.ex:19
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/authz/groups/group.ex:19
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/authz/groups/group.ex:19
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 19 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/groups/group.ex:19: Jason.Encoder.NoizuPromptLingua.Authz.Groups.Group.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Groups.Group)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/groups/group.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Groups.Group (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Groups.Group)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/authz/groups/group.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Authz.Groups.Group (module)
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/pull_create.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 43 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/pull_create.ex:43:36: NoizuPromptLingua.Domains.Github.Tools.PullCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, reason} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.NPL.Reader.sections()
+
+    which has type:
+
+        dynamic({:ok, term()})
+
+    type warning found at:
+    │
+ 20 │       {:error, reason} ->
+    │       ~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/controllers/npl_controller.ex:20: NoizuPromptLinguaWeb.NPLController.index_sections/2
+
+    warning: the following clause will never match:
+
+        {:error, reason} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.NPL.Reader.components(section)
+
+    which has type:
+
+        dynamic({:ok, term()})
+
+    type warning found at:
+    │
+ 33 │       {:error, reason} ->
+    │       ~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/controllers/npl_controller.ex:33: NoizuPromptLinguaWeb.NPLController.index_conventions/2
+
+    warning: the right-hand side of || will always execute:
+
+        components == [] && nil
+
+    because the left-hand side always evaluates to:
+
+        dynamic(false or nil)
+
+    where "x" (context Kernel) was given the type:
+
+        # type: dynamic(false or nil)
+        # from: lib/noizu_prompt_lingua_web/controllers/npl_controller.ex:90
+        x
+
+    type warning found at:
+    │
+ 90 │       components: (components == [] && nil) || components,
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/controllers/npl_controller.ex:90: NoizuPromptLinguaWeb.NPLController.spec_opts_from_params/1
+
+    warning: the right-hand side of || will always execute:
+
+        rendered == [] && nil
+
+    because the left-hand side always evaluates to:
+
+        dynamic(false or nil)
+
+    where "x" (context Kernel) was given the type:
+
+        # type: dynamic(false or nil)
+        # from: lib/noizu_prompt_lingua_web/controllers/npl_controller.ex:91
+        x
+
+    type warning found at:
+    │
+ 91 │       rendered: (rendered == [] && nil) || rendered,
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/controllers/npl_controller.ex:91: NoizuPromptLinguaWeb.NPLController.spec_opts_from_params/1
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/projects/project.ex:26
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Projects.Project{})
+        # from: lib/noizu_prompt_lingua/entities/projects/project.ex:26
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/projects/project.ex:26
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/projects/project.ex:26
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 26 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/projects/project.ex:26: Jason.Encoder.NoizuPromptLingua.Projects.Project.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Projects.Project)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/projects/project.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Projects.Project (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Projects.Project)
+    │
+ 10 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/projects/project.ex:10: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Projects.Project (module)
+
+    warning: unused import Plug.Conn
+    │
+  3 │   import Plug.Conn
+    │   ~
+    │
+    └─ lib/noizu_prompt_lingua_web/plugs/otel_logger_metadata.ex:3:3
+
+    warning: unused require Logger
+    │
+  4 │   require Logger
+    │   ~
+    │
+    └─ lib/noizu_prompt_lingua_web/plugs/otel_logger_metadata.ex:4:3
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 82 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/tickets/tools/ticket_from_entity.ex:82: NoizuPromptLingua.Domains.Tickets.Tools.TicketFromEntity.call/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Auth.Providers.Provider)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Auth.Providers.Provider (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Auth.Providers.Provider)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Auth.Providers.Provider (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:20
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Auth.Providers.Provider{})
+        # from: lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:20
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:20
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:20
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 20 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/auth/providers/provider.ex:20: Jason.Encoder.NoizuPromptLingua.Auth.Providers.Provider.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Names.Name)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/names/name.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Names.Name (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Names.Name)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/names/name.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Names.Name (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/versioned/names/name.ex:17
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Versioned.Names.Name{})
+        # from: lib/noizu_prompt_lingua/entities/versioned/names/name.ex:17
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/versioned/names/name.ex:17
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/versioned/names/name.ex:17
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 17 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/names/name.ex:17: Jason.Encoder.NoizuPromptLingua.Versioned.Names.Name.encode/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.MCP.Resolve.scope(
+          NoizuPromptLingua.MCP.Args.get(args, :organization),
+          NoizuPromptLingua.MCP.Args.get(args, :project)
+        )
+
+    which has type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+            {:ok, nil, nil} or {:ok, not nil, term()}
+        )
+
+    type warning found at:
+    │
+ 66 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/assets/tools/asset_create.ex:66: NoizuPromptLingua.Domains.Assets.Tools.AssetCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 86 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/customers/tools/persona_create.ex:86: NoizuPromptLingua.Domains.Customers.Tools.PersonaCreate.call/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/branch_list.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 33 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/branch_list.ex:33:36: NoizuPromptLingua.Domains.Github.Tools.BranchList.call/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/pull_merge.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 48 │       {{:ok, _}, {:error, reason}} ->
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/pull_merge.ex:48:36: NoizuPromptLingua.Domains.Github.Tools.PullMerge.call/2
+
+    warning: the following clause will never match:
+
+        false ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :not_found} and not {:ok, %{..., expires_at: term()}}) or
+            {:error, :expired or :forbidden}
+        )
+
+    type warning found at:
+    │
+ 86 │       false -> {:error, :forbidden}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/oauth/elevation.ex:86: NoizuPromptLingua.OAuth.Elevation.approve!/2
+
+    warning: the following clause will never match:
+
+        {:scope, {:error, :project_not_in_org}} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:scope,
+            ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+              {:ok, nil, nil} or {:ok, not nil, term()}} and not {:scope, {:ok, term(), term()}}) or
+            ({:when, {:error, :bad_at or :no_duration} or {:ok, %DateTime{}}} and
+               not {:when, {:ok, %DateTime{}}})
+        )
+
+    type warning found at:
+    │
+ 78 │       {:scope, {:error, :project_not_in_org}} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/notifications/tools/follow_up.ex:78: NoizuPromptLingua.Domains.Notifications.Tools.FollowUp.call/2
+
+     warning: the following clause cannot match because the previous clauses already matched all possible values:
+
+         error ->
+
+     it attempts to match on the result of:
+
+         resolve_entity(org, subtree, key)
+
+     which has the already matched type:
+
+         dynamic({:error, :enoent} or {:ok, not nil})
+
+     where "error" was given the type:
+
+         # type: dynamic({:error, :enoent} or {:ok, not nil})
+         # from: lib/noizu_prompt_lingua/mcp/vfs/customers.ex:474:7
+         error
+
+     type warning found at:
+     │
+ 474 │       error -> error
+     │             ~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/vfs/customers.ex:474:13: NoizuPromptLingua.MCP.VFS.Customers.collision_ok/3
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 68 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/market/tools/report_create.ex:68: NoizuPromptLingua.Domains.Market.Tools.ReportCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 82 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/artifacts/tools/artifact_create.ex:82: NoizuPromptLingua.Domains.Artifacts.Tools.ArtifactCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 56 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/campaigns/tools/landing_page_create.ex:56: NoizuPromptLingua.Domains.Campaigns.Tools.LandingPageCreate.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 76 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/campaigns/tools/campaign_create.ex:76: NoizuPromptLingua.Domains.Campaigns.Tools.CampaignCreate.call/2
+
+     warning: the following conditional expression:
+
+         is_map(config)
+
+     will always evaluate to:
+
+         dynamic(true)
+
+     where "config" was given the type:
+
+         # type: dynamic(map())
+         # from: lib/noizu_prompt_lingua/mcp/url_toolset_param.ex:360:20
+         {config, kind} = {scope_config_of(scope), scope_kind(scope)}
+
+     type warning found at:
+     │
+ 364 │         MCPCustomScopes.normalize_config(if(is_map(config), do: config, else: %{}), kind)
+     │         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/url_toolset_param.ex:364: NoizuPromptLingua.MCP.UrlToolsetParam.compile_context/1
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/branch_get.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 29 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/branch_get.ex:29:36: NoizuPromptLingua.Domains.Github.Tools.BranchGet.call/2
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/media/asset.ex:30
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Media.Asset{})
+        # from: lib/noizu_prompt_lingua/entities/media/asset.ex:30
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/media/asset.ex:30
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/media/asset.ex:30
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 30 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/media/asset.ex:30: Jason.Encoder.NoizuPromptLingua.Media.Asset.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Media.Asset)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/media/asset.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Media.Asset (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Media.Asset)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/media/asset.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Media.Asset (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:18
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Versioned.Strings.String{})
+        # from: lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:18
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:18
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:18
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 18 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:18: Jason.Encoder.NoizuPromptLingua.Versioned.Strings.String.encode/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Strings.String)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Strings.String (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Strings.String)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/versioned/strings/string.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Versioned.Strings.String (module)
+
+    warning: the following clause will never match:
+
+        {:error, changeset}
+            when is_map(changeset) and (is_atom(Ecto.Changeset) or :fail) and
+                   is_map_key(changeset, :__struct__) and
+                   :erlang.map_get(:__struct__, changeset) == Ecto.Changeset ->
+
+    it is expected to match on type:
+
+        dynamic(
+          {:error, binary()} and
+            not {:ok,
+             %{bio: term()} or %{bio: term(), email: term()} or
+               %{bio: term(), email: term(), role: :other or :user} or
+               %{bio: term(), email: term(), role: :other or :user, user_name: term()} or
+               %{bio: term(), email: term(), user_name: term()} or %{bio: term(), role: :other or :user} or
+               %{bio: term(), role: :other or :user, user_name: term()} or
+               %{bio: term(), user_name: term()} or %{email: term()} or
+               %{email: term(), role: :other or :user} or
+               %{email: term(), role: :other or :user, user_name: term()} or
+               %{email: term(), user_name: term()} or %{role: :other or :user} or
+               %{role: :other or :user, user_name: term()} or %{user_name: term()} or empty_map()} and
+            not {:ok, term()}
+        )
+
+    where "changeset" was given the types:
+
+        # type: map()
+        # from: lib/noizu_prompt_lingua_web/controllers/user_controller.ex:25
+        is_map(changeset)
+
+        # type: %{..., __struct__: term()}
+        # from: lib/noizu_prompt_lingua_web/controllers/user_controller.ex:25
+        is_map_key(changeset, :__struct__)
+
+        # type: %{..., __struct__: Ecto.Changeset}
+        # from: lib/noizu_prompt_lingua_web/controllers/user_controller.ex:25
+        :erlang.map_get(:__struct__, changeset)
+
+    type warning found at:
+    │
+ 25 │       {:error, changeset} when is_struct(changeset, Ecto.Changeset) ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua_web/controllers/user_controller.ex:25: NoizuPromptLinguaWeb.UserController.update/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/issue_list.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 41 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/issue_list.ex:41:36: NoizuPromptLingua.Domains.Github.Tools.IssueList.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    because it attempts to match on the result of:
+
+        NoizuPromptLingua.MCP.Resolve.scope(
+          NoizuPromptLingua.MCP.Args.get(args, :organization),
+          NoizuPromptLingua.MCP.Args.get(args, :project)
+        )
+
+    which has type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or {:error, :org_not_found} or
+            {:ok, nil, nil} or {:ok, not nil, term()}
+        )
+
+    type warning found at:
+    │
+ 93 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/tickets/tools/definition_create.ex:93: NoizuPromptLingua.Domains.Tickets.Tools.DefinitionCreate.call/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.User)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/user.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.User (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.User)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/user.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.User (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/users/user.ex:31
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Users.User{})
+        # from: lib/noizu_prompt_lingua/entities/users/user.ex:31
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/users/user.ex:31
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/users/user.ex:31
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 31 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/user.ex:31: Jason.Encoder.NoizuPromptLingua.Users.User.encode/2
+
+     warning: variable "v" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 423 │     |> Enum.filter(fn {{o, _}, v} -> o == org_id end)
+     │                                ~
+     │
+     └─ test/support/trp_stub.ex:423:32: NoizuPromptLingua.TRP.TestStub.list_for/3
+
+     warning: def publish_version/3 has multiple clauses and also declares default values. In such cases, the default values should be defined in a header. Instead of:
+
+         def foo(:first_clause, b \\ :default) do ... end
+         def foo(:second_clause, b) do ... end
+
+     one should write:
+
+         def foo(a, b \\ :default)
+         def foo(:first_clause, b) do ... end
+         def foo(:second_clause, b) do ... end
+
+     the previous clause is defined on line 111
+
+     │
+ 140 │   def publish_version(slug, template, change_note) when is_binary(slug) do
+     │       ~
+     │
+     └─ lib/noizu_prompt_lingua/mcp_prompts.ex:140:7
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term(), term()} and not {:ok, term()}) or
+            ({:error, :org_not_found} and not {:ok, term(), term()})
+        )
+
+    type warning found at:
+    │
+ 55 │       {:error, :project_not_in_org} -> {:error, "Project does not belong to organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/unicode_codex/tools/search.ex:55: NoizuPromptLingua.Domains.UnicodeCodex.Tools.Search.call/2
+
+     warning: redefining @doc attribute previously set at line 322
+     │
+ 327 │   @doc "Notification ids of still-unread rows matching a dedup_key for a recipient."
+     │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua/domains/notifications/notifications.ex:327: NoizuPromptLingua.Domains.Notifications (module)
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil}) or
+            {:error, :artifact_not_found or :artifact_not_in_org}
+        )
+
+    type warning found at:
+    │
+ 64 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/review/tools/review_create.ex:64: NoizuPromptLingua.Domains.Review.Tools.ReviewCreate.call/2
+
+     warning: variable "user" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 276 │       {user, org} ->
+     │        ~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/github_controller.ex:276:8: NoizuPromptLinguaWeb.GithubController.handle_github_call/5
+
+    warning: the following clause cannot match because the previous clauses already matched all possible values:
+
+        error ->
+
+    it attempts to match on the result of:
+
+        NoizuPromptLingua.Github.Client.list_repos(user, org)
+
+    which has the already matched type:
+
+        dynamic({:ok, %{count: integer(), repos: term()}})
+
+    where "error" was given the type:
+
+        # type: dynamic({:ok, %{count: integer(), repos: term()}})
+        # from: lib/noizu_prompt_lingua_web/controllers/github_controller.ex:71:11
+        error
+
+    type warning found at:
+    │
+ 71 │           error -> handle_error(conn, error)
+    │                 ~
+    │
+    └─ lib/noizu_prompt_lingua_web/controllers/github_controller.ex:71:17: NoizuPromptLinguaWeb.GithubController.index/2
+
+     warning: clauses with the same name and arity (number of arguments) should be grouped together, "defp meta_get/2" was previously defined (lib/noizu_prompt_lingua/mcp/tool_guard.ex:406)
+     │
+ 426 │   defp meta_get(m, key) when is_map(m), do: Map.get(m, key) || Map.get(m, to_string(key))
+     │        ~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/tool_guard.ex:426:8
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :project_not_found} and not {:ok, term()}) or ({:org, term()} and not {:org, not nil})
+        )
+
+    type warning found at:
+    │
+ 87 │       {:error, :project_not_in_org} ->
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/tickets/tools/ticket_create.ex:87: NoizuPromptLingua.Domains.Tickets.Tools.TicketCreate.call/2
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Sessions.UserSession)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Sessions.UserSession (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Sessions.UserSession)
+    │
+ 12 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:12: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Sessions.UserSession (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:29
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Users.Sessions.UserSession{})
+        # from: lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:29
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:29
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:29
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 29 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/sessions/user_session.ex:29: Jason.Encoder.NoizuPromptLingua.Users.Sessions.UserSession.encode/2
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/pull_get.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 29 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/pull_get.ex:29:36: NoizuPromptLingua.Domains.Github.Tools.PullGet.call/2
+
+    warning: the following clause will never match:
+
+        {:error, :project_not_in_org} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:error, :not_found} and
+             not {:ok,
+              %{count: integer(), relations: term()} or %{element: not %{..., id: term()}, layers: term()}} and
+             not {:ok, %{..., element: %{..., id: term()}}}) or
+            ({:error, :project_not_found} and not {:ok, term(), term()} and not {:ok, term()}) or
+            ({:error, :org_not_found} and not {:ok, term(), term()})
+        )
+
+    type warning found at:
+    │
+ 35 │       {:error, :project_not_in_org} -> {:error, "Project does not belong to organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/domains/unicode_codex/tools/related.ex:35: NoizuPromptLingua.Domains.UnicodeCodex.Tools.Related.call/2
+
+     warning: variable "scope" is unused (if the variable is not meant to be used, prefix it with an underscore)
+     │
+ 347 │   defp read_node([space_slug], scope) do
+     │                                ~~~~~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/vfs/wiki.ex:347:32: NoizuPromptLingua.MCP.VFS.Wiki.read_node/2
+
+      warning: the right-hand side of || will never be executed:
+
+          att.url || ...
+
+      because the left-hand side always evaluates to:
+
+          binary()
+
+      where "att" was given the types:
+
+          # type: dynamic(%{..., url: term()})
+          # from: lib/noizu_prompt_lingua/mcp/vfs/wiki.ex:1101:14
+          att.url
+
+          # type: dynamic(%{..., url: binary()})
+          # from: lib/noizu_prompt_lingua/mcp/vfs/wiki.ex:1101:14
+          att.url
+
+      type warning found at:
+      │
+ 1105 │           _ -> att.url || ""
+      │           ~~~~~~~~~~~~~~~~~~
+      │
+      └─ lib/noizu_prompt_lingua/mcp/vfs/wiki.ex:1105: NoizuPromptLingua.MCP.VFS.Wiki.attachment_content/1
+
+    warning: the following clause is redundant:
+
+        {{:ok, _}, {:error, reason}} ->
+
+    previous clauses have already matched on the following types:
+
+        {{:ok, binary()}, {:ok, not nil}}
+        {{:ok, binary()}, {:error, :org_not_found}}
+
+    where "reason" was given the type:
+
+        # type: dynamic(:org_not_found)
+        # from: lib/noizu_prompt_lingua/domains/github/tools/pull_list.ex
+        {{:ok, _}, {:error, reason}}
+
+    type warning found at:
+    │
+ 41 │       {{:ok, _}, {:error, reason}} -> {:error, reason}
+    │                                    ~
+    │
+    └─ lib/noizu_prompt_lingua/domains/github/tools/pull_list.ex:41:36: NoizuPromptLingua.Domains.Github.Tools.PullList.call/2
+
+    warning: variable "raw_body" is unused (if the variable is not meant to be used, prefix it with an underscore)
+    │
+ 63 │       {:ok, status, raw_body} when status == 401 and left > 0 ->
+    │                     ~
+    │
+    └─ lib/noizu_prompt_lingua/trp/service_auth.ex:63:21: NoizuPromptLingua.TRP.ServiceAuth.do_request/5
+
+    warning: function field_as_record/5 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Media.Asset)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/media/asset.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Media.Asset (module)
+
+    warning: function field_from_record/6 required by protocol Noizu.Entity.Store.Ecto.Entity.FieldProtocol is not implemented (in module Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Media.Asset)
+    │
+  9 │   def_entity do
+    │   ~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/media/asset.ex:9: Noizu.Entity.Store.Ecto.Entity.FieldProtocol.NoizuPromptLingua.Users.Media.Asset (module)
+
+    warning: incompatible types given to Jason.Encode.map/2:
+
+        Jason.Encode.map(
+          Noizu.Entity.Json.Protocol.prep(s, settings, user_settings[:context], user_settings[:settings]),
+          opts
+        )
+
+    given types:
+
+        dynamic(), -dynamic({term(), term(), term()})-
+
+    but expected one of:
+
+        map(), {term(), term()}
+
+    where "opts" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic({term(), term(), term()})
+        # from: lib/noizu_prompt_lingua/entities/users/media/asset.ex:29
+        {_, _, user_settings} = opts
+
+    where "s" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(%NoizuPromptLingua.Users.Media.Asset{})
+        # from: lib/noizu_prompt_lingua/entities/users/media/asset.ex:29
+        s
+
+    where "settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(not false and not nil)
+        # from: lib/noizu_prompt_lingua/entities/users/media/asset.ex:29
+        settings =
+          cond do
+            ...
+          end
+
+    where "user_settings" (context Noizu.Entity.Macros) was given the type:
+
+        # type: dynamic(
+          %{..., __struct__: atom()} or nil or empty_list() or non_empty_list(term(), term()) or
+            non_struct_map()
+        )
+        # from: lib/noizu_prompt_lingua/entities/users/media/asset.ex:29
+        user_settings[:json_format]
+
+    type warning found at:
+    │
+ 29 │   jason_encoder()
+    │   ~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/entities/users/media/asset.ex:29: Jason.Encoder.NoizuPromptLingua.Users.Media.Asset.encode/2
+
+     warning: the following clause cannot match because the previous clauses already matched all possible values:
+
+         {:error, _} = err ->
+
+     it attempts to match on the result of:
+
+         project_in_org(ref, org.id)
+
+     which has the already matched type:
+
+         dynamic({:error, :project_not_found} or {:ok, term()})
+
+     where "err" was given the type:
+
+         # type: dynamic({:error, :project_not_found})
+         # from: lib/noizu_prompt_lingua/mcp/resolve.ex:143:21
+         {:error, _} = err
+
+     type warning found at:
+     │
+ 143 │         {:error, _} = err -> {:halt, err}
+     │                           ~
+     │
+     └─ lib/noizu_prompt_lingua/mcp/resolve.ex:143:27: NoizuPromptLingua.MCP.Resolve.project_across_scope/1
+
+     warning: the following conditional expression will always succeed:
+
+         is_binary(source)
+
+     because it evaluates to:
+
+         dynamic(true)
+
+     where "source" was given the type:
+
+         # type: binary()
+         # from: lib/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller.ex:391:11
+         is_binary(source)
+
+     type warning found at:
+     │
+ 394 │       is_binary(source) and not is_nil(Profiles.get(source)) ->
+     │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     │
+     └─ lib/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller.ex:394: NoizuPromptLinguaWeb.ToolSetProfilesController.resolve_source/2
+
+      warning: clauses with the same name and arity (number of arguments) should be grouped together, "def delete/1" was previously defined (lib/noizu_prompt_lingua/mcp_custom_scopes.ex:1049)
+      │
+ 1080 │   def delete(slug) when is_binary(slug) do
+      │       ~
+      │
+      └─ lib/noizu_prompt_lingua/mcp_custom_scopes.ex:1080:7
+
+    warning: module attribute @visibilities was set but never used
+    │
+ 54 │   @visibilities ~w(org account shared)
+    │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/mcp_custom_scopes.ex:54: NoizuPromptLingua.MCPCustomScopes (module)
+
+      warning: this clause of defp apply_preset/1 is never used (or it will always fail/warn when invoked)
+      │
+ 1468 │   defp apply_preset(_), do: %{}
+      │        ~
+      │
+      └─ lib/noizu_prompt_lingua/mcp_custom_scopes.ex:1468:8: NoizuPromptLingua.MCPCustomScopes.apply_preset/1
+
+    warning: the following clause will never match:
+
+        {:client, :not_found} ->
+
+    it is expected to match on type:
+
+        dynamic(
+          ({:org, term()} and not {:org, not nil}) or ({:owner, not false} and not {:owner, binary()})
+        )
+
+    type warning found at:
+    │
+ 59 │       {:client, :not_found} -> {:error, "Client '#{client_ref}' not found in organization"}
+    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    │
+    └─ lib/noizu_prompt_lingua/mcp/projects/tools/project_create.ex:59: NoizuPromptLingua.MCP.Projects.Tools.ProjectCreate.call/2
+
+** (MatchError) no match of right hand side value:
+
+    {:error,
+     #Ecto.Changeset<
+       action: :insert,
+       changes: %{
+         name: "Dbg",
+         config: %{
+           "groups" => %{
+             "tickets" => %{"tools" => %{"Ticket.Get" => %{"disabled" => true}}}
+           }
+         },
+         kind: "custom",
+         is_default: false,
+         slug: "dbg-param"
+       },
+       errors: [
+         slug: {"has already been taken",
+          [constraint: :unique, constraint_name: "uq_mcp_custom_scopes_slug"]}
+       ],
+       data: #NoizuPromptLingua.Schema.MCPCustomScope<>,
+       valid?: false,
+       ...
+     >}
+
+    /Users/keithbrings/Work/Space/Noizu/Portfolio/Apps/AI/NoizuPromptLingo/.claude/worktrees/alacarte-mcp/.tmp/debug_param.exs:6: (file)
+    (elixir 1.20.1) lib/code.ex:1639: Code.require_file/2

--- a/.tmp/debug_param.exs
+++ b/.tmp/debug_param.exs
@@ -1,0 +1,26 @@
+alias NoizuPromptLingua.MCPCustomScopes
+alias NoizuPromptLingua.MCP.UrlToolsetParam
+alias NoizuPromptLingua.MCP.EffectiveToolset
+alias Noizu.MCP.Ctx
+
+slug = "dbg-param-#{System.unique_integer([:positive])}"
+
+{:ok, scope} =
+  MCPCustomScopes.create(%{
+    "slug" => slug,
+    "name" => "Dbg",
+    "kind" => "custom",
+    "config" => %{"groups" => %{"tickets" => %{"tools" => %{"Ticket.Get" => %{"disabled" => true}}}}}
+  })
+
+{:ok, layer} =
+  UrlToolsetParam.compile(%{"tools" => %{"Ticket_Get" => %{"visible" => true}}}, scope)
+
+IO.inspect(get_in(layer, ["groups", "tickets", "tools", "Ticket_Get"]), label: "layer entry")
+
+ctx = %Ctx{server: NoizuPromptLingua.MCP, assigns: %{custom_scope_slug: slug, toolset_param_cfg: layer}}
+client = EffectiveToolset.param_only_client(ctx)
+
+states = EffectiveToolset.resolve(scope, client, nil)
+IO.inspect(EffectiveToolset.lookup(states, "Ticket.Get"), label: "Ticket.Get state")
+IO.inspect(EffectiveToolset.lookup(states, "Ticket.List"), label: "Ticket.List state")

--- a/.tmp/run2.txt
+++ b/.tmp/run2.txt
@@ -1,0 +1,122 @@
+06:00:09.893 [warning] API ERROR: 
+ {:ok, %Finch.Response{status: 404, body: "", headers: [{"date", "Sun, 06 Sep 2026 23:00:10 GMT"}, {"content-length", "0"}, {"connection", "keep-alive"}, {"access-control-allow-headers", "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Azure-Deployment-Id, X-Azure-Resource-Name, X-Azure-Concurrency, X-Azure-Block-Size, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Goog-Api-Key, X-Goog-Vertex-Api-Key, X-Goog-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key, X-Anthropic-Baseurl, X-Anthropic-Api-Key, X-Databricks-Endpoint, X-Databricks-Token, X-Databricks-User-Agent, X-Friendli-Token, X-Friendli-Baseurl, X-Weaviate-Api-Key, X-Weaviate-Cluster-Url, X-Nvidia-Api-Key, X-Nvidia-Baseurl, X-ContextualAI-Baseurl, X-ContextualAI-Api-Key"}, {"access-control-allow-methods", "*"}, {"access-control-allow-origin", "*"}, {"vary", "Origin"}, {"strict-transport-security", "max-age=31536000; includeSubDomains"}, {"cf-cache-status", "DYNAMIC"}, {"server-timing", "cfCacheStatus;desc=\"DYNAMIC\""}, {"server-timing", "cfEdge;dur=20,cfOrigin;dur=63"}, {"report-to", "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=KW8f3a4SHJ3TJVqFYcbmveTk0eRCwJqlaWrYZasSv%2FjhzeyXYclG2OQGKrElk2SKgjIBY0aJsVVcQBxsthL2yJeABH8z%2B%2BKH7TjwylRBhkMksyxnSW40yjBzqyHqeRB2Htci7qM%3D\"}]}"}, {"nel", "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}"}, {"server", "cloudflare"}, {"cf-ray", "a371169a4c5ca2b3-LAX"}, {"alt-svc", "h3=\":443\"; ma=86400"}], trailers: []}}
+Running ExUnit with seed: 452626, max_cases: 20
+Excluding tags: [live_trp: true]
+
+..........
+
+  1) test compile/1 precedence: white-list defines the enable set snake_case aliases compile to the IDENTICAL layer (golden vector) (NoizuPromptLingua.MCP.UrlToolsetParamTest)
+     test/noizu_prompt_lingua/mcp/url_toolset_param_test.exs:185
+     Assertion with == failed
+     code:  assert snake == kebab
+     left:  %{
+              "groups" => %{
+                "sessions" => %{
+                  "tools" => %{
+                    "Session_Archive" => %{},
+                    "Session_Create" => %{},
+                    "Session_Get" => %{},
+                    "Session_List" => %{},
+                    "Session_Manifest" => %{},
+                    "Session_Overview" => %{},
+                    "Session_Update" => %{}
+                  }
+                },
+                "tickets" => %{
+                  "tools" => %{
+                    "Ticket_Attach" => %{},
+                    "Ticket_Comment" => %{},
+                    "Ticket_Create" => %{},
+                    "Ticket_Definition_Create" => %{},
+                    "Ticket_Definition_Delete" => %{},
+                    "Ticket_Definition_Get" => %{},
+                    "Ticket_Definition_Update" => %{},
+                    "Ticket_Feed" => %{},
+                    "Ticket_Field_Definition_Create" => %{},
+                    "Ticket_Field_Definition_Delete" => %{},
+                    "Ticket_Field_Definition_Update" => %{},
+                    "Ticket_FromEntity" => %{},
+                    "Ticket_Get" => %{},
+                    "Ticket_Link" => %{},
+                    "Ticket_LinkEntity" => %{},
+                    "Ticket_List" => %{},
+                    "Ticket_Overview" => %{},
+                    "Ticket_Queue_Create" => %{},
+                    "Ticket_Queue_Feed" => %{},
+                    "Ticket_Queue_Get" => %{},
+                    "Ticket_Queue_List" => %{},
+                    "Ticket_Unlink" => %{},
+                    "Ticket_UnlinkEntity" => %{},
+                    "Ticket_Update" => %{},
+                    "Ticket_Watch" => %{}
+                  }
+                }
+              }
+            }
+     right: %{
+              "groups" => %{
+                "sessions" => %{
+                  "tools" => %{
+                    "Session_Archive" => %{"disabled" => true},
+                    "Session_Create" => %{"disabled" => true},
+                    "Session_Get" => %{"disabled" => true},
+                    "Session_List" => %{
+                      "disabled" => false,
+                      "hidden" => false
+                    },
+                    "Session_Manifest" => %{"disabled" => true},
+                    "Session_Overview" => %{"disabled" => true},
+                    "Session_Update" => %{"disabled" => true}
+                  }
+                },
+                "tickets" => %{
+                  "tools" => %{
+                    "Ticket_Attach" => %{"disabled" => true},
+                    "Ticket_Comment" => %{"disabled" => true},
+                    "Ticket_Create" => %{"disabled" => true},
+                    "Ticket_Definition_Create" => %{
+                      "disabled" => true
+                    },
+                    "Ticket_Definition_Delete" => %{
+                      "disabled" => true
+                    },
+                    "Ticket_Definition_Get" => %{"disabled" => true},
+                    "Ticket_Definition_Update" => %{
+                      "disabled" => true
+                    },
+                    "Ticket_Feed" => %{"disabled" => true},
+                    "Ticket_Field_Definition_Create" => %{
+                      "disabled" => true
+                    },
+                    "Ticket_Field_Definition_Delete" => %{
+                      "disabled" => true
+                    },
+                    "Ticket_Field_Definition_Update" => %{
+                      "disabled" => true
+                    },
+                    "Ticket_FromEntity" => %{"disabled" => true},
+                    "Ticket_Get" => %{"disabled" => true},
+                    "Ticket_Link" => %{"disabled" => true},
+                    "Ticket_LinkEntity" => %{"disabled" => true},
+                    "Ticket_List" => %{"disabled" => true},
+                    "Ticket_Overview" => %{"disabled" => true},
+                    "Ticket_Queue_Create" => %{"disabled" => true},
+                    "Ticket_Queue_Feed" => %{"disabled" => true},
+                    "Ticket_Queue_Get" => %{"disabled" => true},
+                    "Ticket_Queue_List" => %{"disabled" => true},
+                    "Ticket_Unlink" => %{"disabled" => true},
+                    "Ticket_UnlinkEntity" => %{"disabled" => true},
+                    "Ticket_Update" => %{"disabled" => true},
+                    "Ticket_Watch" => %{"disabled" => true}
+                  }
+                }
+              }
+            }
+     stacktrace:
+       test/noizu_prompt_lingua/mcp/url_toolset_param_test.exs:188: (test)
+
+.................................................................................................................
+Finished in 3.4 seconds (0.4s async, 2.9s sync)
+
+Result: 123/124 passed
+Failed: 1 test

--- a/backend/lib/noizu_prompt_lingua/mcp/custom.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/custom.ex
@@ -39,9 +39,14 @@ defmodule NoizuPromptLingua.MCP.Custom do
   def custom_specs(ctx) do
     with slug when is_binary(slug) <- scope_slug(ctx),
          scope when not is_nil(scope) <- MCPCustomScopes.get_by_slug(slug) do
-      # Effective state for the scope layer (client layer is applied later by
-      # MCP.Server.list_tools via KeyToolsets/EffectiveToolset with the ctx).
-      states = EffectiveToolset.resolve(scope, nil, nil)
+      # Effective state for the scope layer merged with the `?t=` URL
+      # tool-selection layer (alacarte) — PARAM ONLY: the stored client layer
+      # stays out of catalog_specs per contract (key-disabled tools remain
+      # catalog-visible; ToolGuard denies at call time). Required here (not
+      # just in the server pipeline): group_specs/3 pre-drops disabled specs,
+      # so a white-list re-enable must already be reflected in these states or
+      # the tool vanishes from BOTH listing and dispatch.
+      states = EffectiveToolset.resolve(scope, EffectiveToolset.param_only_client(ctx), nil)
 
       scope.config
       |> MCPCustomScopes.normalize_config(scope.kind)

--- a/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/effective_toolset.ex
@@ -417,8 +417,10 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
   DB reads); ACL resolves once for the scope verdict + once per tool deny.
   """
   def apply_to_specs(specs, ctx, group_id \\ nil) when is_list(specs) do
-    client = client_for_ctx(ctx)
     scope = scope_from_ctx(ctx)
+    # The `?t=` param layer (when present) merges into the client layer here —
+    # the listing seam of the alacarte URL tool selection.
+    client = client_with_param(ctx, scope)
     user_ref = user_for_ctx(ctx)
 
     if client == nil and scope == nil do
@@ -463,6 +465,74 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolset do
     do: spec.definition && spec.definition.meta && spec.definition.meta["category"]
 
   # ── ctx plumbing ───────────────────────────────────────────────────────────
+
+  @doc """
+  The calling client WITH the URL tool-selection layer (`?t=` alacarte param)
+  merged in. The compiled param layer rides the session assigns
+  (`:toolset_param_cfg` — snapshotted at initialize by the gateway's
+  `mcp_context/1`) and is UNION-merged into the stored client config
+  (`merge_additive/2` — never `overlay/2`, which would drop white-list entries
+  for tools the stored config doesn't mention). `scope` bounds the param: with
+  no scope the param is dropped, so it can never widen a root/unscoped
+  universe. Returns the plain client when there is no param layer.
+  """
+  def client_with_param(ctx, nil), do: client_for_ctx(ctx)
+
+  def client_with_param(ctx, _scope) do
+    client = client_for_ctx(ctx)
+
+    case param_layer(ctx) do
+      nil -> client
+      layer -> merge_param(client, layer)
+    end
+  end
+
+  @doc """
+  The URL tool-selection layer ALONE as a client (`?t=` alacarte param), or nil
+  when the session carries no param. Used where the stored client layer must
+  stay OUT per the catalog contract — `MCP.Custom.catalog_specs/1` pre-drops
+  disabled specs, and key-disabled tools must remain catalog-visible so
+  ToolGuard denies them with a precise reason instead of "Unknown tool" — while
+  the param layer MUST reach that pre-drop (a white-list re-enable that missed
+  it would vanish from both listing and dispatch).
+  """
+  def param_only_client(ctx) do
+    case param_layer(ctx) do
+      nil -> nil
+      layer -> %{id: :url_toolset_param, kind: :url_param, toolset_config: layer}
+    end
+  end
+
+  defp param_layer(ctx) do
+    assigns = get_in(ctx, [Access.key(:assigns, %{})]) || %{}
+    assigns[:toolset_param_cfg] || assigns["toolset_param_cfg"]
+  end
+
+  defp merge_param(nil, layer),
+    do: %{id: :url_toolset_param, kind: :url_param, toolset_config: layer}
+
+  defp merge_param(client, layer),
+    do: %{client | toolset_config: merge_additive(client.toolset_config, layer)}
+
+  # UNION-merge the param layer INTO the stored client config: groups and tool
+  # maps merge additively (the param layer may name tools the stored config
+  # never mentions — a white-list entry for an absent tool must survive the
+  # merge), with the param layer winning per key.
+  defp merge_additive(base, layer) when is_map(base) do
+    base_groups = Map.get(normalize_config(base), "groups") || %{}
+    layer_groups = Map.get(normalize_config(layer), "groups") || %{}
+
+    merged =
+      Map.merge(base_groups, layer_groups, fn _gid, base_group, layer_group ->
+        Map.merge(base_group, layer_group, fn _tool, base_tool, layer_tool ->
+          Map.merge(base_tool, layer_tool)
+        end)
+      end)
+
+    Map.put(base, "groups", merged)
+  end
+
+  defp merge_additive(_base, layer), do: layer
 
   @doc """
   The calling client resolved from `ctx.assigns.auth_claims`, cached via

--- a/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/key_toolsets.ex
@@ -59,12 +59,16 @@ defmodule NoizuPromptLingua.MCP.KeyToolsets do
       directly unless also disabled.
   """
   def state(group_id, tool_name, ctx) when is_binary(group_id) and is_binary(tool_name) do
+    scope = EffectiveToolset.scope_from_ctx(ctx)
+
     ts =
       EffectiveToolset.state(
         group_id,
         tool_name,
-        EffectiveToolset.scope_from_ctx(ctx),
-        EffectiveToolset.client_for_ctx(ctx),
+        scope,
+        # The `?t=` param layer (when present) merges into the client layer —
+        # the execution seam of the alacarte URL tool selection (ToolGuard).
+        EffectiveToolset.client_with_param(ctx, scope),
         EffectiveToolset.user_for_ctx(ctx),
         DateTime.utc_now()
       )

--- a/backend/lib/noizu_prompt_lingua/mcp/url_toolset_param.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/url_toolset_param.ex
@@ -1,0 +1,477 @@
+defmodule NoizuPromptLingua.MCP.UrlToolsetParam do
+  @moduledoc """
+  The `?t=` URL tool-selection parameter for custom-scope MCP gateways
+  (alacarte): base64url(JSON) decoded once at MCP initialize and compiled into
+  a synthesized toolset layer that is merged into the CLIENT layer of the
+  `EffectiveToolset` cascade (`[client(+param), scope]`) — param wins per key.
+
+  The param NEVER changes the include set — the scope's groups govern which
+  tools exist (entries outside that universe are dead) — it only flips per-tool
+  flags within it. The ACL pass still runs last and cannot be bypassed.
+
+  ## Parameter shape (strict)
+
+      {
+        "white-list": {"Tool_Name": true | false | {"visible": bool}},
+        "black-list": {"Tool_Name": true | false | {"visible": bool}},
+        "tools":      {"Tool_Name": true | false | {"visible": bool}},
+        "default":    true | "basic_crud" | "core" | "full"
+      }
+
+  All keys optional; unknown top-level keys are REJECTED (fail-closed). The
+  `white-list`/`black-list` sections also accept snake_case spellings
+  (`white_list`/`black_list`) — normalized to kebab-case BEFORE validation
+  (snake_case is the JSON convention most generators emit; kebab-case stays
+  canonical). Presenting BOTH spellings of a section is ambiguous and rejected.
+
+  ## Precedence (compile)
+
+    1. `white-list` + `default` define the ENABLE SET — every universe tool
+       absent from the set is stamped `disabled: true`; tools IN the set are
+       stamped `disabled: false` (so a white-list re-enables a scope-disabled
+       tool). A white-list pick also stamps `hidden: false` — the selection is
+       what tools/list shows (statically-hidden flags are overridden) — while
+       default-expansion members keep their current visibility. Empty/absent
+       white-list with a `default` present still constrains.
+    2. `black-list` disables — and loses entirely to a white-list (when one is
+       present, set membership already decided).
+    3. `white-list` entry `visible` flags (`{"visible": false}` = enabled but
+       hidden from listings).
+    4. `tools` map, lowest: `visible: true` re-enables a stored-disabled tool
+       (stamps `disabled: false` + `hidden: false`) ONLY when no white-list /
+       default constrains the enable set — it can never smuggle a tool into a
+       constrained set. `visible: false` always hides.
+
+  `default` expands the enable set: `true` = the endpoint's stored-enabled
+  tools; a preset slug = that preset's tool set
+  (`MCPCustomScopes.preset_tool_sets/1`); unknown preset = error. With a
+  white-list also present, the expansions UNION.
+
+  Universe: the scope's included (non-group-disabled) groups' live catalog
+  tools, Discovery excluded, canonical underscore names. Entries outside the
+  universe are dead.
+
+  Registration-level visibility is out of the param's reach: a tool registered
+  `hidden: true` (e.g. Session_List, Session_Archive) is kept off listings by
+  the no-op default-state contract, the same way no client `toolset_config` can
+  un-hide it today. A white-listed such tool is ENABLED (dispatchable) but not
+  listed; the admin un-hides it at the scope/registration level instead.
+
+  ## Errors (fail-closed)
+
+  Absent param (`nil`/empty) = byte-identical current behavior (`:absent`).
+  Everything else that does not cleanly decode → `{:error, reason}` for the
+  gateway's HTTP 400 BEFORE the transport session starts: >12_000 raw chars,
+  non-base64url charset, bad base64, >8_192 decoded bytes, non-JSON,
+  schema-invalid shape, unknown preset.
+  """
+
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.MCP.ToolNames
+
+  @max_raw_chars 12_000
+  @max_decoded_bytes 8_192
+  @charset ~r/^[A-Za-z0-9_-]*={0,2}$/
+  @allowed_top_keys ~w(white-list black-list tools default)
+  # snake_case spellings normalize to their kebab-case canonical keys BEFORE
+  # shape validation; presenting both spellings of a section is rejected.
+  @section_aliases %{"white_list" => "white-list", "black_list" => "black-list"}
+
+  @type spec :: %{optional(String.t()) => term()}
+
+  @type error ::
+          :too_large
+          | :invalid_charset
+          | :invalid_base64
+          | :invalid_json
+          | :too_large_decoded
+          | {:invalid_shape, String.t()}
+          | {:unknown_preset, String.t()}
+
+  @doc """
+  Decode the raw `?t=` query parameter. `:absent` (nil/empty) means "no
+  parameter" — byte-identical behavior. Structural failures return
+  `{:error, reason}`; semantic checks (preset names) happen in `compile/2`.
+  """
+  @spec decode(term()) :: :absent | {:ok, spec()} | {:error, error()}
+  def decode(nil), do: :absent
+  def decode(""), do: :absent
+
+  def decode(param) when is_binary(param) do
+    cond do
+      String.length(param) > @max_raw_chars ->
+        {:error, :too_large}
+
+      not Regex.match?(@charset, param) ->
+        {:error, :invalid_charset}
+
+      true ->
+        with {:ok, json} <- url_decode(param),
+             :ok <- decoded_size_guard(json),
+             {:ok, body} <- json_decode(json),
+             {:ok, body} <- normalize_aliases(body) do
+          validate_shape(body)
+        end
+    end
+  end
+
+  def decode(_), do: {:error, {:invalid_shape, "parameter must be a string"}}
+
+  # base64url without padding is the wire form; padded input (the `={0,2}`
+  # charset allowance) re-pads through the padded decoder.
+  defp url_decode(param) do
+    case Base.url_decode64(param, padding: false) do
+      {:ok, json} ->
+        {:ok, json}
+
+      :error ->
+        case Base.url_decode64(param, padding: true) do
+          {:ok, json} -> {:ok, json}
+          :error -> {:error, :invalid_base64}
+        end
+    end
+  end
+
+  defp decoded_size_guard(json) when byte_size(json) <= @max_decoded_bytes, do: :ok
+  defp decoded_size_guard(_), do: {:error, :too_large_decoded}
+
+  defp json_decode(json) do
+    case Jason.decode(json) do
+      {:ok, %{} = body} -> {:ok, body}
+      {:ok, _} -> {:error, {:invalid_shape, "must be a JSON object"}}
+      {:error, _} -> {:error, :invalid_json}
+    end
+  end
+
+  # AMENDMENT: `white_list`/`black_list` aliases fold into their kebab-case
+  # canonical keys before shape validation, so both spellings decode to the
+  # SAME spec (golden-vector tested). Both spellings at once is ambiguous —
+  # fail closed rather than pick a winner by merge order.
+  defp normalize_aliases(body) do
+    conflicts =
+      for {alias, canonical} <- @section_aliases,
+          Map.has_key?(body, alias) and Map.has_key?(body, canonical) do
+        {alias, canonical}
+      end
+
+    case conflicts do
+      [] ->
+        {:ok, Map.new(body, fn {key, value} -> {Map.get(@section_aliases, key, key), value} end)}
+
+      [{alias, canonical} | _] ->
+        {:error,
+         {:invalid_shape, "ambiguous key: both \"#{alias}\" and \"#{canonical}\" present"}}
+    end
+  end
+
+  # Strict shape: only the four known top-level keys; list/tools entries must
+  # be booleans or `{"visible": bool}`; default must be true or a preset slug.
+  defp validate_shape(%{} = spec) do
+    unknown = Map.keys(spec) -- @allowed_top_keys
+
+    if unknown == [] do
+      validate_sections(spec)
+    else
+      {:error, {:invalid_shape, "unknown key(s): #{unknown |> Enum.sort() |> Enum.join(", ")}"}}
+    end
+  end
+
+  defp validate_sections(spec) do
+    with :ok <- validate_map_section(spec, "white-list"),
+         :ok <- validate_map_section(spec, "black-list"),
+         :ok <- validate_map_section(spec, "tools"),
+         :ok <- validate_default(spec) do
+      {:ok, spec}
+    end
+  end
+
+  defp validate_map_section(spec, key) do
+    case Map.get(spec, key) do
+      nil ->
+        :ok
+
+      entries when is_map(entries) ->
+        bad? =
+          Enum.any?(entries, fn {name, entry} ->
+            not is_binary(name) or name == "" or not valid_entry?(entry)
+          end)
+
+        if bad? do
+          {:error,
+           {:invalid_shape, "#{key} entries must be true, false, or {\"visible\": boolean}"}}
+        else
+          :ok
+        end
+
+      _ ->
+        {:error, {:invalid_shape, "#{key} must be an object"}}
+    end
+  end
+
+  defp valid_entry?(entry) when is_boolean(entry), do: true
+
+  defp valid_entry?(%{} = entry) do
+    case Map.to_list(entry) do
+      [] -> true
+      [{"visible", visible}] when is_boolean(visible) -> true
+      _ -> false
+    end
+  end
+
+  defp valid_entry?(_), do: false
+
+  defp validate_default(spec) do
+    case Map.get(spec, "default") do
+      nil -> :ok
+      true -> :ok
+      slug when is_binary(slug) and slug != "" -> :ok
+      _ -> {:error, {:invalid_shape, "default must be true or a preset name"}}
+    end
+  end
+
+  @doc """
+  Compile a decoded spec into the synthesized toolset layer — the same
+  `%{"groups" => %{gid => %{"tools" => %{tool => flags}}}}` shape as a stored
+  config — bounded by `scope`'s included groups. `{:error, {:unknown_preset,
+  slug}}` for an unknown `default` preset.
+  """
+  @spec compile(spec(), NoizuPromptLingua.Schema.MCPCustomScope.t() | map() | nil) ::
+          {:ok, map()} | {:error, error()}
+  def compile(spec, scope) when is_map(spec) do
+    # Idempotent second pass: decode already normalized (and validated) the
+    # spec, but compile is also callable directly — spelling-agnostic there too.
+    with {:ok, spec} <- normalize_aliases(spec),
+         {:ok, expansion} <- resolve_default(Map.get(spec, "default"), scope) do
+      {:ok, layer(spec, scope, expansion)}
+    end
+  end
+
+  defp resolve_default(nil, _scope), do: {:ok, nil}
+  defp resolve_default(true, scope), do: {:ok, {:stored, scope}}
+
+  defp resolve_default(slug, _scope) when is_binary(slug) do
+    case MCPCustomScopes.preset_tool_sets(slug) do
+      {:ok, sets} -> {:ok, {:preset, sets}}
+      _ -> {:error, {:unknown_preset, slug}}
+    end
+  end
+
+  defp resolve_default(_, _scope), do: {:error, {:invalid_shape, "invalid default"}}
+
+  # ── layer assembly (the precedence algorithm) ───────────────────────────────
+
+  defp layer(spec, scope, expansion) do
+    {_groups, universe, stored_enabled} = compile_context(scope)
+
+    # F5: param tool names accept the dotted alias form — normalize to the
+    # canonical underscore form used by the universe (later duplicate keys win).
+    white = canonical_section(map_section(spec, "white-list"))
+    black = canonical_section(map_section(spec, "black-list"))
+    tools = canonical_section(map_section(spec, "tools"))
+
+    white? = Map.has_key?(spec, "white-list")
+    constrained? = white? or Map.has_key?(spec, "default")
+
+    white_set = if white?, do: white_enabled(white, universe), else: MapSet.new()
+    default_set = default_expansion(expansion, universe, stored_enabled)
+
+    layer_groups =
+      Map.new(universe, fn {gid, names} ->
+        entries =
+          Map.new(names, fn name ->
+            # (1) enable-set opinion. A white-list pick implies VISIBILITY — the
+            # selection is what tools/list shows (statically-hidden flags are
+            # overridden) — while a default-expansion member keeps its current
+            # visibility. Absent-from-set → disabled.
+            flags =
+              cond do
+                not constrained? ->
+                  %{}
+
+                MapSet.member?(white_set, name) ->
+                  %{"disabled" => false, "hidden" => false}
+
+                MapSet.member?(default_set, name) ->
+                  %{"disabled" => false}
+
+                true ->
+                  %{"disabled" => true}
+              end
+
+            flags =
+              flags
+              # (2) black-list — loses entirely when a white-list is present.
+              |> apply_black_list(black, white?, name)
+              # (3) white-list entry visible flags.
+              |> apply_white_visible(white, name)
+              # (4) tools map, lowest.
+              |> apply_tools_visible(tools, constrained?, name)
+
+            {name, flags}
+          end)
+
+        {gid, %{"tools" => entries}}
+      end)
+
+    %{"groups" => layer_groups}
+  end
+
+  defp default_expansion(expansion, universe, stored_enabled) do
+    case expansion do
+      {:stored, _scope} -> stored_enabled
+      # presets expand to a FLAT enabled-name set over all their groups —
+      # bounded by the universe by intersection
+      {:preset, sets} -> MapSet.intersection(sets, universe_names(universe))
+      _ -> MapSet.new()
+    end
+  end
+
+  defp universe_names(universe),
+    do: universe |> Enum.flat_map(fn {_gid, names} -> names end) |> MapSet.new()
+
+  defp map_section(spec, key) do
+    case Map.get(spec, key) do
+      entries when is_map(entries) -> entries
+      _ -> %{}
+    end
+  end
+
+  defp canonical_section(entries),
+    do: Map.new(entries, fn {name, entry} -> {ToolNames.canonical(name), entry} end)
+
+  # (2) black-list — loses entirely when a white-list is present.
+  defp apply_black_list(flags, black, false, name) do
+    if Map.get(black, name) == true, do: Map.put(flags, "disabled", true), else: flags
+  end
+
+  defp apply_black_list(flags, _black, true, _name), do: flags
+
+  # (3) white-list entry visible flags — only `{"visible": bool}` carries one.
+  defp apply_white_visible(flags, white, name) do
+    case Map.get(white, name) do
+      %{"visible" => visible} when is_boolean(visible) ->
+        Map.put(flags, "hidden", not visible)
+
+      _ ->
+        flags
+    end
+  end
+
+  # (4) tools map, lowest — visible re-enables stored-disabled ONLY when no
+  # enable-set constraint exists; visible:false always hides.
+  defp apply_tools_visible(flags, tools, constrained?, name) do
+    case entry_visible(Map.get(tools, name)) do
+      nil ->
+        flags
+
+      true when constrained? ->
+        # a constrained enable set cannot be re-entered via the tools map
+        flags
+
+      true ->
+        flags |> Map.put("disabled", false) |> Map.put("hidden", false)
+
+      false ->
+        Map.put(flags, "hidden", true)
+    end
+  end
+
+  # tools-map entries: `true` ≡ {"visible": true}; `false` ≡ {"visible": false}.
+  defp entry_visible(true), do: true
+  defp entry_visible(false), do: false
+  defp entry_visible(%{"visible" => visible}) when is_boolean(visible), do: visible
+  defp entry_visible(_), do: nil
+
+  # white-list entries: everything EXCEPT an explicit `false` is in the set
+  # (`true` and `{"visible": ...}` both enable; `visible: false` is
+  # enabled-but-hidden).
+  defp white_enabled(white, universe) do
+    universe
+    |> Enum.flat_map(fn {_gid, names} -> names end)
+    |> Enum.filter(&(Map.get(white, &1) != nil and Map.get(white, &1) != false))
+    |> MapSet.new()
+  end
+
+  # ── universe (bounded-by-groups is automatic) ────────────────────────────────
+
+  # Returns {normalized groups, universe (%{gid => [canonical tool names]}),
+  # stored-enabled set (universe tools whose stored entry is not disabled)}.
+  # The param never widens this — group-disabled groups contribute nothing.
+  defp compile_context(scope) do
+    {config, kind} = {scope_config_of(scope), scope_kind(scope)}
+
+    groups =
+      try do
+        # scope_config_of/1 already guarantees a map (non-maps folded to %{}).
+        MCPCustomScopes.normalize_config(config, kind)
+        |> Map.get("groups") || %{}
+      rescue
+        _ -> %{}
+      end
+
+    universe =
+      Map.new(groups, fn {gid, gcfg} ->
+        names =
+          case gcfg do
+            %{"disabled" => true} -> []
+            _ -> group_catalog(gid)
+          end
+
+        {gid, names}
+      end)
+
+    {groups, universe, stored_enabled(groups, universe)}
+  end
+
+  defp scope_config_of(scope) do
+    case scope do
+      %{config: config} -> if(is_map(config), do: config, else: %{})
+      %{"config" => config} -> if(is_map(config), do: config, else: %{})
+      _ -> %{}
+    end
+  end
+
+  defp scope_kind(scope) do
+    case scope do
+      %{kind: kind} when is_binary(kind) -> kind
+      %{"kind" => kind} when is_binary(kind) -> kind
+      _ -> "custom"
+    end
+  end
+
+  defp stored_enabled(groups, universe) do
+    universe
+    |> Enum.flat_map(fn {gid, names} ->
+      tools = get_in(groups, [gid, "tools"]) || %{}
+
+      Enum.filter(names, fn name ->
+        entry = Map.get(tools, name) || Map.get(tools, ToolNames.dotted(name)) || %{}
+        Map.get(entry, "disabled") != true
+      end)
+    end)
+    |> MapSet.new()
+  end
+
+  defp group_catalog(gid) do
+    case MCPServers.server_module(gid) do
+      module when is_atom(module) and not is_nil(module) ->
+        if Code.ensure_loaded?(module) and function_exported?(module, :__mcp__, 1) do
+          module.__mcp__(:tools)
+          |> Noizu.MCP.Server.Features.Tools.expand()
+          |> Enum.reject(&discovery_spec?/1)
+          |> Enum.map(&ToolNames.canonical(&1.definition.name))
+          |> Enum.uniq()
+        else
+          []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp discovery_spec?(spec) do
+    ((spec.definition.meta && spec.definition.meta["category"]) || "Uncategorized") == "Discovery"
+  end
+end

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -38,6 +38,21 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   # intentionally omitted here (see report follow-ups).
   @core_variant_groups ~w(sessions projects organizations)
 
+  # Restricted-core policy (alacarte): the tools a `core_variant` package keeps
+  # ENABLED per group (canonical underscore names). Everything else in the
+  # group's live catalog is seeded/healed `disabled: true`. Session_Manifest is
+  # exempt — it is the client's own state report and stays enabled everywhere
+  # (W5 contract).
+  @core_variant_policy %{
+    "organizations" => ~w(Organization_Overview Organization_Get),
+    "projects" => ~w(Project_Overview Project_Get),
+    "sessions" => ~w(Session_Create Session_Overview)
+  }
+
+  # Every selectable group id (21 today) — the "full" preset's surface. Derived
+  # from the live catalog so the preset tracks `MCPServers.@servers` drift.
+  @full_preset_groups Enum.map(MCPServers.customizable(), & &1.id)
+
   # W2 scope sharing. Canonical storage is the config jsonb key `"visibility"`;
   # the schema surfaces it via `MCPCustomScope.visibility/1` (virtual field).
   @visibilities ~w(org account shared)
@@ -47,6 +62,10 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   # only `<Entity>_Overview` + `<Entity>_(Create|Get|List|Update|Delete)` stay
   # enabled — everything else in the group is seeded disabled. Groups without a
   # `:crud_entity` keep current behavior (all tools enabled).
+  # `:tools` presets ("core"/"full", alacarte) carry an explicit ALLOW-MAP of
+  # enabled tools per group (`:all` = every catalog tool); everything else in
+  # the group is seeded disabled. Shared expansion for the URL tool-selection
+  # param lives in `preset_tool_sets/1`.
   @presets %{
     "basic_crud" => %{
       name: "Basic CRUD",
@@ -58,6 +77,18 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
         "projects" => "Project",
         "tickets" => "Ticket"
       }
+    },
+    "core" => %{
+      name: "Core",
+      description: "Core variant — essential sessions, projects & organizations tools only.",
+      groups: @core_variant_groups,
+      tools: @core_variant_policy
+    },
+    "full" => %{
+      name: "Full",
+      description: "Every customizable group with every tool enabled.",
+      groups: @full_preset_groups,
+      tools: Map.new(@full_preset_groups, fn id -> {id, :all} end)
     }
   }
 
@@ -110,9 +141,10 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
 
   @doc """
   Config seed for a named preset, or `nil` when unknown. For CRUD-preset groups
-  the seed disables every non-CRUD tool (keys follow the live catalog's emitted
-  tool-name form, so downstream disabled lookups match whatever the server
-  currently emits); unknown groups seed plain group configs.
+  and `:tools` allow-map presets the seed disables every tool outside the
+  preset's enabled set (keys follow the live catalog's emitted tool-name form,
+  so downstream disabled lookups match whatever the server currently emits);
+  unknown groups seed plain group configs.
   """
   def preset_config(slug) when is_binary(slug) do
     case Map.fetch(@presets, slug) do
@@ -121,10 +153,11 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
 
       {:ok, preset} ->
         crud = Map.get(preset, :crud_entity) || %{}
+        allow = Map.get(preset, :tools)
 
         groups =
           Map.new(preset.groups, fn id ->
-            {id, %{"tools" => preset_tools_config(id, crud)}}
+            {id, %{"tools" => preset_tools_config(id, crud, allow)}}
           end)
 
         %{"groups" => groups}
@@ -133,7 +166,106 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
 
   def preset_config(_), do: nil
 
-  defp preset_tools_config(group_id, crud) do
+  @doc """
+  Enabled tool names for a named preset — `{:ok, MapSet.t(String.t())}` of
+  canonical underscore names across every group the preset covers, or
+  `:unknown_preset`. The shared expansion used by config seeding
+  (`preset_config/1`) and the `NoizuPromptLingua.MCP.UrlToolsetParam`
+  white-list compile. The always-on `Session_Manifest` is included wherever
+  the sessions catalog exposes it; Discovery tools are excluded (same
+  rejection as the toolset layer's include set).
+  """
+  @spec preset_tool_sets(String.t()) :: {:ok, MapSet.t(String.t())} | :unknown_preset
+  def preset_tool_sets(slug) when is_binary(slug) do
+    case Map.fetch(@presets, slug) do
+      :error ->
+        :unknown_preset
+
+      {:ok, preset} ->
+        allow = Map.get(preset, :tools)
+        crud = Map.get(preset, :crud_entity) || %{}
+
+        tools =
+          Enum.flat_map(preset.groups, fn group_id ->
+            cond do
+              essential = allow && Map.get(allow, group_id) ->
+                names =
+                  catalog_tool_names(group_id)
+                  |> Enum.filter(&(&1 == @manifest_tool or essential == :all or &1 in essential))
+
+                if group_id == "sessions" and @manifest_tool not in names do
+                  names ++ [@manifest_tool]
+                else
+                  names
+                end
+
+              entity = Map.get(crud, group_id) ->
+                catalog_tool_names(group_id)
+                |> Enum.filter(&(basic_crud_tool?(entity, &1) or &1 == @manifest_tool))
+
+              true ->
+                catalog_tool_names(group_id)
+            end
+          end)
+
+        {:ok, MapSet.new(tools)}
+    end
+  end
+
+  def preset_tool_sets(_), do: :unknown_preset
+
+  # Live catalog tool names for a group, canonical underscore form, Discovery
+  # excluded (same rejection as the toolset layer's include set).
+  defp catalog_tool_names(group_id) do
+    case MCPServers.server_module(group_id) do
+      module when is_atom(module) and not is_nil(module) ->
+        module.__mcp__(:tools)
+        |> Noizu.MCP.Server.Features.Tools.expand()
+        |> Enum.reject(&discovery_spec?/1)
+        |> Enum.map(&NoizuPromptLingua.MCP.ToolNames.canonical(&1.definition.name))
+        |> Enum.uniq()
+
+      _ ->
+        []
+    end
+  end
+
+  # Allow-map presets ("core"/"full"): the map lists the enabled tools per group
+  # (`:all` = everything); every other catalog tool is stamped disabled.
+  # Session_Manifest is exempt (kept enabled, explicit entry in sessions).
+  # Stamp keys are canonical (the allow-map constants are canonical).
+  defp preset_tools_config(group_id, _crud, allow) when is_map(allow) do
+    case Map.get(allow, group_id) do
+      nil ->
+        %{}
+
+      essential ->
+        group_id
+        |> MCPServers.server_module()
+        |> case do
+          nil ->
+            %{}
+
+          module ->
+            module.__mcp__(:tools)
+            |> Noizu.MCP.Server.Features.Tools.expand()
+            |> Enum.reject(&discovery_spec?/1)
+            |> Enum.flat_map(fn spec ->
+              name = NoizuPromptLingua.MCP.ToolNames.canonical(spec.definition.name)
+
+              if name == @manifest_tool or essential == :all or name in essential,
+                do: [],
+                else: [{name, %{"disabled" => true}}]
+            end)
+            |> Map.new()
+            |> then(fn tools ->
+              if group_id == "sessions", do: Map.put_new(tools, @manifest_tool, %{}), else: tools
+            end)
+        end
+    end
+  end
+
+  defp preset_tools_config(group_id, crud, _allow) do
     case Map.fetch(crud, group_id) do
       :error ->
         %{}
@@ -618,8 +750,10 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
         Map.get(attrs, "source_template_slug") || source.source_template_slug || source.slug,
       # PRD-020 FR-4: explicit caller-supplied config (wizard path, US-111)
       # replaces the source groups wholesale; absent config keeps today's
-      # byte-identical groups_from(source) carry-over.
-      "config" => Map.get(attrs, "config") || %{"groups" => groups_from(source)}
+      # byte-identical groups_from(source) carry-over — plus the source's
+      # display identity (alacarte WP4; visibility/segment stay per-clone
+      # decisions).
+      "config" => Map.get(attrs, "config") || inherited_config(source)
     })
   end
 
@@ -675,6 +809,23 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
 
   defp groups_from(_), do: Map.new(@default_package_groups, fn id -> {id, group_seed(id)} end)
 
+  # Clone-time config carry-over: the source's groups plus its display
+  # identity (sanitized — an invalid display never blocks a clone).
+  defp inherited_config(source) do
+    config = %{"groups" => groups_from(source)}
+
+    case source && source.config && get_key(source.config, "display") do
+      nil ->
+        config
+
+      display ->
+        case sanitize_display(display) do
+          display when display != %{} -> Map.put(config, "display", display)
+          _ -> config
+        end
+    end
+  end
+
   # Additive-only: the sessions group always carries the (unrestricted)
   # manifest tool entry. An explicit owner override for `Session_Manifest`
   # (disabled/hidden) is already present in the tools map and never clobbered.
@@ -718,11 +869,15 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   @doc """
   Get-or-create the default `"core"` core-variant scope (global/org-less). Idempotent.
   Included in `core+custom` packaging output.
+
+  The seed is RESTRICTED: a catalog walk stamps `disabled: true` on every tool
+  outside `@core_variant_policy` (Session_Manifest exempt). An existing global
+  row is repaired in place via `heal_core_variant/1`.
   """
   def get_core_variant(_opts \\ []) do
     case get_by_slug(@core_variant_slug) do
       nil ->
-        groups = Map.new(@core_variant_groups, fn id -> {id, group_seed(id)} end)
+        groups = Map.new(@core_variant_groups, fn id -> {id, core_variant_group_seed(id)} end)
 
         attrs = %{
           "slug" => @core_variant_slug,
@@ -739,7 +894,104 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
         end
 
       scope ->
-        scope
+        heal_core_variant(scope)
+    end
+  end
+
+  @doc "The restricted-core enable policy (`%{group_id => canonical tool names}`)."
+  def core_variant_policy, do: @core_variant_policy
+
+  # Fresh group config for a core-variant group: every catalog tool NOT in the
+  # restricted policy (and not the exempt manifest) is seeded disabled.
+  defp core_variant_group_seed(group_id) do
+    essential = Map.get(@core_variant_policy, group_id, [])
+
+    tools =
+      catalog_tool_names(group_id)
+      |> Map.new(fn name ->
+        if name == @manifest_tool or name in essential,
+          do: {name, %{}},
+          else: {name, %{"disabled" => true}}
+      end)
+
+    tools = if group_id == "sessions", do: Map.put_new(tools, @manifest_tool, %{}), else: tools
+    %{"tools" => tools}
+  end
+
+  # Repair drift on the stored global `core` row (mirror of
+  # `heal_default_package/1`): union-merge any missing core-variant groups
+  # (seeded restricted), stamp the restricted policy's `disabled: true` on
+  # non-essential tools, and CLEAR stray disables on essential tools (and the
+  # always-on `Session_Manifest`). Policy-only — never removes a group and
+  # leaves group-level flags (a deliberate group disable) alone. User clones of
+  # core keep their frozen configs — this heals the global template row ONLY.
+  # Idempotent; persists only when something actually changed, and on update
+  # failure the healed config is still returned so the caller sees the intended
+  # tool set.
+  def heal_core_variant(%MCPCustomScope{} = scope) do
+    groups = normalize_groups(scope.config || %{})
+
+    healed =
+      Enum.reduce(@core_variant_groups, groups, fn id, acc ->
+        case Map.get(acc, id) do
+          nil -> Map.put(acc, id, core_variant_group_seed(id))
+          gc -> Map.put(acc, id, heal_core_variant_group(id, gc))
+        end
+      end)
+
+    if healed == groups do
+      scope
+    else
+      config = Map.put(scope.config || %{}, "groups", healed)
+
+      case update(scope, %{"config" => config}) do
+        {:ok, updated} -> updated
+        _ -> %{scope | config: config}
+      end
+    end
+  end
+
+  defp heal_core_variant_group(group_id, gc) do
+    essential = Map.get(@core_variant_policy, group_id, [])
+    tools = Map.get(gc, "tools") || %{}
+
+    healed =
+      catalog_tool_names(group_id)
+      |> Enum.reduce(tools, fn name, acc ->
+        heal_core_tool(acc, name, name in essential or name == @manifest_tool)
+      end)
+
+    healed =
+      if group_id == "sessions", do: Map.put_new(healed, @manifest_tool, %{}), else: healed
+
+    Map.put(gc, "tools", healed)
+  end
+
+  # Stamp the policy disable on a non-essential tool; clear a stray disable on
+  # an essential one. Writes canonical keys; a legacy dotted key (if present) is
+  # repaired in place; other flags on the entry are preserved.
+  defp heal_core_tool(tools, name, essential?) do
+    dotted = NoizuPromptLingua.MCP.ToolNames.dotted(name)
+
+    {key, entry} =
+      cond do
+        Map.has_key?(tools, name) -> {name, Map.get(tools, name) || %{}}
+        dotted != name and Map.has_key?(tools, dotted) -> {dotted, Map.get(tools, dotted) || %{}}
+        true -> {name, %{}}
+      end
+
+    cond do
+      essential? and Map.get(entry, "disabled") == true ->
+        Map.put(tools, key, Map.delete(entry, "disabled"))
+
+      essential? ->
+        tools
+
+      Map.get(entry, "disabled") == true ->
+        tools
+
+      true ->
+        Map.put(tools, key, Map.put(entry, "disabled", true))
     end
   end
 
@@ -887,11 +1139,96 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   #     Carried verbatim (from the incoming config, falling back to `prior` so a
   #     group-only edit keeps the stored mode); invalid values are carried too so
   #     the schema's config validation rejects them rather than silently dropping.
+  #   * `display` — endpoint visual identity (alacarte): {image, emoji, color},
+  #     sanitized per field (non-conforming fields dropped); absent carries prior.
   defp put_reserved_keys(normalized, config, prior) do
+    config = sanitize_display_config(config)
+    prior = sanitize_display_config(prior)
+
     normalized
     |> maybe_put_reserved("segment", config, prior, &is_boolean/1)
     |> maybe_put_reserved("visibility", config, prior, fn _ -> true end)
+    |> maybe_put_reserved("display", config, prior, &valid_display?/1)
   end
+
+  # Sanitize the `display` reserved key in a config map before reservation:
+  # only {image, emoji, color} survive, each validated; a display that
+  # sanitizes to nothing is REMOVED, so the reservation falls back to prior
+  # (absent carries prior — an empty or fully-invalid display never clears a
+  # stored one).
+  defp sanitize_display_config(config) when is_map(config) do
+    case get_key(config, "display") do
+      nil ->
+        config
+
+      display ->
+        case sanitize_display(display) do
+          display when display != %{} -> Map.put(config, "display", display)
+          _ -> drop_display_key(config)
+        end
+    end
+  end
+
+  defp sanitize_display_config(config), do: config
+
+  defp drop_display_key(config) do
+    config
+    |> Enum.reject(fn {key, _} -> to_string(key) == "display" end)
+    |> Map.new()
+  end
+
+  # `image` = media short_id/URL ≤512 chars; `emoji` = ≤16 graphemes;
+  # `color` = hex3/6/8 or a CSS named color.
+  @display_hex ~r/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+  # CSS Color Module level-3/4 extended (148) named colors, lowercase.
+  @css_colors ~w(
+    aliceblue antiquewhite aqua aquamarine azure beige bisque black blanchedalmond blue
+    blueviolet brown burlywood cadetblue chartreuse chocolate coral cornflowerblue
+    cornsilk crimson cyan darkblue darkcyan darkgoldenrod darkgray darkgreen darkgrey
+    darkkhaki darkmagenta darkolivegreen darkorange darkorchid darkred darksalmon
+    darkseagreen darkslateblue darkslategray darkslategrey darkturquoise darkviolet
+    deeppink deepskyblue dimgray dimgrey dodgerblue firebrick floralwhite forestgreen
+    fuchsia gainsboro ghostwhite gold goldenrod gray green greenyellow grey honeydew
+    hotpink indianred indigo ivory khaki lavender lavenderblush lawngreen lemonchiffon
+    lightblue lightcoral lightcyan lightgoldenrodyellow lightgray lightgreen lightgrey
+    lightpink lightsalmon lightseagreen lightskyblue lightslategray lightslategrey
+    lightsteelblue lightyellow lime limegreen linen magenta maroon mediumaquamarine
+    mediumblue mediumorchid mediumpurple mediumseagreen mediumslateblue mediumspringgreen
+    mediumturquoise mediumvioletred midnightblue mintcream mistyrose moccasin navajowhite
+    navy oldlace olive olivedrab orange orangered orchid palegoldenrod palegreen
+    paleturquoise palevioletred papayawhip peachpuff peru pink plum powderblue purple
+    rebeccapurple red rosybrown royalblue saddlebrown salmon sandybrown seagreen seashell
+    sienna silver skyblue slateblue slategray slategrey snow springgreen steelblue tan
+    teal thistle tomato turquoise violet wheat white whitesmoke yellow yellowgreen
+  )
+
+  defp sanitize_display(display) when is_map(display) do
+    %{}
+    |> maybe_put_display("image", display, &(is_binary(&1) and String.length(&1) <= 512))
+    |> maybe_put_display("emoji", display, &(is_binary(&1) and String.length(&1) <= 16))
+    |> maybe_put_display("color", display, &valid_display_color?/1)
+  end
+
+  defp sanitize_display(_), do: nil
+
+  defp maybe_put_display(map, key, display, valid?) do
+    case get_key(display, key) do
+      value when is_binary(value) ->
+        if valid?.(value), do: Map.put(map, key, value), else: map
+
+      _ ->
+        map
+    end
+  end
+
+  defp valid_display_color?(value) when is_binary(value),
+    do: Regex.match?(@display_hex, value) or value in @css_colors
+
+  defp valid_display_color?(_), do: false
+
+  # display passes reservation only when something survived sanitization
+  defp valid_display?(display), do: is_map(display) and map_size(display) > 0
 
   defp maybe_put_reserved(map, key, config, prior, valid?) do
     value =

--- a/backend/lib/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_controller.ex
@@ -2,6 +2,7 @@ defmodule NoizuPromptLinguaWeb.CustomMCPGatewayController do
   use NoizuPromptLinguaWeb, :controller
 
   alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.MCP.UrlToolsetParam
   alias NoizuPromptLingua.Organizations
   alias NoizuPromptLingua.Repo
   alias NoizuPromptLingua.Schema.MCPCustomScope
@@ -212,36 +213,81 @@ defmodule NoizuPromptLinguaWeb.CustomMCPGatewayController do
   end
 
   defp serve(conn, scope, path, org_id) do
-    resource = "https://#{conn.host}#{path}"
+    # Alacarte: `?t=` (base64url JSON tool selection) is decoded + compiled
+    # BEFORE the transport plug — a bad parameter fails closed with a 400
+    # instead of opening a session. Initialize freezes the compiled layer into
+    # the session assigns (mcp_context/1): session snapshot semantics —
+    # changing `?t=` requires reconnect. The legacy 301 preserves the query.
+    case toolset_param(conn, scope) do
+      {:ok, param_cfg} ->
+        resource = "https://#{conn.host}#{path}"
 
-    # This endpoint audience-binds to its own URL, so its 401 challenge must
-    # advertise its own RFC 9728 document -- the root one declares
-    # `<host>/mcp`, and a client honouring that would come back with a token
-    # bound to the wrong resource.
-    opts =
-      NoizuPromptLinguaWeb.MCPConfig.plug_opts(
-        NoizuPromptLingua.MCP.Custom,
-        [expected_audience: resource],
-        resource_metadata:
-          NoizuPromptLinguaWeb.MCPConfig.resource_metadata_url_for_path(conn.host, path)
-      )
-      |> Keyword.put(:context, {__MODULE__, :mcp_context})
-      |> Noizu.MCP.Transport.StreamableHTTP.Plug.init()
+        # This endpoint audience-binds to its own URL, so its 401 challenge must
+        # advertise its own RFC 9728 document -- the root one declares
+        # `<host>/mcp`, and a client honouring that would come back with a token
+        # bound to the wrong resource.
+        opts =
+          NoizuPromptLinguaWeb.MCPConfig.plug_opts(
+            NoizuPromptLingua.MCP.Custom,
+            [expected_audience: resource],
+            resource_metadata:
+              NoizuPromptLinguaWeb.MCPConfig.resource_metadata_url_for_path(conn.host, path)
+          )
+          |> Keyword.put(:context, {__MODULE__, :mcp_context})
+          |> Noizu.MCP.Transport.StreamableHTTP.Plug.init()
 
-    conn
-    |> Plug.Conn.assign(:custom_scope_slug, scope.slug)
-    |> Plug.Conn.assign(:custom_scope_org_id, org_id)
-    |> Map.put(:path_info, [])
-    # Guarded mount (B4): malformed jsonrpc framing answers -32600 inline.
-    |> NoizuPromptLinguaWeb.MCP.TransportPlug.call(opts)
+        conn
+        |> Plug.Conn.assign(:custom_scope_slug, scope.slug)
+        |> Plug.Conn.assign(:custom_scope_org_id, org_id)
+        |> Plug.Conn.assign(:toolset_param_cfg, param_cfg)
+        |> Map.put(:path_info, [])
+        # Guarded mount (B4): malformed jsonrpc framing answers -32600 inline.
+        |> NoizuPromptLinguaWeb.MCP.TransportPlug.call(opts)
+
+      {:error, reason} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{"error" => "invalid tool selection parameter", "detail" => param_detail(reason)})
+    end
   end
 
+  defp toolset_param(conn, scope) do
+    case UrlToolsetParam.decode(raw_toolset_param(conn)) do
+      :absent ->
+        {:ok, nil}
+
+      {:ok, spec} ->
+        case UrlToolsetParam.compile(spec, scope) do
+          {:ok, layer} -> {:ok, layer}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp raw_toolset_param(conn) do
+    conn = Plug.Conn.fetch_query_params(conn)
+    Map.get(conn.query_params, "t")
+  end
+
+  defp param_detail({:invalid_shape, msg}) when is_binary(msg), do: msg
+  defp param_detail({:unknown_preset, slug}), do: "unknown preset: #{slug}"
+  defp param_detail(reason) when is_atom(reason), do: Atom.to_string(reason)
+
   def mcp_context(conn) do
-    base = %{custom_scope_slug: conn.assigns[:custom_scope_slug]}
+    base =
+      %{custom_scope_slug: conn.assigns[:custom_scope_slug]}
+      |> maybe_put_param_cfg(conn.assigns[:toolset_param_cfg])
 
     case conn.assigns[:custom_scope_org_id] do
       nil -> base
       org_id -> Map.put(base, :custom_scope_org_id, org_id)
     end
   end
+
+  # No-param requests keep a byte-identical ctx (the param layer is absent).
+  defp maybe_put_param_cfg(base, nil), do: base
+  defp maybe_put_param_cfg(base, cfg), do: Map.put(base, :toolset_param_cfg, cfg)
 end

--- a/backend/test/noizu_prompt_lingua/mcp/custom_scope_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/custom_scope_test.exs
@@ -125,4 +125,331 @@ defmodule NoizuPromptLingua.MCP.CustomScopeTest do
     assert "Session.Create" in lean_names
     assert Enum.find(tool_specs("lean"), &(&1.definition.name == "Session.Create")).hidden == true
   end
+
+  # ── alacarte WP1: `display` reserved config key ──────────────────────────────
+
+  describe "display reserved key" do
+    @valid_display %{"image" => "abc123shortid", "emoji" => "🚀", "color" => "#ff8800"}
+
+    test "a valid display persists through create" do
+      {:ok, scope} =
+        MCPCustomScopes.create(%{
+          "slug" => "display-1",
+          "name" => "Display",
+          "config" => %{"groups" => %{"sessions" => %{}}, "display" => @valid_display}
+        })
+
+      assert scope.config["display"] == @valid_display
+    end
+
+    test "hex3/hex8 and CSS named colors pass" do
+      for color <- ["#f80", "#ff8800", "#ff8800cc", "cornflowerblue", "rebeccapurple"] do
+        {:ok, scope} =
+          MCPCustomScopes.create(%{
+            "slug" => "display-#{System.unique_integer([:positive])}",
+            "name" => "Display",
+            "config" => %{"groups" => %{"sessions" => %{}}, "display" => %{"color" => color}}
+          })
+
+        assert scope.config["display"] == %{"color" => color}
+      end
+    end
+
+    test "non-conforming fields are dropped, conforming ones kept" do
+      {:ok, scope} =
+        MCPCustomScopes.create(%{
+          "slug" => "display-mixed",
+          "name" => "Display",
+          "config" => %{
+            "groups" => %{"sessions" => %{}},
+            "display" => %{
+              "image" => String.duplicate("a", 513),
+              "emoji" => "🚀",
+              "color" => "not-a-color",
+              "bogus" => "x"
+            }
+          }
+        })
+
+      assert scope.config["display"] == %{"emoji" => "🚀"}
+    end
+
+    test "a display that sanitizes to nothing is dropped entirely" do
+      for bad <- [
+            %{"emoji" => String.duplicate("🚀", 17)},
+            %{"color" => 12},
+            "red",
+            %{"bogus" => "x"}
+          ] do
+        {:ok, scope} =
+          MCPCustomScopes.create(%{
+            "slug" => "display-bad-#{System.unique_integer([:positive])}",
+            "name" => "Display",
+            "config" => %{"groups" => %{"sessions" => %{}}, "display" => bad}
+          })
+
+        refute Map.has_key?(scope.config, "display")
+      end
+    end
+
+    test "absent display carries prior across a group-only edit; empty display too" do
+      {:ok, scope} =
+        MCPCustomScopes.create(%{
+          "slug" => "display-carry",
+          "name" => "Display",
+          "config" => %{"groups" => %{"sessions" => %{}}, "display" => @valid_display}
+        })
+
+      {:ok, updated} =
+        MCPCustomScopes.update("display-carry", %{
+          "config" => %{"groups" => %{"sessions" => %{}, "tickets" => %{}}}
+        })
+
+      assert updated.config["display"] == @valid_display
+      assert Map.has_key?(updated.config["groups"], "tickets")
+
+      # an explicit empty display sanitizes to nothing → prior carries (matches
+      # the reservation semantics: absent ≠ clear)
+      {:ok, kept} =
+        MCPCustomScopes.update("display-carry", %{"config" => %{"display" => %{}}})
+
+      assert kept.config["display"] == @valid_display
+      _ = scope
+    end
+
+    test "a new display replaces the prior one" do
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "display-replace",
+          "name" => "Display",
+          "config" => %{"groups" => %{"sessions" => %{}}, "display" => @valid_display}
+        })
+
+      {:ok, updated} =
+        MCPCustomScopes.update("display-replace", %{
+          "config" => %{"display" => %{"emoji" => "🎯", "color" => "#f80"}}
+        })
+
+      assert updated.config["display"] == %{"emoji" => "🎯", "color" => "#f80"}
+    end
+  end
+
+  # ── alacarte WP2: restricted core variant + heal ─────────────────────────────
+
+  describe "restricted core variant" do
+    defp unrestricted_core_config do
+      %{
+        "groups" => %{
+          "sessions" => %{"tools" => %{"Session_Manifest" => %{}}},
+          "organizations" => %{"tools" => %{}},
+          "projects" => %{"tools" => %{}}
+        }
+      }
+    end
+
+    test "fresh core seed is restricted (catalog walk stamps non-essentials)" do
+      core = MCPCustomScopes.get_core_variant()
+      groups = core.config["groups"]
+
+      sessions = groups["sessions"]["tools"]
+      assert sessions["Session_Create"] == %{}
+      assert sessions["Session_Overview"] == %{}
+      assert sessions["Session_Manifest"] == %{}
+
+      for stripped <- ~w(Session_Get Session_Update Session_List Session_Archive) do
+        assert sessions[stripped] == %{"disabled" => true}, stripped
+      end
+
+      organizations = groups["organizations"]["tools"]
+      assert organizations["Organization_Overview"] == %{}
+      assert organizations["Organization_Get"] == %{}
+
+      for stripped <- ~w(Organization_Create Organization_Update Organization_List) do
+        assert organizations[stripped] == %{"disabled" => true}, stripped
+      end
+
+      projects = groups["projects"]["tools"]
+      assert projects["Project_Overview"] == %{}
+      assert projects["Project_Get"] == %{}
+      assert projects["Project_Create"] == %{"disabled" => true}
+    end
+
+    test "heal stamps the policy on a prod-shaped unrestricted core row" do
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "core",
+          "name" => "Core",
+          "kind" => "core_variant",
+          "config" => unrestricted_core_config()
+        })
+
+      core = MCPCustomScopes.get_core_variant()
+      sessions = core.config["groups"]["sessions"]["tools"]
+
+      # non-essentials stamped
+      assert sessions["Session_Archive"] == %{"disabled" => true}
+      # essentials left enabled (heal never adds entries; absent = enabled)
+      assert Map.get(sessions, "Session_Create") in [nil, %{}]
+      assert Map.get(sessions, "Session_Overview") in [nil, %{}]
+      # manifest exempt: present + enabled
+      assert sessions["Session_Manifest"] == %{}
+
+      organizations = core.config["groups"]["organizations"]["tools"]
+      assert organizations["Organization_Create"] == %{"disabled" => true}
+      assert Map.get(organizations, "Organization_Get") in [nil, %{}]
+
+      # other groups untouched; groups not in the core set never appear
+      refute Map.has_key?(core.config["groups"], "tickets")
+    end
+
+    test "heal clears stray disables on essentials and is idempotent" do
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "core",
+          "name" => "Core",
+          "kind" => "core_variant",
+          "config" =>
+            unrestricted_core_config()
+            |> put_in(
+              ["groups", "sessions", "tools", "Session_Create"],
+              %{"disabled" => true}
+            )
+            |> put_in(
+              ["groups", "sessions", "tools", "Session_Manifest"],
+              %{"disabled" => true}
+            )
+        })
+
+      core = MCPCustomScopes.get_core_variant()
+      sessions = core.config["groups"]["sessions"]["tools"]
+
+      # stray disables on essentials cleared
+      assert sessions["Session_Create"] == %{}
+      assert sessions["Session_Manifest"] == %{}
+      assert sessions["Session_Archive"] == %{"disabled" => true}
+
+      # idempotent: a second heal changes nothing
+      core2 = MCPCustomScopes.get_core_variant()
+      assert core2.config == core.config
+    end
+
+    test "user clones of core keep their frozen configs (heal touches the template only)" do
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "core",
+          "name" => "Core",
+          "kind" => "core_variant",
+          "config" => unrestricted_core_config()
+        })
+
+      {:ok, _clone} =
+        MCPCustomScopes.copy("core", %{"slug" => "core-clone-frozen", "name" => "Frozen"})
+
+      _healed = MCPCustomScopes.get_core_variant()
+
+      clone = MCPCustomScopes.get_by_slug("core-clone-frozen")
+      sessions = clone.config["groups"]["sessions"]["tools"]
+      # unrestricted carry-over survives — no policy stamps on the clone
+      refute Map.has_key?(sessions, "Session_Archive")
+      assert sessions["Session_Manifest"] == %{}
+    end
+  end
+
+  # ── alacarte WP2: core/full presets ──────────────────────────────────────────
+
+  describe "core/full presets" do
+    test "presets/0: core over the core-variant groups, full over every customizable group" do
+      presets = MCPCustomScopes.presets()
+      assert presets["core"].groups == ~w(sessions projects organizations)
+
+      full_groups = presets["full"].groups
+      assert length(full_groups) == length(NoizuPromptLingua.MCPServers.customizable())
+
+      assert MapSet.subset?(
+               MapSet.new(~w(sessions projects organizations)),
+               MapSet.new(full_groups)
+             )
+    end
+
+    test "preset_tool_sets/1: core expands to the policy + manifest; unknown rejected" do
+      assert {:ok, core_set} = MCPCustomScopes.preset_tool_sets("core")
+
+      for name <- ~w(Organization_Overview Organization_Get Project_Overview Project_Get
+                     Session_Create Session_Overview Session_Manifest) do
+        assert MapSet.member?(core_set, name), name
+      end
+
+      for stripped <- ~w(Session_Get Session_Archive Organization_Create Project_Create) do
+        refute MapSet.member?(core_set, stripped), stripped
+      end
+
+      assert :unknown_preset = MCPCustomScopes.preset_tool_sets("nope")
+      assert :unknown_preset = MCPCustomScopes.preset_tool_sets(nil)
+    end
+
+    test "preset_tool_sets/1: full covers every catalog tool (core ⊆ full); basic_crud restricted" do
+      assert {:ok, core_set} = MCPCustomScopes.preset_tool_sets("core")
+      assert {:ok, full_set} = MCPCustomScopes.preset_tool_sets("full")
+
+      assert MapSet.subset?(core_set, full_set)
+
+      for name <- ~w(Session_Archive Session_Get Session_Update Session_List
+                     Organization_Create Organization_Update Project_Create Project_List) do
+        assert MapSet.member?(full_set, name), name
+      end
+
+      assert {:ok, crud_set} = MCPCustomScopes.preset_tool_sets("basic_crud")
+      for name <- ~w(Session_Create Session_Get Session_List Ticket_List Ticket_Create) do
+        assert MapSet.member?(crud_set, name), name
+      end
+
+      for stripped <- ~w(Session_Archive Ticket_Comment Ticket_Watch) do
+        refute MapSet.member?(crud_set, stripped), stripped
+      end
+    end
+
+    test "preset_config/1 seeds the restricted core stamps" do
+      assert %{"groups" => groups} = MCPCustomScopes.preset_config("core")
+
+      tools = groups["sessions"]["tools"]
+      # enabled tools are absent from the tools map; only non-essentials stamped
+      refute Map.has_key?(tools, "Session_Create")
+      refute Map.has_key?(tools, "Session_Overview")
+      assert tools["Session_Manifest"] == %{}
+      assert tools["Session_Get"] == %{"disabled" => true}
+      assert tools["Session_Archive"] == %{"disabled" => true}
+
+      assert %{"groups" => full_groups} = MCPCustomScopes.preset_config("full")
+      # :all = no stamps; the manifest keeps its explicit sessions entry
+      assert full_groups["sessions"]["tools"] == %{"Session_Manifest" => %{}}
+      assert full_groups["organizations"]["tools"] == %{}
+      assert full_groups["projects"]["tools"] == %{}
+    end
+
+    test "create with the core preset seeds a restricted scope" do
+      {:ok, scope} =
+        MCPCustomScopes.create(%{
+          "slug" => "preset-core",
+          "name" => "Preset Core",
+          "preset" => "core"
+        })
+
+      sessions = scope.config["groups"]["sessions"]["tools"]
+      assert sessions["Session_List"] == %{"disabled" => true}
+      assert sessions["Session_Manifest"] == %{}
+      refute Map.has_key?(sessions, "Session_Create")
+
+      {:ok, full} =
+        MCPCustomScopes.create(%{
+          "slug" => "preset-full",
+          "name" => "Preset Full",
+          "preset" => "full"
+        })
+
+      assert full.config["groups"]["projects"]["tools"] == %{}
+      # full covers every customizable group, all tools enabled (no stamps)
+      assert map_size(full.config["groups"]) ==
+               length(NoizuPromptLingua.MCPServers.customizable())
+    end
+  end
 end

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_matrix_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_matrix_test.exs
@@ -9,14 +9,20 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetMatrixTest do
 
   use NoizuPromptLingua.DataCase
 
+  require Noizu.EntityReference.Records
+
   alias Noizu.MCP.Ctx
   alias Noizu.MCP.Server.Features.Tools
+  alias Noizu.EntityReference.Records, as: R
+  alias NoizuPromptLingua.Acl
   alias NoizuPromptLingua.MCP.EffectiveToolset
   alias NoizuPromptLingua.MCP.KeyToolsets
   alias NoizuPromptLingua.MCP.ToolNames
+  alias NoizuPromptLingua.MCP.UrlToolsetParam
   alias NoizuPromptLingua.MCPApiKeys
   alias NoizuPromptLingua.MCPCustomScopes
   alias NoizuPromptLingua.MCPServers
+  alias NoizuPromptLingua.Schema.McpTool
 
   @group "tickets"
   @tool_hidden "Ticket.List"
@@ -369,5 +375,94 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetMatrixTest do
       )
 
     scope
+  end
+
+  # ── alacarte ?t= param layer golden vectors ─────────────────────────────────
+
+  describe "param layer (alacarte ?t=)" do
+    # Scope: Ticket_Get stored-disabled; everything else stored-enabled.
+    defp param_scope(slug) do
+      create_scope(slug, %{
+        "groups" => %{@group => %{"tools" => %{@tool_plain => %{"disabled" => true}}}}
+      })
+    end
+
+    defp param_ctx(slug, spec, scope) do
+      assert {:ok, layer} = UrlToolsetParam.compile(spec, scope)
+
+      %Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: %{custom_scope_slug: slug, toolset_param_cfg: layer}
+      }
+    end
+
+    test "white-list golden vector: selected listed + callable, unlisted dead" do
+      scope = param_scope("param-mx-wl")
+      ctx = param_ctx("param-mx-wl", %{"white-list" => %{"Ticket_List" => true}}, scope)
+
+      states = EffectiveToolset.resolve(scope, EffectiveToolset.param_only_client(ctx), nil)
+
+      listed = EffectiveToolset.lookup(states, @tool_hidden)
+      assert listed.enabled and listed.visible
+
+      # stored-disabled + absent-from-set: doubly dead
+      refute EffectiveToolset.lookup(states, @tool_plain).enabled
+
+      # include set is still the scope's group set
+      for name <- Map.keys(states) do
+        assert ToolNames.dotted(name) |> String.starts_with?("Ticket.")
+      end
+
+      # dispatch-level (ToolGuard) agrees with the listing decision
+      refute KeyToolsets.state(@group, @tool_hidden, ctx).disabled
+      assert KeyToolsets.state(@group, @tool_plain, ctx).disabled
+    end
+
+    test "default:true + black-list golden vector: stored set minus blacklisted" do
+      scope = param_scope("param-mx-bl")
+
+      spec = %{"default" => true, "black-list" => %{"Ticket_Overview" => true}}
+      ctx = param_ctx("param-mx-bl", spec, scope)
+
+      states = EffectiveToolset.resolve(scope, EffectiveToolset.param_only_client(ctx), nil)
+
+      refute EffectiveToolset.lookup(states, "Ticket_Overview").enabled
+      assert EffectiveToolset.lookup(states, @tool_hidden).enabled
+      # stored-disabled stays disabled (default:true preserves the stored set)
+      refute EffectiveToolset.lookup(states, @tool_plain).enabled
+    end
+
+    test "tools-map visible re-enable golden vector (no white-list)" do
+      scope = param_scope("param-mx-tools")
+
+      spec = %{"tools" => %{@tool_plain => %{"visible" => true}}}
+      ctx = param_ctx("param-mx-tools", spec, scope)
+
+      states = EffectiveToolset.resolve(scope, EffectiveToolset.param_only_client(ctx), nil)
+      assert EffectiveToolset.lookup(states, @tool_plain).enabled
+    end
+
+    test "ACL stays final: deny beats a param-enabled tool" do
+      scope = param_scope("param-mx-acl")
+
+      ctx = param_ctx("param-mx-acl", %{"white-list" => %{"Ticket_List" => true}}, scope)
+
+      user_id = Ecto.UUID.generate()
+      user_ref = R.ref(module: NoizuPromptLingua.Users.User, id: user_id)
+
+      {:ok, _} =
+        Acl.create_rule(%{
+          subject_ref: user_ref,
+          resource_ref: R.ref(module: McpTool, id: "Ticket_List"),
+          action: "mcp.tool",
+          effect: "deny"
+        })
+
+      states = EffectiveToolset.resolve(scope, EffectiveToolset.param_only_client(ctx), user_ref)
+
+      # the white-list re-enabled Ticket_List, but the ACL deny hides + disables
+      refute EffectiveToolset.lookup(states, @tool_hidden).enabled
+      refute EffectiveToolset.lookup(states, @tool_hidden).visible
+    end
   end
 end

--- a/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/effective_toolset_test.exs
@@ -1,11 +1,16 @@
 defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
   use NoizuPromptLingua.DataCase
 
+  require Noizu.EntityReference.Records
+
   alias Noizu.MCP.Ctx
+  alias Noizu.EntityReference.Records, as: R
+  alias NoizuPromptLingua.Acl
   alias NoizuPromptLingua.MCP.EffectiveToolset
   alias NoizuPromptLingua.MCP.KeyToolsets
   alias NoizuPromptLingua.MCPApiKeys
   alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.Schema.McpTool
 
   @tool "Ticket.List"
   # F5: resolve/2 output is keyed canonical underscore
@@ -691,6 +696,145 @@ defmodule NoizuPromptLingua.MCP.EffectiveToolsetTest do
       entry = get_in(scope.config, ["groups", @group, "tools", @tool])
       assert String.length(entry["name_override"]) == 128
       assert String.length(entry["description_override"]) == 1024
+    end
+  end
+
+  # ── alacarte: the ?t= URL tool-selection layer ───────────────────────────────
+
+  describe "url toolset param layer" do
+    # Compiled param layer (UrlToolsetParam output shape): re-enable @tool.
+    @param_reenable %{
+      "groups" => %{@group => %{"tools" => %{@tool_canonical => %{"disabled" => false, "hidden" => false}}}}
+    }
+
+    defp ctx_with_param(assigns_extra) do
+      base = key_ctx(scope_config(%{}))
+      %Ctx{base | assigns: Map.merge(base.assigns, assigns_extra)}
+    end
+
+    test "param beats scope disabled (resolution + ToolGuard ctx path)" do
+      create_scope(
+        "acme",
+        scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => true}}}})
+      )
+
+      scope = MCPCustomScopes.get_by_slug("acme")
+      client = %{id: :url_toolset_param, kind: :url_param, toolset_config: @param_reenable}
+
+      state = EffectiveToolset.state(@group, @tool, scope, client)
+      assert state.enabled and state.visible
+
+      ctx = ctx_with_param(%{custom_scope_slug: "acme", toolset_param_cfg: @param_reenable})
+
+      flags = KeyToolsets.state(@group, @tool, ctx)
+      refute flags.disabled
+      refute flags.hidden
+    end
+
+    test "param beats client key flags (union merge, param wins per key)" do
+      create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+
+      # stored key config disables @tool at the group level; the param re-enables it
+      %Ctx{assigns: base_assigns} = key_ctx(scope_config(%{@group => %{"disabled" => true}}))
+
+      ctx = %Noizu.MCP.Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns:
+          base_assigns
+          |> Map.put(:toolset_param_cfg, @param_reenable)
+          |> Map.put(:custom_scope_slug, "acme")
+      }
+
+      flags = KeyToolsets.state(@group, @tool, ctx)
+      refute flags.disabled
+      refute flags.hidden
+
+      # without the param layer the stored key disable holds
+      %Ctx{assigns: plain} = key_ctx(scope_config(%{@group => %{"disabled" => true}}))
+
+      plain_ctx = %Noizu.MCP.Ctx{
+        server: NoizuPromptLingua.MCP,
+        assigns: Map.put(plain, :custom_scope_slug, "acme")
+      }
+
+      assert KeyToolsets.state(@group, @tool, plain_ctx).disabled
+    end
+
+    test "white-list entry for a tool absent from the stored client config survives (union, not overlay)" do
+      create_scope("acme", scope_config(%{@group => %{"tools" => %{}}}))
+      scope = MCPCustomScopes.get_by_slug("acme")
+
+      merged =
+        EffectiveToolset.client_with_param(ctx_with_param(%{toolset_param_cfg: @param_reenable}), scope)
+
+      tools = get_in(merged.toolset_config, ["groups", @group, "tools"])
+      assert Map.has_key?(tools, @tool_canonical)
+
+      # param wins per key over the stored client's hidden flag
+      state = EffectiveToolset.state(@group, @tool, scope, merged)
+      assert state.visible and state.enabled
+    end
+
+    test "param cannot widen the include set (scope groups govern)" do
+      create_scope("acme", scope_config(%{"sessions" => %{"tools" => %{}}}))
+
+      param_layer = %{
+        "groups" => %{"organizations" => %{"tools" => %{"Organization_List" => %{}}}}
+      }
+
+      scope = MCPCustomScopes.get_by_slug("acme")
+
+      client =
+        EffectiveToolset.client_with_param(ctx_with_param(%{toolset_param_cfg: param_layer}), scope)
+
+      states = EffectiveToolset.resolve(scope, client, nil)
+      assert Map.has_key?(states, "Session_Create")
+      refute Map.has_key?(states, "Organization_List")
+    end
+
+    test "nil scope drops the param (never widens a root universe)" do
+      ctx = ctx_with_param(%{toolset_param_cfg: @param_reenable})
+      client = EffectiveToolset.client_with_param(ctx, nil)
+      assert client == EffectiveToolset.client_for_ctx(ctx)
+    end
+
+    test "param_only_client carries ONLY the param layer (catalog contract)" do
+      ctx = ctx_with_param(%{toolset_param_cfg: @param_reenable})
+      client = EffectiveToolset.param_only_client(ctx)
+      assert client.toolset_config == @param_reenable
+
+      # no param → nil (the stored client layer stays out of catalog_specs)
+      assert EffectiveToolset.param_only_client(key_ctx(scope_config(%{}))) == nil
+    end
+
+    test "ACL stays final over the param layer (deny hides + disables a param-enabled tool)" do
+      create_scope("acme", scope_config(%{@group => %{"tools" => %{@tool => %{"disabled" => true}}}}))
+      scope = MCPCustomScopes.get_by_slug("acme")
+
+      user_id = Ecto.UUID.generate()
+      user_ref = R.ref(module: NoizuPromptLingua.Users.User, id: user_id)
+
+      {:ok, _} =
+        Acl.create_rule(%{
+          subject_ref: user_ref,
+          resource_ref: R.ref(module: McpTool, id: @tool_canonical),
+          action: "mcp.tool",
+          effect: "deny"
+        })
+
+      client = %{id: :url_toolset_param, kind: :url_param, toolset_config: @param_reenable}
+
+      # without ACL: the param re-enables the scope-disabled tool
+      assert EffectiveToolset.state(@group, @tool, scope, client).enabled
+
+      # with the denied user: ACL has the final word
+      state = EffectiveToolset.state(@group, @tool, scope, client, user_ref, DateTime.utc_now())
+      refute state.enabled
+      refute state.visible
+
+      # and resolve/4 agrees (listing path)
+      states = EffectiveToolset.resolve(scope, client, user_ref)
+      refute EffectiveToolset.lookup(states, @tool).visible
     end
   end
 end

--- a/backend/test/noizu_prompt_lingua/mcp/url_toolset_param_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/url_toolset_param_test.exs
@@ -1,0 +1,384 @@
+defmodule NoizuPromptLingua.MCP.UrlToolsetParamTest do
+  @moduledoc """
+  Alacarte `?t=` URL tool-selection parameter: the decode error taxonomy and
+  the full compile precedence matrix (white-list > black-list > white-list
+  visible flags > tools map), bounded by the scope's included groups.
+
+  decode/compile are pure (catalog walks are module-backed) — no DB rows here.
+  """
+
+  use NoizuPromptLingua.DataCase, async: true
+
+  alias NoizuPromptLingua.MCP.UrlToolsetParam
+
+  # sessions with a stored-disabled tool + tickets wide open. The universe is
+  # the two groups' live catalogs (canonical underscore names).
+  @scope %{
+    "kind" => "custom",
+    "config" => %{
+      "groups" => %{
+        "sessions" => %{"tools" => %{"Session_List" => %{"disabled" => true}}},
+        "tickets" => %{"tools" => %{}}
+      }
+    }
+  }
+
+  defp encode(spec), do: Base.url_encode64(Jason.encode!(spec), padding: false)
+
+  defp compile_ok!(spec, scope \\ @scope) do
+    assert {:ok, layer} = UrlToolsetParam.compile(spec, scope)
+    layer
+  end
+
+  defp flags(layer, group, tool),
+    do: get_in(layer, ["groups", group, "tools", tool]) || :absent
+
+  # ── decode/1: error taxonomy ────────────────────────────────────────────────
+
+  describe "decode/1" do
+    test "nil and empty are absent (byte-identical no-param behavior)" do
+      assert UrlToolsetParam.decode(nil) == :absent
+      assert UrlToolsetParam.decode("") == :absent
+    end
+
+    test "raw size cap: >12_000 chars" do
+      assert {:error, :too_large} = UrlToolsetParam.decode(String.duplicate("a", 12_001))
+    end
+
+    test "charset guard rejects base64-standard and whitespace spellings" do
+      assert {:error, :invalid_charset} = UrlToolsetParam.decode("ab+cd")
+      assert {:error, :invalid_charset} = UrlToolsetParam.decode("ab/cd")
+      assert {:error, :invalid_charset} = UrlToolsetParam.decode("ab cd")
+    end
+
+    test "bad base64" do
+      # length ≡ 1 (mod 4) is never valid base64
+      assert {:error, :invalid_base64} = UrlToolsetParam.decode("abcde")
+    end
+
+    test "valid base64 of non-JSON" do
+      assert {:error, :invalid_json} = UrlToolsetParam.decode("abcd")
+    end
+
+    test "decoded size cap: >8_192 decoded bytes (under the 12_000 raw-char cap)" do
+      # ~8.6KB key: decoded ≈ 8.6KB (>8_192) while raw base64 ≈ 11.5KB (<12_000)
+      spec = %{"tools" => %{String.duplicate("a", 8_600) => true}}
+      assert {:error, :too_large_decoded} = UrlToolsetParam.decode(encode(spec))
+    end
+
+    test "padded base64url is accepted (decoder re-pads)" do
+      padded = Base.url_encode64(Jason.encode!(%{}), padding: true)
+      assert {:ok, %{}} = UrlToolsetParam.decode(padded)
+    end
+
+    test "unknown top-level keys are rejected (fail-closed)" do
+      assert {:error, {:invalid_shape, msg}} = UrlToolsetParam.decode(encode(%{"bogus" => 1}))
+      assert msg =~ "bogus"
+    end
+
+    test "non-object JSON is rejected" do
+      assert {:error, {:invalid_shape, _}} = UrlToolsetParam.decode(encode([1, 2]))
+    end
+
+    test "list/tools entries must be booleans or {\"visible\": bool}" do
+      assert {:error, {:invalid_shape, _}} =
+               UrlToolsetParam.decode(encode(%{"white-list" => %{"Session_List" => "yes"}}))
+
+      assert {:error, {:invalid_shape, _}} =
+               UrlToolsetParam.decode(encode(%{"tools" => %{"Session_List" => %{"extra" => 1}}}))
+    end
+
+    test "empty tool names are rejected" do
+      assert {:error, {:invalid_shape, _}} =
+               UrlToolsetParam.decode(encode(%{"black-list" => %{"" => true}}))
+    end
+
+    test "default must be true or a preset slug" do
+      assert {:error, {:invalid_shape, _}} = UrlToolsetParam.decode(encode(%{"default" => false}))
+      assert {:error, {:invalid_shape, _}} = UrlToolsetParam.decode(encode(%{"default" => 1}))
+      assert {:error, {:invalid_shape, _}} = UrlToolsetParam.decode(encode(%{"default" => ""}))
+    end
+
+    test "a valid spec round-trips" do
+      spec = %{
+        "white-list" => %{"Session_List" => true},
+        "black-list" => %{"Session_Get" => true},
+        "tools" => %{"Session_Create" => %{"visible" => true}},
+        "default" => "core"
+      }
+
+      assert {:ok, ^spec} = UrlToolsetParam.decode(encode(spec))
+    end
+
+    # ── snake_case aliases (golden vectors, both spellings) ────────────────────
+
+    test "white_list/black_list aliases normalize to the kebab-case spec" do
+      snake = %{
+        "white_list" => %{"Session_List" => true},
+        "black_list" => %{"Session_Get" => true}
+      }
+
+      kebab = %{
+        "white-list" => %{"Session_List" => true},
+        "black-list" => %{"Session_Get" => true}
+      }
+
+      assert UrlToolsetParam.decode(encode(snake)) == {:ok, kebab}
+    end
+
+    test "aliases are rejected when BOTH spellings of a section are present" do
+      ambiguous = %{"white-list" => %{"Session_List" => true}, "white_list" => %{}}
+      assert {:error, {:invalid_shape, msg}} = UrlToolsetParam.decode(encode(ambiguous))
+      assert msg =~ "white_list" and msg =~ "white-list"
+
+      ambiguous_black = %{"black-list" => %{}, "black_list" => %{}}
+      assert {:error, {:invalid_shape, msg}} = UrlToolsetParam.decode(encode(ambiguous_black))
+      assert msg =~ "black_list" and msg =~ "black-list"
+    end
+  end
+
+  # ── compile/2: the precedence matrix ────────────────────────────────────────
+
+  describe "compile/1 precedence: white-list defines the enable set" do
+    test "in-set tools enabled, absent-from-set disabled across ALL groups" do
+      layer = compile_ok!(%{"white-list" => %{"Session_List" => true}})
+
+      # a white-list pick implies visibility (the selection is what tools/list shows)
+      assert flags(layer, "sessions", "Session_List") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => true}
+      assert flags(layer, "sessions", "Session_Manifest") == %{"disabled" => true}
+      assert flags(layer, "tickets", "Ticket_List") == %{"disabled" => true}
+    end
+
+    test "empty white-list disables the whole universe" do
+      layer = compile_ok!(%{"white-list" => %{}})
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => true}
+      assert flags(layer, "tickets", "Ticket_Get") == %{"disabled" => true}
+    end
+
+    test "white-list beats black-list" do
+      layer =
+        compile_ok!(%{
+          "white-list" => %{"Session_List" => true},
+          "black-list" => %{"Session_List" => true, "Session_Create" => true}
+        })
+
+      # white-list wins over the black-list: enabled AND visible
+      assert flags(layer, "sessions", "Session_List") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => true}
+    end
+
+    test "white-list visible:false = enabled but hidden" do
+      layer = compile_ok!(%{"white-list" => %{"Session_List" => %{"visible" => false}}})
+
+      assert flags(layer, "sessions", "Session_List") == %{"disabled" => false, "hidden" => true}
+    end
+
+    test "snake_case aliases compile to the IDENTICAL layer (golden vector)" do
+      kebab = compile_ok!(%{"white-list" => %{"Session_List" => true}})
+      snake = compile_ok!(%{"white_list" => %{"Session_List" => true}})
+      assert snake == kebab
+
+      kebab = compile_ok!(%{"black-list" => %{"Session_List" => true}})
+      snake = compile_ok!(%{"black_list" => %{"Session_List" => true}})
+      assert snake == kebab
+    end
+  end
+
+  describe "compile/1 precedence: black-list (unconstrained)" do
+    test "black-list disables; other tools carry no opinions" do
+      layer = compile_ok!(%{"black-list" => %{"Session_List" => true}})
+
+      assert flags(layer, "sessions", "Session_List") == %{"disabled" => true}
+      assert flags(layer, "sessions", "Session_Create") == %{}
+      assert flags(layer, "tickets", "Ticket_List") == %{}
+    end
+
+    test "black-list false is inert" do
+      layer = compile_ok!(%{"black-list" => %{"Session_List" => false}})
+      assert flags(layer, "sessions", "Session_List") == %{}
+    end
+  end
+
+  describe "compile/1 precedence: default expansions" do
+    test "default:true = stored-enabled; black-list trims it" do
+      layer =
+        compile_ok!(%{"default" => true, "black-list" => %{"Session_Create" => true}})
+
+      # stored-disabled Session_List stays disabled (out of the stored-enabled set)
+      assert flags(layer, "sessions", "Session_List") == %{"disabled" => true}
+      # stored-enabled but blacklisted
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => true}
+      # stored-enabled, untouched (in-set => explicit disabled:false)
+      assert flags(layer, "tickets", "Ticket_Get") == %{"disabled" => false}
+    end
+
+    test "default:\"core\" expands the core preset bounded by the universe" do
+      layer = compile_ok!(%{"default" => "core"})
+
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => false}
+      assert flags(layer, "sessions", "Session_Overview") == %{"disabled" => false}
+      assert flags(layer, "sessions", "Session_Manifest") == %{"disabled" => false}
+      assert flags(layer, "sessions", "Session_Get") == %{"disabled" => true}
+
+      # tickets has no core set — the preset decides, bounded by the universe
+      assert flags(layer, "tickets", "Ticket_List") == %{"disabled" => true}
+    end
+
+    test "default:\"full\" enables every universe tool (full covers all customizable groups)" do
+      layer = compile_ok!(%{"default" => "full"})
+
+      assert flags(layer, "sessions", "Session_Archive") == %{"disabled" => false}
+      assert flags(layer, "sessions", "Session_Manifest") == %{"disabled" => false}
+      assert flags(layer, "tickets", "Ticket_List") == %{"disabled" => false}
+      assert flags(layer, "tickets", "Ticket_Comment") == %{"disabled" => false}
+    end
+
+    test "default:\"basic_crud\" keeps the entity CRUD set" do
+      layer = compile_ok!(%{"default" => "basic_crud"})
+
+      assert flags(layer, "tickets", "Ticket_List") == %{"disabled" => false}
+      assert flags(layer, "tickets", "Ticket_Comment") == %{"disabled" => true}
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => false}
+      assert flags(layer, "sessions", "Session_Archive") == %{"disabled" => true}
+    end
+
+    test "unknown preset errors" do
+      assert {:error, {:unknown_preset, "nope"}} =
+               UrlToolsetParam.compile(%{"default" => "nope"}, @scope)
+    end
+
+    test "white-list and default union into one enable set" do
+      layer =
+        compile_ok!(%{"default" => "core", "white-list" => %{"Ticket_List" => true}})
+
+      assert flags(layer, "sessions", "Session_Create")["disabled"] == false
+      assert flags(layer, "tickets", "Ticket_List")["disabled"] == false
+      assert flags(layer, "tickets", "Ticket_Comment") == %{"disabled" => true}
+    end
+  end
+
+  describe "compile/1 precedence: tools map (lowest)" do
+    test "visible re-enables a stored-disabled tool when unconstrained" do
+      layer = compile_ok!(%{"tools" => %{"Session_List" => %{"visible" => true}}})
+
+      assert flags(layer, "sessions", "Session_List") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+
+      assert flags(layer, "sessions", "Session_Create") == %{}
+    end
+
+    test "true is the visible:true shorthand; visible:false hides" do
+      layer =
+        compile_ok!(%{
+          "tools" => %{"Session_List" => true, "Session_Create" => %{"visible" => false}}
+        })
+
+      assert flags(layer, "sessions", "Session_List") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+
+      assert flags(layer, "sessions", "Session_Create") == %{"hidden" => true}
+    end
+
+    test "a constrained enable set cannot be re-entered via the tools map" do
+      layer =
+        compile_ok!(%{
+          "white-list" => %{"Session_Create" => true},
+          "tools" => %{"Session_List" => %{"visible" => true}}
+        })
+
+      assert flags(layer, "sessions", "Session_List") == %{"disabled" => true}
+      assert flags(layer, "sessions", "Session_Create") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+    end
+
+    test "visible:false still hides under a constrained set (narrowing is safe)" do
+      layer =
+        compile_ok!(%{
+          "white-list" => %{"Session_Create" => true, "Session_Overview" => true},
+          "tools" => %{"Session_Overview" => %{"visible" => false}}
+        })
+
+      assert flags(layer, "sessions", "Session_Overview") == %{
+               "disabled" => false,
+               "hidden" => true
+             }
+    end
+
+    test "dotted tool-name aliases are canonicalized (F5: lookup points accept either form)" do
+      # white-list pick (implies visibility) …
+      layer = compile_ok!(%{"white-list" => %{"Ticket.List" => true}})
+      assert flags(layer, "tickets", "Ticket_List") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+
+      # … and an unconstrained tools-map re-enable, both via the dotted alias
+      layer = compile_ok!(%{"tools" => %{"Session.List" => %{"visible" => true}}})
+
+      assert flags(layer, "sessions", "Session_List") == %{
+               "disabled" => false,
+               "hidden" => false
+             }
+    end
+  end
+
+  describe "compile/1 universe bounds" do
+    test "entries outside the universe are dead" do
+      layer =
+        compile_ok!(%{"white-list" => %{"Organization_List" => true, "Nonexistent_Tool" => true}})
+
+      names =
+        layer["groups"]
+        |> Enum.flat_map(fn {_gid, g} -> Map.keys(g["tools"]) end)
+
+      assert "Organization_List" not in names
+      assert "Nonexistent_Tool" not in names
+    end
+
+    test "include set is invariant: layer groups == scope groups" do
+      layer = compile_ok!(%{"white-list" => %{"Ticket_List" => true}})
+      assert MapSet.new(Map.keys(layer["groups"])) == MapSet.new(["sessions", "tickets"])
+    end
+
+    test "group-disabled groups contribute nothing" do
+      scope = %{
+        "kind" => "custom",
+        "config" => %{
+          "groups" => %{"sessions" => %{}, "tickets" => %{"disabled" => true}}
+        }
+      }
+
+      layer = compile_ok!(%{"white-list" => %{"Ticket_List" => true}}, scope)
+      assert layer["groups"]["tickets"]["tools"] == %{}
+      assert flags(layer, "sessions", "Session_Create") == %{"disabled" => true}
+    end
+
+    test "accepts a real scope struct and nil scope" do
+      struct_scope = %NoizuPromptLingua.Schema.MCPCustomScope{
+        kind: "custom",
+        config: @scope["config"]
+      }
+
+      assert {:ok, _} = UrlToolsetParam.compile(%{"white-list" => %{"Session_List" => true}}, struct_scope)
+
+      # nil scope: empty universe, layer is inert — never a widening vehicle
+      assert {:ok, layer} = UrlToolsetParam.compile(%{"white-list" => %{"Session_List" => true}}, nil)
+      assert layer["groups"] == %{}
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_param_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_param_test.exs
@@ -1,0 +1,271 @@
+defmodule NoizuPromptLinguaWeb.CustomMCPGatewayParamTest do
+  @moduledoc """
+  Alacarte `?t=` URL tool-selection parameter over the custom-scope gateway
+  (legacy `/custom/:slug/mcp` surface):
+
+    * decode happens BEFORE the transport plug — garbage fails closed with a
+      400 (even unauthenticated) instead of opening a session;
+    * a white-list shapes `tools/list` (and re-enables a stored-disabled tool);
+    * the re-enabled tool is also DISPATCHABLE (ToolGuard seam);
+    * an excluded tool's call is rejected;
+    * no-param behavior is byte-identical (stored config governs);
+    * the param is a session SNAPSHOT — follow-ups without the query keep the
+      initialize-time layer.
+
+  async: false (shared sandbox): the transport's session process reads the DB.
+  """
+
+  use NoizuPromptLinguaWeb.ConnCase, async: false
+
+  alias NoizuPromptLingua.MCPCustomScopes
+  alias NoizuPromptLingua.Repo
+  alias NoizuPromptLingua.Schema.McpApiKey
+  alias NoizuPromptLingua.Schema.Users.User
+  alias NoizuPromptLingua.Token
+
+  # sessions group with Session_Get stored-disabled — the param's re-enable
+  # target (Session_Get is NOT statically hidden; Session_List/Session_Archive
+  # are, and registration-level visibility is out of the param's reach).
+  defp create_scope(slug) do
+    {:ok, scope} =
+      MCPCustomScopes.create(%{
+        "slug" => slug,
+        "name" => "Param Scope",
+        "kind" => "custom",
+        "config" => %{
+          "groups" => %{"sessions" => %{"tools" => %{"Session_Get" => %{"disabled" => true}}}}
+        }
+      })
+
+    scope
+  end
+
+  defp create_user do
+    n = System.unique_integer([:positive])
+
+    Repo.insert!(%User{
+      id: Ecto.UUID.generate(),
+      email: "param-gw-#{n}@example.com",
+      user_name: "paramgw#{n}",
+      handle: "paramgwh#{n}",
+      status: :active,
+      verified: false,
+      flagged: false
+    })
+  end
+
+  defp create_api_key(user_id) do
+    Repo.insert!(%McpApiKey{
+      id: Ecto.UUID.generate(),
+      user_id: user_id,
+      key_prefix: "mcp_t",
+      key_hash: Ecto.UUID.generate(),
+      status: "active"
+    })
+  end
+
+  defp key_caller do
+    user = create_user()
+    key = create_api_key(user.id)
+
+    {:ok, token, _exp} =
+      Token.mint(%{id: user.id, email: user.email, name: user.user_name}, %{id: key.id},
+        alg: :hs256
+      )
+
+    token
+  end
+
+  defp encode_query(spec),
+    do: "?t=" <> Base.url_encode64(Jason.encode!(spec), padding: false)
+
+  defp rpc_req(conn, token, path, body) do
+    conn
+    |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+    |> Plug.Conn.put_req_header("accept", "application/json, text/event-stream")
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> post(path, body)
+  end
+
+  defp initialize(token, path, query) do
+    body =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => "initialize",
+        "params" => %{
+          "protocolVersion" => "2024-11-05",
+          "capabilities" => %{},
+          "clientInfo" => %{"name" => "param-test", "version" => "1.0"}
+        }
+      })
+
+    conn = rpc_req(build_conn(), token, path <> query, body)
+    session = conn |> Plug.Conn.get_resp_header("mcp-session-id") |> List.first()
+
+    # Standard MCP handshake: the peer only accepts requests after the
+    # notifications/initialized notification.
+    if session do
+      build_conn()
+      |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+      |> Plug.Conn.put_req_header("content-type", "application/json")
+      |> Plug.Conn.put_req_header("mcp-session-id", session)
+      |> post(path, Jason.encode!(%{"jsonrpc" => "2.0", "method" => "notifications/initialized"}))
+    end
+
+    {conn, session}
+  end
+
+  defp follow_up(token, path, session, method, id, params \\ %{}) do
+    build_conn()
+    |> Plug.Conn.put_req_header("authorization", "Bearer " <> token)
+    |> Plug.Conn.put_req_header("accept", "application/json, text/event-stream")
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("mcp-session-id", session)
+    |> post(
+      path,
+      Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params})
+    )
+    |> json_response(200)
+  end
+
+  defp listed_tools(token, path, session) do
+    follow_up(token, path, session, "tools/list", 2)
+    |> get_in(["result", "tools"])
+    |> Enum.map(& &1["name"])
+  end
+
+  setup do
+    uniq = System.unique_integer([:positive])
+    slug = "param-gw-#{uniq}"
+    scope = create_scope(slug)
+    token = key_caller()
+
+    %{scope: scope, slug: slug, token: token, path: "/custom/#{slug}/mcp"}
+  end
+
+  # ── decode-before-transport: fail-closed 400s ───────────────────────────────
+
+  describe "invalid parameter → 400 before the transport" do
+    test "garbage charset is rejected even unauthenticated", %{path: path} do
+      conn =
+        build_conn()
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> post(path <> "?t=!!!not-base64url", Jason.encode!(%{"jsonrpc" => "2.0"}))
+
+      assert conn.status == 400
+
+      assert %{"error" => "invalid tool selection parameter", "detail" => detail} =
+               json_response(conn, 400)
+
+      assert is_binary(detail) and detail != ""
+    end
+
+    test "bad base64 padding is rejected", %{token: token, path: path} do
+      conn =
+        rpc_req(build_conn(), token, path <> "?t=abcde", Jason.encode!(%{"jsonrpc" => "2.0"}))
+
+      assert conn.status == 400
+      assert %{"detail" => "invalid_base64"} = json_response(conn, 400)
+    end
+
+    test "unknown preset is rejected with a detail", %{token: token, path: path} do
+      conn =
+        rpc_req(
+          build_conn(),
+          token,
+          path <> encode_query(%{"default" => "nope"}),
+          Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize", "params" => %{}})
+        )
+
+      assert conn.status == 400
+      assert %{"detail" => "unknown preset: nope"} = json_response(conn, 400)
+    end
+  end
+
+  # ── listing + dispatch through the session ──────────────────────────────────
+
+  describe "param-shaped serving" do
+    test "white-list shapes tools/list and re-enables a stored-disabled tool", %{
+      token: token,
+      path: path
+    } do
+      query = encode_query(%{"white-list" => %{"Session_Get" => true, "Session_Manifest" => true}})
+      {conn, session} = initialize(token, path, query)
+      assert conn.status == 200
+
+      names = listed_tools(token, path, session)
+
+      # stored-disabled Session_Get: re-enabled by the white-list
+      assert "Session_Get" in names
+      assert "Session_Manifest" in names
+
+      # absent-from-set → disabled → dropped from the listing
+      refute "Session_Create" in names
+      refute "Session_Update" in names
+
+      # the Discovery browsing plane stays ungated
+      assert "ToolSummary" in names
+    end
+
+    test "re-enabled tool is dispatchable; excluded tool call is rejected", %{
+      token: token,
+      path: path
+    } do
+      query = encode_query(%{"white-list" => %{"Session_Get" => true}})
+      {_conn, session} = initialize(token, path, query)
+
+      # the re-enabled tool passes the toolset guard: whatever the handler
+      # answers, the response must NOT be a toolset denial or an unknown-tool
+      body =
+        follow_up(token, path, session, "tools/call", 3, %{
+          "name" => "Session_Get",
+          "arguments" => %{}
+        })
+
+      text = inspect(body)
+      refute text =~ "tool_disabled_for_key"
+      refute text =~ "Unknown tool"
+
+      # the excluded tool is not even dispatchable (dropped from the catalog)
+      denied =
+        follow_up(token, path, session, "tools/call", 4, %{
+          "name" => "Session_Create",
+          "arguments" => %{}
+        })
+
+      assert denied["error"] != nil or get_in(denied, ["result", "isError"]) == true
+      assert inspect(denied) =~ "Unknown tool"
+    end
+
+    test "no-param behavior is unchanged (stored config governs)", %{token: token, path: path} do
+      {conn, session} = initialize(token, path, "")
+      assert conn.status == 200
+
+      names = listed_tools(token, path, session)
+
+      # stored-disabled Session_Get stays off; the enabled sessions tools serve.
+      # (Session_List/Session_Archive are statically hidden — registration-level
+      # visibility survives no-op states, param or not.)
+      refute "Session_Get" in names
+      assert "Session_Create" in names
+      assert "Session_Update" in names
+      assert "Session_Manifest" in names
+      assert "ToolSummary" in names
+    end
+
+    test "the param is an initialize-time snapshot: follow-ups without the query keep it", %{
+      token: token,
+      path: path
+    } do
+      query = encode_query(%{"white-list" => %{"Session_Get" => true}})
+      {conn, session} = initialize(token, path, query)
+      assert conn.status == 200
+
+      # same session, no ?t= on this request
+      names = listed_tools(token, path, session)
+      assert "Session_Get" in names
+      refute "Session_Create" in names
+    end
+  end
+end

--- a/backend/test/noizu_prompt_lingua_web/controllers/mcp_custom_scope_controller_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/mcp_custom_scope_controller_test.exs
@@ -105,4 +105,102 @@ defmodule NoizuPromptLinguaWeb.MCPCustomScopeControllerTest do
     missing = post(conn, "/api/v1/admin/mcp-custom-scopes/nope/clone") |> json_response(404)
     assert missing["error"] =~ "not found"
   end
+
+  # ── alacarte WP1/WP4: display passthrough + clone inheritance ────────────────
+
+  describe "display styling config (alacarte)" do
+    @display %{"image" => "abc123shortid", "emoji" => "🚀", "color" => "#ff8800"}
+
+    test "admin create + update round-trip display; group-only updates keep it", %{conn: conn} do
+      created =
+        post(conn, "/api/v1/admin/mcp-custom-scopes", %{
+          scope: %{
+            slug: "display-admin",
+            name: "Display Admin",
+            config: %{groups: %{sessions: %{}}, display: @display}
+          }
+        })
+        |> json_response(201)
+
+      assert created["scope"]["config"]["display"] == @display
+
+      # a groups-only update must not drop the stored display (prior carry)
+      updated =
+        patch(conn, "/api/v1/admin/mcp-custom-scopes/display-admin", %{
+          scope: %{config: %{groups: %{tickets: %{}}}}
+        })
+        |> json_response(200)
+
+      assert updated["scope"]["config"]["display"] == @display
+      assert Map.has_key?(updated["scope"]["config"]["groups"], "tickets")
+
+      # a new display replaces it
+      replaced =
+        patch(conn, "/api/v1/admin/mcp-custom-scopes/display-admin", %{
+          scope: %{config: %{display: %{"emoji" => "🎯", "color" => "#f80"}}}
+        })
+        |> json_response(200)
+
+      assert replaced["scope"]["config"]["display"] == %{"emoji" => "🎯", "color" => "#f80"}
+    end
+
+    test "display sanitization: non-conforming fields dropped, conforming kept", %{conn: conn} do
+      created =
+        post(conn, "/api/v1/admin/mcp-custom-scopes", %{
+          scope: %{
+            slug: "display-sanitize",
+            name: "Display Sanitize",
+            config: %{
+              groups: %{sessions: %{}},
+              display: %{
+                image: String.duplicate("a", 513),
+                emoji: "🚀",
+                color: "not-a-color",
+                bogus: "x"
+              }
+            }
+          }
+        })
+        |> json_response(201)
+
+      assert created["scope"]["config"]["display"] == %{"emoji" => "🚀"}
+    end
+
+    test "clone inherits the source display", %{conn: conn} do
+      post(conn, "/api/v1/admin/mcp-custom-scopes", %{
+        scope: %{
+          slug: "display-src",
+          name: "Display Source",
+          config: %{groups: %{sessions: %{}}, display: @display}
+        }
+      })
+      |> json_response(201)
+
+      clone =
+        post(conn, "/api/v1/admin/mcp-custom-scopes/display-src/clone", %{
+          scope: %{slug: "display-clone", name: "Display Clone"}
+        })
+        |> json_response(201)
+
+      assert clone["scope"]["config"]["display"] == @display
+    end
+
+    test "user default endpoint round-trips display through its config", %{conn: conn} do
+      # seed the user's default endpoint (cloned from the tobor template)
+      shown = conn |> get("/api/v1/auth/mcp/default-endpoint") |> json_response(200)
+      assert shown["scope"]["slug"]
+
+      updated =
+        patch(conn, "/api/v1/auth/mcp/default-endpoint", %{
+          config: %{groups: %{sessions: %{}}, display: %{"emoji" => "🎯", "color" => "#f80"}}
+        })
+        |> json_response(200)
+
+      assert updated["scope"]["config"]["display"] == %{"emoji" => "🎯", "color" => "#f80"}
+
+      # persisted — a re-fetch shows the stored display
+      fetched = conn |> get("/api/v1/auth/mcp/default-endpoint") |> json_response(200)
+      assert fetched["scope"]["config"]["display"] == %{"emoji" => "🎯", "color" => "#f80"}
+    end
+  end
 end

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:e2e:install": "playwright install chromium",
     "e2e:stage:login": "node e2e/scripts/stage-login.mjs",
     "e2e:stage": "node e2e/scripts/stage-login.mjs && E2E_STORAGE_STATE=\"$PWD/e2e/.auth/state.json\" playwright test",
-    "test:contracts": "node --import tsx --test src/components/app-shell.contract.test.ts src/lib/pm/trp-board-embed.test.ts src/lib/mcp-setup.test.ts src/components/mcp-oauth-setup.contract.test.ts src/lib/tool-overrides.test.ts src/components/kit/acl-editor.contract.test.ts src/components/kit/acl-state.test.ts src/components/mcp-config/endpoint-wizard-state.test.ts src/components/kit/wizard-stepper.contract.test.ts",
+    "test:contracts": "node --import tsx --test src/components/app-shell.contract.test.ts src/lib/pm/trp-board-embed.test.ts src/lib/mcp-setup.test.ts src/lib/toolset-param.test.ts src/components/mcp-oauth-setup.contract.test.ts src/lib/tool-overrides.test.ts src/components/kit/acl-editor.contract.test.ts src/components/kit/acl-state.test.ts src/components/mcp-config/endpoint-wizard-state.test.ts src/components/kit/wizard-stepper.contract.test.ts",
     "test:e2e:authentik": "cypress run --browser chrome --config-file cypress.authentik.config.ts --spec 'cypress/e2e/auth/login-authentik.cy.ts'"
   },
   "dependencies": {

--- a/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
+++ b/frontend/src/app/app/admin/mcp-custom-scopes/page.tsx
@@ -43,6 +43,8 @@ import {
   type ToolSetIndex,
 } from '@/lib/acl-api';
 import McpEndpointSetupPopunder from '@/components/mcp-endpoint-setup-popunder';
+import DisplayFieldset from '@/components/mcp-config/display-fieldset';
+import ToolsetUrlBuilder from '@/components/mcp-config/toolset-url-builder';
 import { ToolOverrideFields } from '@/components/kit/tool-overrides-editor';
 import {
   applyOverridePatch,
@@ -77,7 +79,11 @@ function slugify(value: string) {
 }
 
 function normalizeConfig(config?: McpCustomScopeConfig | null): McpCustomScopeConfig {
-  return { groups: { ...(config?.groups ?? {}) } };
+  return {
+    // Reserved `display` key (alacarte endpoint identity) rides along.
+    ...(config?.display ? { display: config.display } : {}),
+    groups: { ...(config?.groups ?? {}) },
+  };
 }
 
 function blankForm(): ScopeForm {
@@ -124,6 +130,8 @@ function nextConfig(
   update: (draft: McpCustomScopeConfig) => void,
 ) {
   const draft: McpCustomScopeConfig = {
+    // Reserved `display` key rides along while groups are cloned.
+    ...(config.display ? { display: config.display } : {}),
     groups: Object.fromEntries(
       Object.entries(config.groups ?? {}).map(([groupId, group]) => [
         groupId,
@@ -170,6 +178,8 @@ function AdminMcpCustomScopesInner() {
   const [tempTool, setTempTool] = useState('');
   const [newGroupName, setNewGroupName] = useState('');
   const [setupScope, setSetupScope] = useState<McpCustomScope | null>(null);
+  // Alacarte: per-row ?t= tool-selection URL builder (core included).
+  const [builderScope, setBuilderScope] = useState<McpCustomScope | null>(null);
 
   const selectedScope = useMemo(
     () => scopes.find((s) => s.slug === form.originalSlug) ?? null,
@@ -483,6 +493,7 @@ function AdminMcpCustomScopesInner() {
         disabled: saving,
       },
       { id: 'setup', label: 'Setup MCP' },
+      { id: 'toolset-url', label: 'Tool selection URL' },
       { id: 'delete', label: 'Delete', destructive: true, disabled: isDefault },
     ];
   }
@@ -492,6 +503,7 @@ function AdminMcpCustomScopesInner() {
     else if (id === 'rename') renameScope(scope);
     else if (id === 'clone') cloneScope(scope);
     else if (id === 'setup') setSetupScope(scope);
+    else if (id === 'toolset-url') setBuilderScope(scope);
     else if (id === 'delete') remove(scope);
   }
 
@@ -673,6 +685,25 @@ function AdminMcpCustomScopesInner() {
           value={form.description}
           onChange={(e) => setForm((current) => ({ ...current, description: e.target.value }))}
           rows={3}
+        />
+      </div>
+
+      {/* Alacarte: display metadata — the reserved config.display key. Saved
+          with the payload (config rides through normalizeConfigToolKeys, which
+          preserves display). Org-owned scopes register org-visible uploads. */}
+      <div>
+        <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>Display (optional)</div>
+        <DisplayFieldset
+          value={form.config.display ?? null}
+          ownerOrgId={selectedScope?.organization_id ?? null}
+          onChange={(next) =>
+            setForm((current) => {
+              const config: McpCustomScopeConfig = { ...current.config };
+              if (next) config.display = next;
+              else delete config.display;
+              return { ...current, config };
+            })
+          }
         />
       </div>
 
@@ -1062,6 +1093,13 @@ function AdminMcpCustomScopesInner() {
             onClose={() => setSetupScope(null)}
             scope={setupScope}
             mcpUrl={stubScopeUrl(setupScope)}
+          />
+        )}
+
+        {builderScope && (
+          <ToolsetUrlBuilder
+            slug={builderScope.slug}
+            onClose={() => setBuilderScope(null)}
           />
         )}
       </main>

--- a/frontend/src/app/app/mcp-setup/page.tsx
+++ b/frontend/src/app/app/mcp-setup/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  api,
+  type McpCustomGroup,
+  type McpCustomScope,
+  type McpOAuthConnection,
+} from '@/lib/api';
+import McpEndpointList from '@/components/mcp-endpoint-list';
+import EndpointWizard from '@/components/mcp-config/endpoint-wizard';
+
+/**
+ * Dedicated user setup page (/app/mcp-setup): visual endpoint picker, the
+ * endpoint-creation wizard, and connected-client (OAuth pairing grant)
+ * revocation. Lean composition of existing API routes — no new backend
+ * surface; detailed per-client install snippets stay on the MCP client setup
+ * page.
+ */
+export default function McpSetupPage() {
+  const [templates, setTemplates] = useState<McpCustomScope[]>([]);
+  const [endpoints, setEndpoints] = useState<McpCustomScope[]>([]);
+  const [selected, setSelected] = useState<McpCustomScope | null>(null);
+  const [catalog, setCatalog] = useState<McpCustomGroup[]>([]);
+  const [connections, setConnections] = useState<McpOAuthConnection[]>([]);
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [endpointRes, catalogRes] = await Promise.all([
+        api.listMcpEndpoints(),
+        // The wizard needs the catalog; without it the picker still works.
+        api.mcpCatalog().catch(() => ({ groups: [] as McpCustomGroup[] })),
+      ]);
+      setTemplates(endpointRes.templates ?? []);
+      setEndpoints(endpointRes.endpoints ?? []);
+      setSelected(endpointRes.default_scope ?? endpointRes.endpoints?.[0] ?? null);
+      setCatalog(catalogRes.groups ?? []);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load endpoints');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const fetchConnections = useCallback(async () => {
+    try {
+      const data = await api.listMcpConnections();
+      setConnections(data.connections ?? []);
+    } catch {
+      // Endpoint may 404 on older deploys — connections are optional here.
+      setConnections([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchConnections();
+  }, [fetchConnections]);
+
+  async function revoke(grantId: string) {
+    if (!confirm('Revoke this OAuth connection? Connected clients must re-authorize.')) return;
+    try {
+      await api.revokeMcpConnection(grantId);
+      await fetchConnections();
+      toast.success('Connection revoked');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to revoke connection');
+    }
+  }
+
+  async function copyUrl() {
+    if (!selected?.url) return;
+    try {
+      await navigator.clipboard.writeText(selected.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      toast.success('Copied');
+    } catch {
+      toast.error('Copy failed — select and copy manually');
+    }
+  }
+
+  function wizardCreated(endpoint: McpCustomScope) {
+    toast.success('Endpoint created');
+    setEndpoints((prev) => [endpoint, ...prev.filter((s) => s.id !== endpoint.id)]);
+    setSelected(endpoint);
+    // Reconcile with the server (templates may have shifted) without blocking
+    // on it — the local row already renders.
+    void load();
+  }
+
+  return (
+    <div className="content">
+      <main>
+        <h1 className="sg-page-title">MCP setup</h1>
+        <p className="sg-page-intro">
+          Pick an endpoint, copy its MCP URL into your client, and manage what you
+          have connected. Per-client install snippets and key minting live on{' '}
+          <strong>MCP client setup</strong>.
+        </p>
+
+        <section className="dash-panel">
+          <div className="dash-panel__head">
+            <h2 className="dash-panel__title">Endpoints</h2>
+            <button
+              type="button"
+              className="sg-btn sg-btn--black sg-btn--sm"
+              onClick={() => setWizardOpen(true)}
+            >
+              Add endpoint
+            </button>
+          </div>
+
+          <McpEndpointList
+            templates={templates}
+            endpoints={endpoints}
+            selectedId={selected?.id ?? null}
+            onSelect={setSelected}
+          />
+
+          {selected ? (
+            <div className="authz-reveal">
+              <div className="authz-reveal__label">MCP URL</div>
+              <div className="authz-reveal__row">
+                <code className="authz-reveal__key font-mono">{selected.url}</code>
+                <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={copyUrl}>
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p className="sg-page-intro">Loading standard Tobor Locker endpoint…</p>
+          )}
+        </section>
+
+        <section className="dash-panel" style={{ marginTop: 'var(--space-4)' }}>
+          <div className="dash-panel__head">
+            <h2 className="dash-panel__title">Connected clients</h2>
+            <span className="dash-badge">{connections.length}</span>
+          </div>
+          <p className="sg-page-intro" style={{ marginBottom: 12 }}>
+            Clients you allowed via OAuth. Revoke to cut a client off immediately
+            (its refresh tokens stop working).
+          </p>
+          {connections.length === 0 ? (
+            <p className="sg-page-intro">No connections yet.</p>
+          ) : (
+            <ul className="admin-table-wrap">
+              {connections.map((connection) => (
+                <li key={connection.grant_id} className="gh-row">
+                  <div className="gh-row__main">
+                    <div className="gh-row__title font-mono">{connection.client_id}</div>
+                    <div className="gh-row__sub font-mono">{connection.resource}</div>
+                    <span className="gh-row__sub">
+                      {connection.scope} · grant {connection.grant_id}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className="sg-btn sg-btn--outline sg-btn--sm"
+                    onClick={() => revoke(connection.grant_id)}
+                  >
+                    Revoke
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <EndpointWizard
+          open={wizardOpen}
+          catalog={catalog}
+          onClose={() => setWizardOpen(false)}
+          onCreated={wizardCreated}
+        />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/mcp-config/display-fieldset.tsx
+++ b/frontend/src/components/mcp-config/display-fieldset.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { api, ENDPOINT_IMAGE_TYPES, type McpScopeDisplay } from '@/lib/api';
+import { parseMediaRef } from '@/lib/mcp-setup';
+
+/**
+ * Alacarte endpoint display editor — the reserved `config.display` key
+ * ({image, emoji, color}). Image uploads go through the media domain
+ * (presign → S3 PUT → register, via api.uploadEndpointImage) and preview as
+ * the same 48px thumb the endpoint lists render; emoji and color are the
+ * fallback glyphs when no image is set.
+ */
+export interface DisplayFieldsetProps {
+  value: McpScopeDisplay | null | undefined;
+  onChange: (next: McpScopeDisplay | null) => void;
+  /** Owning org id — org uploads register "org" visibility so every org
+   * member's <img> render resolves; null registers private. */
+  ownerOrgId?: string | null;
+  disabled?: boolean;
+  idPrefix?: string;
+}
+
+export default function DisplayFieldset({
+  value,
+  onChange,
+  ownerOrgId = null,
+  disabled = false,
+  idPrefix = 'display',
+}: DisplayFieldsetProps) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const thumb = parseMediaRef(value?.image).thumb;
+  const emoji = value?.emoji ?? '';
+  const color = value?.color ?? '';
+  // input[type=color] only accepts #rrggbb; stored CSS names / #rgb fall back
+  // for the picker while the text field keeps the real value.
+  const pickerColor = /^#[0-9a-fA-F]{6}$/.test(color) ? color : '#7c3aed';
+
+  function patch(next: Partial<McpScopeDisplay>) {
+    const merged: McpScopeDisplay = { ...(value ?? {}), ...next };
+    const pruned: McpScopeDisplay = {};
+    if (merged.image) pruned.image = merged.image;
+    if (merged.emoji) pruned.emoji = merged.emoji;
+    if (merged.color) pruned.color = merged.color;
+    onChange(Object.keys(pruned).length > 0 ? pruned : null);
+  }
+
+  async function onFile(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    setUploading(true);
+    try {
+      const shortId = await api.uploadEndpointImage(file, { organizationId: ownerOrgId });
+      patch({ image: shortId });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Image upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+        {thumb ? (
+          <img
+            src={thumb}
+            alt="Endpoint image"
+            width={48}
+            height={48}
+            style={{
+              borderRadius: 8,
+              objectFit: 'cover',
+              border: '1px solid var(--border)',
+              flexShrink: 0,
+            }}
+          />
+        ) : (
+          <div
+            aria-hidden
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 8,
+              border: '1px dashed var(--border)',
+              background: color || 'var(--bg-3, #fafafa)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: emoji ? 22 : 16,
+              color: color ? '#fff' : 'var(--text-3)',
+              flexShrink: 0,
+            }}
+          >
+            {emoji || (value?.image ? '' : '—')}
+          </div>
+        )}
+        <input
+          ref={fileRef}
+          type="file"
+          accept={ENDPOINT_IMAGE_TYPES.join(',')}
+          onChange={onFile}
+          hidden
+        />
+        <button
+          type="button"
+          className="sg-btn sg-btn--outline sg-btn--sm"
+          disabled={disabled || uploading}
+          onClick={() => fileRef.current?.click()}
+        >
+          {uploading ? 'Uploading…' : thumb ? 'Replace image' : 'Upload image'}
+        </button>
+        {thumb ? (
+          <button
+            type="button"
+            className="sg-btn sg-btn--outline sg-btn--sm"
+            disabled={disabled || uploading}
+            onClick={() => patch({ image: undefined })}
+          >
+            Remove
+          </button>
+        ) : null}
+      </div>
+      <span className="sg-field__hint">
+        PNG, JPEG, WebP, or GIF up to 2 MB — shown as a 48px avatar in endpoint lists.
+      </span>
+
+      <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+        <div className="sg-field" style={{ marginBottom: 0 }}>
+          <label htmlFor={`${idPrefix}-emoji`}>Emoji</label>
+          <input
+            id={`${idPrefix}-emoji`}
+            value={emoji}
+            maxLength={4}
+            placeholder="One emoji"
+            disabled={disabled}
+            onChange={(e) => patch({ emoji: e.target.value })}
+            style={{ width: 110 }}
+          />
+        </div>
+
+        <div className="sg-field" style={{ marginBottom: 0 }}>
+          <label htmlFor={`${idPrefix}-color`}>Color</label>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <input
+              id={`${idPrefix}-color-picker`}
+              type="color"
+              value={pickerColor}
+              disabled={disabled}
+              onChange={(e) => patch({ color: e.target.value })}
+              aria-label="Pick a color"
+              style={{
+                width: 36,
+                height: 30,
+                padding: 0,
+                border: '1px solid var(--border)',
+                borderRadius: 6,
+                background: 'none',
+                cursor: disabled ? 'default' : 'pointer',
+              }}
+            />
+            <input
+              className="gh-add-form__input font-mono"
+              value={color}
+              maxLength={32}
+              placeholder="#7c3aed"
+              disabled={disabled}
+              aria-label="Color hex or CSS name"
+              onChange={(e) => patch({ color: e.target.value })}
+              style={{ width: 120 }}
+            />
+          </div>
+          <span className="sg-field__hint">Backdrop for the emoji / initial.</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/mcp-config/endpoint-wizard-state.test.ts
+++ b/frontend/src/components/mcp-config/endpoint-wizard-state.test.ts
@@ -44,6 +44,8 @@ const initialState = (overrides: Partial<EndpointWizardState> = {}): EndpointWiz
   proposalSummary: null,
   status: 'idle',
   error: null,
+  // Alacarte step-1 display metadata (implementation-added field).
+  display: null,
   ...overrides,
 });
 

--- a/frontend/src/components/mcp-config/endpoint-wizard-state.ts
+++ b/frontend/src/components/mcp-config/endpoint-wizard-state.ts
@@ -18,6 +18,7 @@
 import type {
   ClarifyQuestion,
   McpCustomScopeConfig,
+  McpScopeDisplay,
   ProposedTool,
   SlugAvailabilityResponse,
 } from '@/lib/api';
@@ -50,6 +51,8 @@ export interface EndpointWizardState {
   proposalSummary: string | null;
   status: 'idle' | 'loading-questions' | 'loading-proposal' | 'fallback' | 'submitting';
   error: string | null;
+  // Alacarte: optional display metadata (config.display) collected on step 1.
+  display: McpScopeDisplay | null;
 }
 
 export type WizardAction =
@@ -75,7 +78,11 @@ export type WizardAction =
   // loading-proposal / submitting / idle) for spinner + cancel affordances.
   | { type: 'status'; value: EndpointWizardState['status'] }
   // Implementation-added: proposal round landed — delegates to applyProposal.
-  | { type: 'proposal_received'; tools: ProposedTool[]; summary: string };
+  | { type: 'proposal_received'; tools: ProposedTool[]; summary: string }
+  // Implementation-added (alacarte): step-1 display metadata (config.display);
+  // null clears it. Clone mode ignores display — the copy carries the source
+  // config (display included) verbatim server-side.
+  | { type: 'set_display'; value: McpScopeDisplay | null };
 
 const LLM_UNAVAILABLE_MESSAGE =
   'LLM-powered suggestions are unavailable. Pick tools manually — nothing you entered was lost.';
@@ -94,6 +101,7 @@ export function initialWizardState(): EndpointWizardState {
     proposalSummary: null,
     status: 'idle',
     error: null,
+    display: null,
   };
 }
 
@@ -125,6 +133,9 @@ export function reduceWizard(state: EndpointWizardState, action: WizardAction): 
 
     case 'set_description':
       return { ...state, description: action.value };
+
+    case 'set_display':
+      return { ...state, display: action.value };
 
     case 'set_slug':
       // First manual keystroke permanently stops derivation.

--- a/frontend/src/components/mcp-config/endpoint-wizard.tsx
+++ b/frontend/src/components/mcp-config/endpoint-wizard.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { WizardStepper, type WizardStepDef } from '@/components/kit';
 import ToolPicker from '@/components/mcp-config/tool-picker';
+import DisplayFieldset from '@/components/mcp-config/display-fieldset';
 import {
   initialWizardState,
   proposalToConfig,
@@ -266,7 +267,14 @@ export default function EndpointWizard({
             ? { ...base, source_slug: source.slug }
             : { ...base, source_id: source?.id };
       } else {
-        input = { ...base, config: proposalToConfig(state.selections) };
+        const config = proposalToConfig(state.selections);
+        // Display rides inside the config jsonb (reserved key) so the create
+        // payload carries it in one place. Clone mode sends no config — the
+        // copy inherits the source's config (display included) verbatim.
+        input = {
+          ...base,
+          config: state.display ? { ...config, display: state.display } : config,
+        };
       }
 
       const res = await api.createMcpEndpoint(input);
@@ -307,6 +315,20 @@ export default function EndpointWizard({
             placeholder="What should this endpoint be able to do?"
           />
         </div>
+
+        {/* Alacarte: optional display metadata — stored as config.display.
+            Clone mode omits it: the copy inherits the source config (display
+            included) verbatim server-side. */}
+        {state.mode === 'create' ? (
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>Display (optional)</div>
+            <DisplayFieldset
+              value={state.display}
+              onChange={(next) => dispatch({ type: 'set_display', value: next })}
+              idPrefix="wizard-display"
+            />
+          </div>
+        ) : null}
 
         <div className="sg-field">
           <label htmlFor="wizard-slug">Slug</label>

--- a/frontend/src/components/mcp-config/toolset-url-builder.tsx
+++ b/frontend/src/components/mcp-config/toolset-url-builder.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { api, type McpCustomGroup, type McpCustomScope } from '@/lib/api';
+import {
+  compactToolsetSpec,
+  computeEffectiveTools,
+  encodeToolsetParam,
+  toolSelectionUrl,
+  universeFromCatalog,
+  type ToolsetParamSpec,
+  type ToolsetParamWhiteEntry,
+  type ToolsetUniverseEntry,
+} from '@/lib/mcp-setup';
+
+/**
+ * Alacarte admin URL builder (WP9): compose a `?t=` tool-selection spec from
+ * per-tool Include/Exclude + Visible/Hidden toggles and a default selector,
+ * preview the effective toolset live (computeEffectiveTools — the TS mirror
+ * of the backend compile), and emit the raw JSON, the base64url token, and
+ * the full gateway URL for distribution.
+ *
+ * `?t=` is read once at MCP initialize (session snapshot): clients must
+ * reconnect to pick up a changed URL.
+ */
+
+// Preview-side preset registry. Names mirror the backend `@presets` registry
+// (core / full / basic_crud); `core` mirrors the backend named-subset policy.
+// `full` expands to the endpoint catalog's group list at load time, so only
+// unknown presets (e.g. basic_crud) resolve server-side and stay approximate.
+const PREVIEW_PRESETS: Record<string, string[]> = {
+  core: [
+    'Organization_Overview',
+    'Organization_Get',
+    'Project_Overview',
+    'Project_Get',
+    'Session_Create',
+    'Session_Overview',
+    'Session_Manifest',
+  ],
+};
+
+const DEFAULT_OPTIONS = [
+  { value: 'true', label: 'Endpoint default (stored config)' },
+  { value: 'basic_crud', label: 'basic_crud preset' },
+  { value: 'core', label: 'core preset' },
+  { value: 'full', label: 'full preset' },
+] as const;
+
+type DefaultMode = (typeof DEFAULT_OPTIONS)[number]['value'];
+
+/**
+ * Per-tool builder state — only tools the admin touched appear here.
+ * `selection` distinguishes "never touched" from an explicit Exclude (Include
+ * toggled off), so a Visible-only tweak never widens into a black-list entry.
+ */
+interface ToolRowState {
+  selection: 'default' | 'included' | 'excluded';
+  visible: boolean;
+}
+
+function canon(name: string): string {
+  return name.replace(/\./g, '_');
+}
+
+function buildSpec(rows: Record<string, ToolRowState>, defaultMode: DefaultMode): ToolsetParamSpec {
+  const white_list: ToolsetParamWhiteEntry[] = [];
+  const black_list: string[] = [];
+  const tools: Record<string, { visible?: boolean }> = {};
+
+  for (const [name, row] of Object.entries(rows)) {
+    if (row.selection === 'included') {
+      white_list.push(row.visible ? name : { name, visible: false });
+    } else if (row.selection === 'excluded') {
+      black_list.push(name);
+    }
+    // Visibility for non-included tools rides the (lowest-precedence) tools
+    // map; included tools carry the flag on their white-list entry. A disabled
+    // (excluded) tool is unlisted anyway, so no flag is needed there.
+    if (row.selection === 'default' && !row.visible) {
+      tools[canon(name)] = { visible: false };
+    }
+  }
+
+  return {
+    // Kebab-case keys per the approved plan (backend decode mirrors them).
+    ...(white_list.length > 0 ? { "white-list": white_list } : {}),
+    ...(black_list.length > 0 ? { "black-list": black_list } : {}),
+    ...(Object.keys(tools).length > 0 ? { tools } : {}),
+    default: defaultMode === 'true' ? true : defaultMode,
+  };
+}
+
+export interface ToolsetUrlBuilderProps {
+  slug: string;
+  onClose: () => void;
+}
+
+export default function ToolsetUrlBuilder({ slug, onClose }: ToolsetUrlBuilderProps) {
+  const [scope, setScope] = useState<McpCustomScope | null>(null);
+  const [catalog, setCatalog] = useState<McpCustomGroup[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [rows, setRows] = useState<Record<string, ToolRowState>>({});
+  const [defaultMode, setDefaultMode] = useState<DefaultMode>('true');
+  const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadError(null);
+    Promise.all([api.adminGetMcpCustomScope(slug), api.adminMcpCustomScopeCatalog()])
+      .then(([scopeRes, catalogRes]) => {
+        if (cancelled) return;
+        setScope(scopeRes.scope);
+        setCatalog(catalogRes.groups ?? []);
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : 'Failed to load endpoint');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  // Param power is bounded by the endpoint's included groups.
+  const universe: ToolsetUniverseEntry[] = useMemo(
+    () => (scope ? universeFromCatalog(catalog, scope.config) : []),
+    [catalog, scope],
+  );
+
+  const spec = useMemo(() => buildSpec(rows, defaultMode), [rows, defaultMode]);
+  const baseline = useMemo(
+    () => (scope ? computeEffectiveTools(scope.config, universe, null) : {}),
+    [scope, universe],
+  );
+  // `full` = every customizable group in the catalog (bounded by the endpoint's
+  // included groups at compile time); core rides PREVIEW_PRESETS.
+  const presets = useMemo(
+    () => ({
+      ...PREVIEW_PRESETS,
+      ...(catalog.length > 0
+        ? { full: catalog.flatMap((group) => group.tools.map((tool) => tool.name)) }
+        : {}),
+    }),
+    [catalog],
+  );
+  const effective = useMemo(
+    () => (scope ? computeEffectiveTools(scope.config, universe, spec, { presets }) : {}),
+    [scope, universe, spec, presets],
+  );
+
+  const hasSelection =
+    defaultMode !== 'true' ||
+    Object.values(rows).some((row) => row.selection !== 'default' || !row.visible);
+  const gatewayUrl = scope?.url || `https://tobor.locker/custom/${encodeURIComponent(slug)}/mcp`;
+  const rawJson = JSON.stringify(compactToolsetSpec(spec));
+  const token = encodeToolsetParam(spec);
+  const fullUrl = toolSelectionUrl(gatewayUrl, spec);
+  const tooLong = fullUrl.length > 2000;
+  const presetApproximate = defaultMode !== 'true' && !(defaultMode in presets);
+
+  const enabledCount = Object.values(effective).filter((flags) => flags.enabled).length;
+
+  async function copy(text: string, id: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(id);
+      setTimeout(() => setCopied(null), 2000);
+      toast.success('Copied');
+    } catch {
+      toast.error('Copy failed — select and copy manually');
+    }
+  }
+
+  function toggleInclude(name: string, include: boolean) {
+    setRows((current) => {
+      const prior = current[name] ?? {
+        selection: 'default' as const,
+        visible: baseline[canon(name)]?.visible ?? true,
+      };
+      return {
+        ...current,
+        [name]: { ...prior, selection: include ? ('included' as const) : ('excluded' as const) },
+      };
+    });
+  }
+
+  function toggleVisible(name: string, visible: boolean) {
+    setRows((current) => {
+      const prior = current[name] ?? {
+        selection: 'default' as const,
+        visible: baseline[canon(name)]?.visible ?? true,
+      };
+      return { ...current, [name]: { ...prior, visible } };
+    });
+  }
+
+  const grouped = useMemo(() => {
+    const byGroup = new Map<string, { label: string; tools: ToolsetUniverseEntry[] }>();
+    for (const entry of universe) {
+      const label = catalog.find((group) => group.id === entry.group)?.label ?? entry.group;
+      const bucket = byGroup.get(entry.group) ?? { label, tools: [] };
+      bucket.tools.push(entry);
+      byGroup.set(entry.group, bucket);
+    }
+    return [...byGroup.values()];
+  }, [universe, catalog]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Tool selection URL builder"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 900,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        padding: '6vh 16px 16px',
+        background: 'rgba(0,0,0,0.5)',
+        overflowY: 'auto',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="dash-panel"
+        style={{ width: '100%', maxWidth: 760, background: 'var(--bg-1, #fff)', padding: 16 }}
+      >
+        <div className="dash-panel__head">
+          <h2 className="dash-panel__title">
+            Tool selection URL{scope ? ` — ${scope.name}` : ''}
+          </h2>
+          <button type="button" className="sg-btn sg-btn--outline sg-btn--sm" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <p className="sg-page-intro" style={{ marginTop: 0 }}>
+          Compose a per-client <span className="font-mono">?t=</span> tool selection for this
+          endpoint&apos;s gateway URL. Power is bounded by the endpoint&apos;s included groups;
+          ACL rules still apply last.
+        </p>
+
+        {loadError ? (
+          <p role="alert" className="sg-page-intro">
+            {loadError}
+          </p>
+        ) : !scope ? (
+          <p className="sg-page-intro">Loading endpoint…</p>
+        ) : (
+          <div style={{ display: 'grid', gap: 16 }}>
+            <div className="sg-field" style={{ marginBottom: 0 }}>
+              <label htmlFor="toolset-default">Default set</label>
+              <select
+                id="toolset-default"
+                value={defaultMode}
+                onChange={(e) => setDefaultMode(e.target.value as DefaultMode)}
+              >
+                {DEFAULT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <span className="sg-field__hint">
+                What tools fall back to when the white-list does not mention them. The endpoint
+                default is its stored config; presets resolve server-side at connect time.
+              </span>
+            </div>
+
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>
+                Per-tool selection
+              </div>
+              {universe.length === 0 ? (
+                <p className="sg-page-intro" style={{ margin: 0 }}>
+                  No tools available — include a group on the endpoint first.
+                </p>
+              ) : (
+                <div style={{ display: 'grid', gap: 10 }}>
+                  {grouped.map((group) => (
+                    <section
+                      key={group.label}
+                      style={{
+                        border: '1px solid var(--border, #e5e5e5)',
+                        borderRadius: 8,
+                        padding: '0.75rem',
+                      }}
+                    >
+                      <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 6 }}>
+                        {group.label}
+                      </div>
+                      <div style={{ display: 'grid', gap: 4 }}>
+                        {group.tools.map((entry) => {
+                          const row = rows[entry.name];
+                          const included = row?.selection === 'included';
+                          const visible = row?.visible ?? baseline[canon(entry.name)]?.visible ?? true;
+                          return (
+                            <div
+                              key={entry.name}
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 16,
+                                flexWrap: 'wrap',
+                                fontSize: 13,
+                              }}
+                            >
+                              <span
+                                className="font-mono"
+                                style={{ minWidth: 220, fontSize: 12 }}
+                                title={entry.name}
+                              >
+                                {entry.name}
+                              </span>
+                              <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                                <input
+                                  type="checkbox"
+                                  checked={included}
+                                  onChange={(e) => toggleInclude(entry.name, e.target.checked)}
+                                />
+                                Include
+                              </label>
+                              <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                                <input
+                                  type="checkbox"
+                                  checked={visible}
+                                  onChange={(e) => toggleVisible(entry.name, e.target.checked)}
+                                />
+                                Visible
+                              </label>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>
+                Effective preview
+              </div>
+              {presetApproximate ? (
+                <p className="sg-page-intro" style={{ marginTop: 0 }}>
+                  Approximate: the <span className="font-mono">{defaultMode}</span> preset&apos;s
+                  tools resolve from the server registry at connect time — the preview shows your
+                  explicit selections plus the endpoint default.
+                </p>
+              ) : null}
+              <p style={{ margin: '0 0 8px', fontSize: 12, color: 'var(--text-2)' }}>
+                {enabledCount} of {Object.keys(effective).length} tools enabled for a client
+                connecting with this URL.
+              </p>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {Object.entries(effective).map(([name, flags]) => (
+                  <span
+                    key={name}
+                    className="font-mono"
+                    style={{
+                      fontSize: 11,
+                      padding: '2px 8px',
+                      borderRadius: 999,
+                      border: '1px solid var(--border)',
+                      opacity: flags.enabled ? 1 : 0.45,
+                      textDecoration: flags.enabled && flags.visible ? 'none' : 'line-through',
+                    }}
+                    title={`${name}: ${flags.enabled ? 'enabled' : 'disabled'}, ${
+                      flags.visible ? 'visible' : 'hidden'
+                    }`}
+                  >
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {hasSelection ? (
+              <>
+                <OutputRow
+                  id="raw-json"
+                  label="Raw JSON"
+                  value={rawJson}
+                  copied={copied}
+                  onCopy={copy}
+                />
+                <OutputRow
+                  id="token"
+                  label="?t= token (base64url)"
+                  value={token}
+                  copied={copied}
+                  onCopy={copy}
+                />
+                <OutputRow
+                  id="full-url"
+                  label="Gateway URL with selection"
+                  value={fullUrl}
+                  copied={copied}
+                  onCopy={copy}
+                />
+                {tooLong ? (
+                  <p role="alert" style={{ color: 'var(--text-3)', fontSize: 12, margin: 0 }}>
+                    Warning: this URL is {fullUrl.length} characters — some MCP clients reject
+                    URLs over 2000. Trim selections or use a preset default to shorten it.
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <p className="sg-page-intro" style={{ margin: 0 }}>
+                No overrides selected — the plain gateway URL already reflects the endpoint
+                config.
+              </p>
+            )}
+
+            <p className="sg-page-intro" style={{ margin: 0 }}>
+              The <span className="font-mono">?t=</span> parameter takes effect at connect time —
+              it is read once when the client initializes its session. Reconnect to apply a
+              changed URL.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OutputRow({
+  id,
+  label,
+  value,
+  copied,
+  onCopy,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  copied: string | null;
+  onCopy: (text: string, id: string) => void;
+}) {
+  return (
+    <div className="authz-reveal">
+      <div className="authz-reveal__label">{label}</div>
+      <div className="authz-reveal__row">
+        <code
+          className="authz-reveal__key font-mono"
+          style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}
+        >
+          {value}
+        </code>
+        <button
+          type="button"
+          className="sg-btn sg-btn--outline sg-btn--sm"
+          onClick={() => onCopy(value, id)}
+        >
+          {copied === id ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/mcp-endpoint-list.tsx
+++ b/frontend/src/components/mcp-endpoint-list.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import type { McpCustomScope } from '@/lib/api';
+import { parseMediaRef } from '@/lib/mcp-setup';
+
+/**
+ * Visual endpoint picker shared by the MCP client-setup page and the endpoint
+ * manager (it replaces the old native <select>): 48px display thumb —
+ * config.display image → emoji on its color backdrop → initial letter — plus
+ * name, the /custom/<slug>/mcp gateway line, and the default badge. The
+ * yours / organization / templates groupings from the select are preserved.
+ */
+export interface McpEndpointListProps {
+  templates: McpCustomScope[];
+  endpoints: McpCustomScope[];
+  selectedId?: string | null;
+  onSelect: (scope: McpCustomScope) => void;
+}
+
+/** Display thumb per the alacarte precedence: image → emoji on color → initial. */
+export function EndpointThumb({ scope, size = 48 }: { scope: McpCustomScope; size?: number }) {
+  const display = scope.config?.display;
+  const media = parseMediaRef(display?.image);
+  if (media.thumb) {
+    return (
+      <img
+        src={media.thumb}
+        alt=""
+        width={size}
+        height={size}
+        style={{
+          borderRadius: 8,
+          objectFit: 'cover',
+          border: '1px solid var(--border)',
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+  const emoji = display?.emoji;
+  const background = display?.color || 'var(--bg-3, #fafafa)';
+  const glyph = emoji || (scope.name?.trim()?.[0] ?? '?').toUpperCase();
+  return (
+    <div
+      aria-hidden
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 8,
+        background,
+        color: display?.color ? '#fff' : 'var(--text-2)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: emoji ? Math.round(size * 0.5) : Math.round(size * 0.4),
+        flexShrink: 0,
+      }}
+    >
+      {glyph}
+    </div>
+  );
+}
+
+export default function McpEndpointList({
+  templates,
+  endpoints,
+  selectedId,
+  onSelect,
+}: McpEndpointListProps) {
+  const groups: { label: string; rows: McpCustomScope[] }[] = [
+    { label: 'Your endpoints', rows: endpoints.filter((s) => s.owner_kind !== 'organization') },
+    { label: 'Organization', rows: endpoints.filter((s) => s.owner_kind === 'organization') },
+    { label: 'Standard templates', rows: templates },
+  ];
+
+  return (
+    <div style={{ display: 'grid', gap: 14, marginBottom: 12 }}>
+      {groups
+        .filter((group) => group.rows.length > 0)
+        .map((group) => (
+          <div key={group.label}>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: 0.5,
+                color: 'var(--text-3)',
+                marginBottom: 6,
+              }}
+            >
+              {group.label}
+            </div>
+            <div style={{ display: 'grid', gap: 6 }}>
+              {group.rows.map((scope) => {
+                const isCurrent = scope.id === selectedId;
+                return (
+                  <button
+                    key={scope.id}
+                    type="button"
+                    aria-pressed={isCurrent}
+                    onClick={() => onSelect(scope)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 12,
+                      width: '100%',
+                      textAlign: 'left',
+                      padding: '8px 10px',
+                      borderRadius: 10,
+                      border: `1px solid ${isCurrent ? 'var(--accent)' : 'var(--border)'}`,
+                      background: isCurrent ? 'var(--accent-dim, var(--bg-3, #fafafa))' : 'transparent',
+                      cursor: 'pointer',
+                      color: 'inherit',
+                      font: 'inherit',
+                    }}
+                  >
+                    <EndpointThumb scope={scope} />
+                    <span style={{ minWidth: 0, flex: 1 }}>
+                      <span
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 8,
+                          minWidth: 0,
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontWeight: 600,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {scope.name}
+                        </span>
+                        {scope.is_default ? <span className="dash-badge">default</span> : null}
+                        {group.label === 'Standard templates' && scope.slug === 'tobor' ? (
+                          <span className="dash-badge">standard</span>
+                        ) : null}
+                      </span>
+                      <span
+                        className="font-mono"
+                        style={{
+                          display: 'block',
+                          fontSize: 12,
+                          color: 'var(--text-3)',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        /custom/{scope.slug}/mcp
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/frontend/src/components/mcp-endpoint-manager.tsx
+++ b/frontend/src/components/mcp-endpoint-manager.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/api';
 import McpIncludeEditor from '@/components/mcp-include-editor';
 import EndpointWizard from '@/components/mcp-config/endpoint-wizard';
+import McpEndpointList from '@/components/mcp-endpoint-list';
 import type { WizardSource } from '@/components/mcp-config/endpoint-wizard-state';
 
 interface McpEndpointManagerProps {
@@ -232,47 +233,17 @@ export default function McpEndpointManager({
         </button>
       </div>
 
-      <div className="sg-field" style={{ marginBottom: 12 }}>
-        <label htmlFor="mcp-endpoint-select">Endpoint</label>
-        <select
-          id="mcp-endpoint-select"
-          value={current?.id ?? ''}
-          onChange={(e) => {
-            const next = all.find((s) => s.id === e.target.value);
-            if (!next) return;
-            onSelect(next);
-            setName(next.name);
-          }}
-        >
-          {endpoints.length > 0 ? (
-            <optgroup label="Your endpoints">
-              {endpoints.filter((s) => s.owner_kind !== 'organization').map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}{s.is_default ? ' (default)' : ''} — /custom/{s.slug}/mcp
-                </option>
-              ))}
-            </optgroup>
-          ) : null}
-          {endpoints.some((s) => s.owner_kind === 'organization') ? (
-            <optgroup label="Organization">
-              {endpoints.filter((s) => s.owner_kind === 'organization').map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name} — /custom/{s.slug}/mcp
-                </option>
-              ))}
-            </optgroup>
-          ) : null}
-          {templates.length > 0 ? (
-            <optgroup label="Standard templates">
-              {templates.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}{s.slug === 'tobor' ? ' (standard)' : ''} — /custom/{s.slug}/mcp
-                </option>
-              ))}
-            </optgroup>
-          ) : null}
-        </select>
-      </div>
+      {/* Alacarte: visual picker (display thumb / emoji / color) replaces the
+          native select; groupings + selection semantics unchanged. */}
+      <McpEndpointList
+        templates={templates}
+        endpoints={endpoints}
+        selectedId={current?.id ?? null}
+        onSelect={(next) => {
+          onSelect(next);
+          setName(next.name);
+        }}
+      />
 
       {current ? (
         <>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -337,6 +337,18 @@ export interface McpCustomGroup {
   tools: McpCustomTool[];
 }
 
+// Alacarte endpoint display metadata — the reserved `display` key inside the
+// config jsonb (sanitized server-side; write paths must send it nested in
+// config or the backend normalize drops it).
+export interface McpScopeDisplay {
+  /** Media `short_id` (api.uploadEndpointImage) or an absolute http(s) URL. */
+  image?: string;
+  /** Short fallback glyph rendered on the color backdrop (≤4 chars). */
+  emoji?: string;
+  /** CSS color (hex or name) — backdrop for the emoji/initial thumb. */
+  color?: string;
+}
+
 export interface McpCustomScopeConfig {
   groups: Record<string, {
     disabled?: boolean;
@@ -354,6 +366,7 @@ export interface McpCustomScopeConfig {
       enabled_at?: string;
     }>;
   }>;
+  display?: McpScopeDisplay;
 }
 
 export interface McpCustomScope {
@@ -1624,6 +1637,11 @@ function buildQuery(params: Record<string, string | string[] | number | undefine
   return s ? `?${s}` : '';
 }
 
+// Endpoint display images (alacarte): client-side caps only — the media
+// domain enforces no size limit of its own.
+export const ENDPOINT_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+export const ENDPOINT_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+
 export const api = {
   login(email: string, password: string) {
     return request<AuthResponse>("/api/v1/auth/login", {
@@ -1792,6 +1810,62 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ key }),
     });
+  },
+
+  // ── Alacarte endpoint display images: presign → S3 PUT → register. ──
+
+  registerMedia(input: {
+    key: string;
+    filename: string;
+    visibility: "private" | "org";
+    organization_id?: string;
+    content_type?: string;
+  }) {
+    return request<{ short_id: string }>("/api/v1/media/register", {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  },
+
+  /**
+   * Validate → presign → PUT bytes → register; returns the media `short_id`
+   * for config.display.image. Size/type caps are client-side only (the media
+   * domain has no server-side limit). Org-owned endpoints register "org"
+   * visibility so every org member's `<img>` render resolves; personal ones
+   * stay "private".
+   */
+  async uploadEndpointImage(
+    file: File,
+    owner?: { organizationId?: string | null } | null,
+  ): Promise<string> {
+    if (file.size > ENDPOINT_IMAGE_MAX_BYTES) {
+      throw new Error("Image must be 2 MB or smaller");
+    }
+    if (!ENDPOINT_IMAGE_TYPES.includes(file.type)) {
+      throw new Error("Use a PNG, JPEG, WebP, or GIF image");
+    }
+    const presign = await request<{ upload_url: string; key: string }>("/api/v1/media/presign", {
+      method: "POST",
+      body: JSON.stringify({ filename: file.name, content_type: file.type }),
+    });
+    const put = await fetch(presign.upload_url, {
+      method: "PUT",
+      body: file,
+      headers: { "Content-Type": file.type },
+    });
+    if (!put.ok) throw new Error(`Image upload failed (${put.status})`);
+    const organizationId = owner?.organizationId || undefined;
+    const registered = await request<{ short_id: string }>("/api/v1/media/register", {
+      method: "POST",
+      body: JSON.stringify({
+        key: presign.key,
+        filename: file.name,
+        visibility: organizationId ? "org" : "private",
+        ...(organizationId ? { organization_id: organizationId } : {}),
+        content_type: file.type,
+      }),
+    });
+    return registered.short_id;
   },
 
   adminListUsers(page = 1, perPage = 50) {

--- a/frontend/src/lib/mcp-setup.test.ts
+++ b/frontend/src/lib/mcp-setup.test.ts
@@ -8,6 +8,7 @@ import {
   mcpOauthHint,
   mcpOauthServerName,
   mcpOauthSnippet,
+  toolSelectionUrl,
   type McpOauthClient,
 } from './mcp-setup';
 
@@ -81,4 +82,15 @@ test('every OAuth client has a dedicated snippet builder', () => {
   for (const id of ids) {
     assert.ok(mcpOauthSnippet(id, NAME, URL).includes(NAME));
   }
+});
+
+// ── Alacarte WP5: ?t= tool-selection URLs ride the same snippet path ─────────
+
+test('a tool-selection URL is a plain MCP URL plus a url-safe ?t= token', () => {
+  const selectionUrl = toolSelectionUrl(URL, { "white-list": ['Ticket_Create'] });
+  assert.match(selectionUrl, /^https:\/\/tobor\.locker\/custom\/tobor\/mcp\?t=[A-Za-z0-9_-]+$/);
+  const snippet = mcpOauthSnippet('claude-code', NAME, selectionUrl);
+  assert.match(snippet, /t=[A-Za-z0-9_-]+/);
+  const token = selectionUrl.split('?t=')[1];
+  assert.ok(token && !/[+/=]/.test(token), 'token stays URL-path/query safe');
 });

--- a/frontend/src/lib/mcp-setup.ts
+++ b/frontend/src/lib/mcp-setup.ts
@@ -1,3 +1,5 @@
+import type { McpCustomGroup, McpCustomScopeConfig } from '@/lib/api';
+
 /**
  * Env var name for the MCP bearer token in generated setup snippets.
  *
@@ -85,4 +87,257 @@ export function mcpOauthSnippet(client: McpOauthClient, name: string, url: strin
     case 'grok':
       return `grok mcp add --transport http ${name} ${url}`;
   }
+}
+
+// ── Alacarte: ?t= tool-selection params + endpoint display media ────────────
+
+/**
+ * A `?t=` tool-selection spec for custom-scope gateways. Shape mirrors the
+ * backend `NoizuPromptLingua.MCP.UrlToolsetParam` decode schema. Kebab-case
+ * keys are canonical (what encodeToolsetParam emits, per the plan's
+ * "white-list" > "black-list" > tools wording); the snake_case aliases are
+ * accepted on input and canonicalized by compactToolsetSpec.
+ */
+export type ToolsetParamWhiteEntry = string | { name: string; visible?: boolean };
+
+export interface ToolsetParamSpec {
+  "white-list"?: ToolsetParamWhiteEntry[];
+  "black-list"?: string[];
+  // Accepted snake_case aliases for the kebab-case keys above.
+  white_list?: ToolsetParamWhiteEntry[];
+  black_list?: string[];
+  tools?: Record<string, { visible?: boolean }>;
+  default?: boolean | string;
+}
+
+/** Canonical underscore tool name (`Session.Create` → `Session_Create`). */
+function canonTool(name: string): string {
+  return name.replace(/\./g, '_');
+}
+
+function normalizeWhiteEntries(spec: ToolsetParamSpec | null | undefined): WhiteEntry[] {
+  const entries: WhiteEntry[] = [];
+  for (const entry of [...(spec?.["white-list"] ?? []), ...(spec?.white_list ?? [])]) {
+    if (typeof entry === 'string') {
+      if (entry.trim() !== '') entries.push({ name: entry });
+    } else if (entry && typeof entry.name === 'string' && entry.name.trim() !== '') {
+      entries.push(
+        entry.visible === undefined ? { name: entry.name } : { name: entry.name, visible: entry.visible },
+      );
+    }
+  }
+  return entries;
+}
+
+interface WhiteEntry {
+  name: string;
+  visible?: boolean;
+}
+
+/** Drop empty keys so the JSON — and therefore the URL token — stays small;
+ * snake_case aliases are canonicalized to kebab-case here. */
+export function compactToolsetSpec(spec: ToolsetParamSpec): ToolsetParamSpec {
+  const out: ToolsetParamSpec = {};
+
+  const white = normalizeWhiteEntries(spec);
+  if (white.length > 0) {
+    out["white-list"] = white.map((entry) =>
+      entry.visible === undefined ? entry.name : { name: entry.name, visible: entry.visible },
+    );
+  }
+
+  const black = [
+    ...(spec["black-list"] ?? []),
+    ...(spec.black_list ?? []),
+  ].filter((name) => typeof name === 'string' && name.trim() !== '');
+  if (black.length > 0) out["black-list"] = black;
+
+  const tools: Record<string, { visible?: boolean }> = {};
+  for (const [name, flags] of Object.entries(spec.tools ?? {})) {
+    if (!flags || flags.visible === undefined) continue;
+    tools[name] = { visible: flags.visible };
+  }
+  if (Object.keys(tools).length > 0) out.tools = tools;
+
+  if (spec.default !== undefined && spec.default !== false) out.default = spec.default;
+  return out;
+}
+
+/**
+ * base64url (no padding — the decoder re-pads and rejects +/) of the compact
+ * JSON spec. UTF-8-safe via the classic btoa(unescape(encodeURIComponent())).
+ */
+export function encodeToolsetParam(spec: ToolsetParamSpec): string {
+  const json = JSON.stringify(compactToolsetSpec(spec));
+  return btoa(unescape(encodeURIComponent(json)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/** Full gateway URL with the `?t=` token appended (? or & as appropriate). */
+export function toolSelectionUrl(path: string, spec: ToolsetParamSpec): string {
+  const sep = path.includes('?') ? '&' : '?';
+  return `${path}${sep}t=${encodeToolsetParam(spec)}`;
+}
+
+// Media refs (endpoint display images).
+
+// Mirrors lib/api's API_URL: empty on the client (same-origin), absolute when
+// server-rendered with NEXT_PUBLIC_API_URL set.
+const MEDIA_API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+export interface MediaRefUrls {
+  thumb: string | null;
+  banner: string | null;
+}
+
+/**
+ * Endpoint display image refs are media `short_id`s (from
+ * api.uploadEndpointImage) — rendered as `/media/:short_id` variants — or
+ * plain http(s) URLs, which pass through unchanged.
+ */
+export function parseMediaRef(ref?: string | null): MediaRefUrls {
+  const value = (ref ?? '').trim();
+  if (value === '') return { thumb: null, banner: null };
+  if (/^https?:\/\//i.test(value)) return { thumb: value, banner: value };
+  const shortId = value.replace(/^\/media\//, '');
+  return {
+    thumb: `${MEDIA_API_URL}/media/${encodeURIComponent(shortId)}?w=200&f=webp`,
+    banner: `${MEDIA_API_URL}/media/${encodeURIComponent(shortId)}?w=1600&fit=cover`,
+  };
+}
+
+// Effective-toolset preview (TS mirror of the backend compile).
+
+/** One available tool, bounded to the endpoint's included groups. */
+export interface ToolsetUniverseEntry {
+  group: string;
+  name: string;
+  /** Catalog default visibility (`tool.hidden`); absent = visible. */
+  catalogHidden?: boolean;
+}
+
+export interface EffectiveToolFlags {
+  enabled: boolean;
+  visible: boolean;
+}
+
+export interface ToolsetCompileOptions {
+  /** Preset name → tool names, mirroring the backend `@presets` registry. */
+  presets?: Record<string, string[]>;
+}
+
+function storedToolEntry(
+  config: McpCustomScopeConfig | null | undefined,
+  group: string,
+  name: string,
+) {
+  const tools = config?.groups?.[group]?.tools ?? {};
+  const canonical = canonTool(name);
+  return tools[name] ?? tools[canonical];
+}
+
+/**
+ * Group-bounded universe: only tools of groups the scope config includes
+ * (group present and not `disabled`). Everything else is outside the param's
+ * power — the param narrows within this set, never widens past it.
+ */
+export function universeFromCatalog(
+  catalog: McpCustomGroup[],
+  scopeConfig: McpCustomScopeConfig | null | undefined,
+): ToolsetUniverseEntry[] {
+  const entries: ToolsetUniverseEntry[] = [];
+  for (const group of catalog) {
+    const groupEntry = scopeConfig?.groups?.[group.id];
+    if (!groupEntry || groupEntry.disabled === true) continue;
+    for (const tool of group.tools) {
+      entries.push({ group: group.id, name: tool.name, catalogHidden: tool.hidden });
+    }
+  }
+  return entries;
+}
+
+/**
+ * TS mirror of `UrlToolsetParam.compile/2` for live admin preview — keep in
+ * lockstep with the backend or the golden vectors drift. Accepts both
+ * kebab-case (canonical) and snake_case top-level keys. Precedence:
+ *
+ *   1) white-list / `default` define the enable set (absent-from-set →
+ *      disabled; white-listed tools re-enable stored-disabled entries).
+ *      `default: true` expands to the stored-config enabled set; preset
+ *      names expand from `opts.presets` (unknown presets expand empty).
+ *   2) black-list disables unless the tool is explicitly white-listed
+ *      (default-expanded tools do NOT count as white-listed).
+ *   3) white-list entry `visible` flags set visibility for that tool.
+ *   4) `tools` map is lowest — applies only when no white-list constrains;
+ *      `visible: true` re-enables a stored-disabled tool within the universe.
+ *
+ * Unknown names are dead entries: they never appear in the result. Returns
+ * flags keyed by canonical tool name. Absent/empty spec = the stored-config
+ * baseline (byte-identical no-param behavior).
+ */
+export function computeEffectiveTools(
+  scopeConfig: McpCustomScopeConfig | null | undefined,
+  universe: ToolsetUniverseEntry[],
+  spec: ToolsetParamSpec | null | undefined,
+  opts: ToolsetCompileOptions = {},
+): Record<string, EffectiveToolFlags> {
+  const result: Record<string, EffectiveToolFlags> = {};
+  const baseline = new Map<string, EffectiveToolFlags>();
+  for (const entry of universe) {
+    const key = canonTool(entry.name);
+    if (baseline.has(key)) continue;
+    const stored = storedToolEntry(scopeConfig, entry.group, entry.name);
+    const hidden = stored?.hidden ?? entry.catalogHidden === true;
+    baseline.set(key, { enabled: stored?.disabled !== true, visible: !hidden });
+  }
+
+  const whiteEntries = normalizeWhiteEntries(spec);
+  const whiteNames = new Set(whiteEntries.map((entry) => canonTool(entry.name)));
+  const blackNames = new Set(
+    [...(spec?.["black-list"] ?? []), ...(spec?.black_list ?? [])].map(canonTool),
+  );
+  const toolsMap = spec?.tools ?? {};
+  const hasWhite = whiteNames.size > 0;
+  const hasDefault = spec?.default !== undefined && spec.default !== false;
+
+  let enableSet: Set<string> | null = null;
+  if (hasWhite || hasDefault) {
+    enableSet = new Set(whiteNames);
+    if (hasDefault && spec!.default === true) {
+      for (const [key, flags] of baseline) {
+        if (flags.enabled) enableSet.add(key);
+      }
+    } else if (hasDefault && typeof spec!.default === 'string') {
+      for (const name of opts.presets?.[spec!.default] ?? []) enableSet.add(canonTool(name));
+    }
+  }
+
+  for (const [key, base] of baseline) {
+    let enabled = base.enabled;
+    let visible = base.visible;
+
+    if (enableSet) {
+      // Absent-from-set → disabled; white-listed re-enables stored-disabled.
+      enabled = enableSet.has(key);
+    }
+
+    // Black-list loses to an explicit white-list entry.
+    if (blackNames.has(key) && !(hasWhite && whiteNames.has(key))) enabled = false;
+
+    if (hasWhite) {
+      const entry = whiteEntries.find((e) => canonTool(e.name) === key);
+      if (entry?.visible !== undefined) visible = entry.visible;
+    } else {
+      const flags = toolsMap[key];
+      if (flags?.visible !== undefined) {
+        visible = flags.visible;
+        if (flags.visible) enabled = true; // re-enable stored-disabled, in-universe
+      }
+    }
+
+    result[key] = { enabled, visible };
+  }
+  return result;
 }

--- a/frontend/src/lib/tool-overrides.ts
+++ b/frontend/src/lib/tool-overrides.ts
@@ -73,6 +73,9 @@ function pruneEntry(entry: ScopeToolEntry): ScopeToolEntry | undefined {
 
 function cloneConfig(config: McpCustomScopeConfig): McpCustomScopeConfig {
   return {
+    // Reserved `display` key rides along untouched — these helpers only ever
+    // touch `groups`.
+    ...(config.display ? { display: config.display } : {}),
     groups: Object.fromEntries(
       Object.entries(config.groups ?? {}).map(([groupId, group]) => [
         groupId,

--- a/frontend/src/lib/toolset-param.test.ts
+++ b/frontend/src/lib/toolset-param.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Alacarte WP5 contract tests: the `?t=` toolset param encoder and the TS
+ * compile mirror (`computeEffectiveTools`). The precedence golden vectors
+ * mirror the backend `UrlToolsetParam` ExUnit vectors — white-list beats
+ * black-list; `{"default":"core"}` preset expansion; tools-map `visible`
+ * re-enable without a constraining white-list. Keep both sides in lockstep.
+ *
+ * Pure logic only — node test runner, no DOM, no network.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  compactToolsetSpec,
+  computeEffectiveTools,
+  encodeToolsetParam,
+  parseMediaRef,
+  toolSelectionUrl,
+  universeFromCatalog,
+  type ToolsetParamSpec,
+  type ToolsetUniverseEntry,
+} from './mcp-setup';
+
+const UNIVERSE: ToolsetUniverseEntry[] = [
+  { group: 'sessions', name: 'Session_Create' },
+  { group: 'sessions', name: 'Session_Overview' },
+  { group: 'orgs', name: 'Organization_Get' },
+];
+
+const NO_CONFIG = { groups: {} };
+
+// ── encoder ──────────────────────────────────────────────────────────────────
+
+function decodeToken(token: string): unknown {
+  const padded = token.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (token.length % 4)) % 4);
+  return JSON.parse(decodeURIComponent(escape(atob(padded))));
+}
+
+test('encodeToolsetParam: base64url without padding, JSON round-trips', () => {
+  const spec: ToolsetParamSpec = {
+    "white-list": ['Session_Create', { name: 'Session_Overview', visible: false }],
+    "black-list": ['Organization_Get'],
+    tools: { Org_Search: { visible: true } },
+    default: 'core',
+  };
+  const token = encodeToolsetParam(spec);
+  assert.ok(!token.includes('+'), 'no + (charset guard)');
+  assert.ok(!token.includes('/'), 'no / (charset guard)');
+  assert.ok(!token.includes('='), 'no padding');
+  assert.match(token, /^[A-Za-z0-9_-]+$/);
+  assert.deepEqual(decodeToken(token), {
+    "white-list": ['Session_Create', { name: 'Session_Overview', visible: false }],
+    "black-list": ['Organization_Get'],
+    tools: { Org_Search: { visible: true } },
+    default: 'core',
+  });
+});
+
+test('encodeToolsetParam: unicode emoji in the JSON survives the round-trip', () => {
+  const spec: ToolsetParamSpec = { "white-list": ['Résumé_⚡Generate'] };
+  const token = encodeToolsetParam(spec);
+  assert.deepEqual(decodeToken(token), { "white-list": ['Résumé_⚡Generate'] });
+});
+
+test('compactToolsetSpec drops empty keys so short specs stay short', () => {
+  assert.deepEqual(compactToolsetSpec({}), {});
+  assert.deepEqual(compactToolsetSpec({ "white-list": [], "black-list": [], tools: {} }), {});
+  assert.deepEqual(compactToolsetSpec({ default: false, "white-list": ['A'] }), { "white-list": ['A'] });
+  assert.deepEqual(compactToolsetSpec({ tools: { A: {} } }), {});
+});
+
+test('snake_case keys are accepted and canonicalized to kebab-case', () => {
+  assert.deepEqual(
+    compactToolsetSpec({ white_list: ['Session_Create'], black_list: ['Organization_Get'] }),
+    { "white-list": ['Session_Create'], "black-list": ['Organization_Get'] },
+  );
+  const snake = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { white_list: ['Session_Create'], black_list: ['Session_Create'] },
+  );
+  const kebab = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { "white-list": ['Session_Create'], "black-list": ['Session_Create'] },
+  );
+  assert.deepEqual(snake, kebab);
+  assert.equal(
+    encodeToolsetParam({ white_list: ['Session_Create'] }),
+    encodeToolsetParam({ "white-list": ['Session_Create'] }),
+    'encoder always emits the canonical kebab-case token',
+  );
+});
+
+// ── precedence golden vectors (mirror the backend ExUnit vectors) ────────────
+
+test('golden: white-list beats black-list', () => {
+  const result = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { "white-list": ['Session_Create'], "black-list": ['Session_Create'] },
+  );
+  assert.equal(result.Session_Create.enabled, true);
+  assert.equal(result.Session_Overview.enabled, false, 'absent-from-set → disabled');
+  assert.equal(result.Organization_Get.enabled, false);
+});
+
+test('golden: {"default":"core"} expands from the preset registry', () => {
+  const result = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { default: 'core' },
+    { presets: { core: ['Session_Create', 'Session_Overview'] } },
+  );
+  assert.equal(result.Session_Create.enabled, true);
+  assert.equal(result.Session_Overview.enabled, true);
+  assert.equal(result.Organization_Get.enabled, false, 'outside the preset set → disabled');
+});
+
+test('golden: tools-map visible re-enables stored-disabled without a white-list', () => {
+  const config = { groups: { sessions: { tools: { Session_Create: { disabled: true } } } } };
+  const result = computeEffectiveTools(
+    config,
+    UNIVERSE,
+    { tools: { Session_Create: { visible: true } } },
+  );
+  assert.equal(result.Session_Create.enabled, true);
+  assert.equal(result.Session_Create.visible, true);
+  assert.equal(result.Session_Overview.enabled, true, 'unlisted tools keep the stored baseline');
+});
+
+test('white-list defines the enable set; absent-from-set is disabled', () => {
+  const result = computeEffectiveTools(NO_CONFIG, UNIVERSE, { "white-list": ['Session_Create'] });
+  assert.equal(result.Session_Create.enabled, true);
+  assert.equal(result.Session_Overview.enabled, false);
+  assert.equal(result.Organization_Get.enabled, false);
+});
+
+test('white-list re-enables a tool the stored config disabled', () => {
+  const config = { groups: { sessions: { tools: { Session_Create: { disabled: true } } } } };
+  const result = computeEffectiveTools(config, UNIVERSE, { "white-list": ['Session_Create'] });
+  assert.equal(result.Session_Create.enabled, true, 'param layer wins per key');
+});
+
+test('black-list without a white-list disables listed tools', () => {
+  const result = computeEffectiveTools(NO_CONFIG, UNIVERSE, { "black-list": ['Session_Overview'] });
+  assert.equal(result.Session_Overview.enabled, false);
+  assert.equal(result.Session_Create.enabled, true);
+});
+
+test('black-list beats default expansion but not an explicit white-list entry', () => {
+  const presets = { core: ['Session_Overview'] };
+  const blacked = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { default: 'core', "black-list": ['Session_Overview'] },
+    { presets },
+  );
+  assert.equal(blacked.Session_Overview.enabled, false);
+
+  const whitelisted = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { default: 'core', "black-list": ['Session_Overview'], "white-list": ['Session_Overview'] },
+    { presets },
+  );
+  assert.equal(whitelisted.Session_Overview.enabled, true);
+});
+
+test('white-list entry visible flags hide a tool without disabling it', () => {
+  const result = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { "white-list": [{ name: 'Session_Create', visible: false }] },
+  );
+  assert.equal(result.Session_Create.enabled, true);
+  assert.equal(result.Session_Create.visible, false);
+});
+
+test('tools map is dead when a white-list constrains', () => {
+  const result = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { "white-list": ['Session_Create'], tools: { Session_Overview: { visible: true } } },
+  );
+  assert.equal(result.Session_Overview.enabled, false, 'no re-enable under a white-list');
+  assert.equal(result.Session_Overview.visible, true);
+});
+
+test('default:true resolves the endpoint stored-config enabled set', () => {
+  const config = { groups: { sessions: { tools: { Session_Create: { disabled: true } } } } };
+  const result = computeEffectiveTools(config, UNIVERSE, { default: true });
+  assert.equal(result.Session_Create.enabled, false);
+  assert.equal(result.Session_Overview.enabled, true);
+  assert.equal(result.Organization_Get.enabled, true);
+});
+
+test('unknown names are dead entries — never added to the result', () => {
+  const result = computeEffectiveTools(
+    NO_CONFIG,
+    UNIVERSE,
+    { "white-list": ['Nonexistent_Tool'], "black-list": ['Also_Missing'] },
+  );
+  assert.equal(result.Nonexistent_Tool, undefined);
+  assert.equal(result.Also_Missing, undefined);
+  for (const entry of UNIVERSE) {
+    assert.equal(result[entry.name].enabled, false, 'white-list of a dead name still disables the set');
+  }
+});
+
+test('absent param returns the stored-config baseline (no-param behavior)', () => {
+  const config = {
+    groups: { sessions: { tools: { Session_Create: { disabled: true, hidden: true } } } },
+  };
+  const result = computeEffectiveTools(config, UNIVERSE, null);
+  assert.deepEqual(result.Session_Create, { enabled: false, visible: false });
+  assert.deepEqual(result.Session_Overview, { enabled: true, visible: true });
+  assert.deepEqual(result.Organization_Get, { enabled: true, visible: true });
+});
+
+test('catalog dotted names match canonical underscore config/param keys', () => {
+  const universe: ToolsetUniverseEntry[] = [{ group: 'sessions', name: 'Session.Create' }];
+  const config = { groups: { sessions: { tools: { Session_Create: { disabled: true } } } } };
+  const result = computeEffectiveTools(
+    config,
+    universe,
+    { tools: { Session_Create: { visible: true } } },
+  );
+  assert.deepEqual(result.Session_Create, { enabled: true, visible: true });
+});
+
+// ── universe bounding ────────────────────────────────────────────────────────
+
+test('universeFromCatalog bounds the param to included groups', () => {
+  const catalog = [
+    {
+      id: 'sessions',
+      label: 'Sessions',
+      desc: '',
+      tools: [{ name: 'Session_Create', category: '', description: '', parameters: [], hidden: false }],
+    },
+    {
+      id: 'orgs',
+      label: 'Organizations',
+      desc: '',
+      tools: [{ name: 'Organization_Get', category: '', description: '', parameters: [], hidden: true }],
+    },
+  ];
+  assert.deepEqual(
+    universeFromCatalog(catalog, { groups: { sessions: {} } }).map((entry) => entry.name),
+    ['Session_Create'],
+  );
+  assert.deepEqual(
+    universeFromCatalog(catalog, { groups: { sessions: { disabled: true } } }),
+    [],
+  );
+});
+
+// ── media refs / URL assembly ────────────────────────────────────────────────
+
+test('parseMediaRef: short_id → thumb/banner variants; http(s) passes through', () => {
+  assert.deepEqual(parseMediaRef(null), { thumb: null, banner: null });
+  assert.deepEqual(parseMediaRef(''), { thumb: null, banner: null });
+  assert.deepEqual(parseMediaRef('  '), { thumb: null, banner: null });
+  assert.deepEqual(parseMediaRef('abc123'), {
+    thumb: '/media/abc123?w=200&f=webp',
+    banner: '/media/abc123?w=1600&fit=cover',
+  });
+  assert.deepEqual(parseMediaRef('/media/abc123'), {
+    thumb: '/media/abc123?w=200&f=webp',
+    banner: '/media/abc123?w=1600&fit=cover',
+  });
+  const external = 'https://cdn.example.com/logo.png';
+  assert.deepEqual(parseMediaRef(external), { thumb: external, banner: external });
+  assert.equal(parseMediaRef('http://insecure.example/x.gif').banner, 'http://insecure.example/x.gif');
+});
+
+test('toolSelectionUrl appends ?t= (or &t= on existing queries) with a url-safe token', () => {
+  const url = toolSelectionUrl('https://tobor.locker/custom/tobor/mcp', {
+    "white-list": ['Session_Create'],
+  });
+  assert.match(url, /^https:\/\/tobor\.locker\/custom\/tobor\/mcp\?t=[A-Za-z0-9_-]+$/);
+  assert.match(toolSelectionUrl('https://tobor.locker/custom/tobor/mcp?org=1', {}), /[?&]t=[A-Za-z0-9_-]*$/);
+});


### PR DESCRIPTION
## Summary
- Restricted `core` endpoint variant (orgs/projects Overview+Get; sessions Create/Overview/Manifest) with `heal_core_variant` policy stamping and core/full presets
- Reserved `display` config key (image, emoji, color) with media presign/S3/register flow and `/media` transform serving (thumb w=200, banner w=1600 fit=cover)
- `UrlToolsetParam`: base64url `?t=` JSON with white-list > black-list > tools precedence, `default: true|named-preset`, bounded by included groups, snake_case alias normalization, 400 on invalid
- Frontend: `/app/mcp-setup` page (endpoint list, add wizard, connected clients), display fieldset in admin editor + wizard, admin toolset URL builder with live effective-tool preview
- Media register contract fix: frontend now sends the required `filename` field

## Test plan
- ExUnit named subsets: 124 passed (precedence matrix, core heal, display round-trips, gateway param e2e); `mix compile` exit 0
- Frontend: 95/95 contract tests pass; `tsc --noEmit` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)