### PR TITLE
feat: core variant attaches minimal NPL loader tools

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/custom.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/custom.ex
@@ -81,7 +81,10 @@ defmodule NoizuPromptLingua.MCP.Custom do
   end
 
   # NPL load/spec live on the root aggregator, not a selectable group. Include
-  # them on the default all-in-one package so one endpoint covers the daily set.
+  # them on the default all-in-one package and the restricted core variant (plus
+  # clones of either template) so one endpoint covers the daily set — core
+  # endpoints still need the loaders for NPL-syntax prompts even though their
+  # group surface is restricted.
   @npl_tools [
     {NoizuPromptLingua.Tools.NPLLoad, [category: "NPL"]},
     {NoizuPromptLingua.Tools.NPLSpec, [category: "NPL"]}
@@ -95,8 +98,10 @@ defmodule NoizuPromptLingua.MCP.Custom do
     with slug when is_binary(slug) <- scope_slug(ctx),
          scope when not is_nil(scope) <- MCPCustomScopes.get_by_slug(slug) do
       scope.kind == "all_in_one" or
+        scope.kind == "core_variant" or
         scope.slug == MCPCustomScopes.default_package_slug() or
         scope.source_template_slug == MCPCustomScopes.default_package_slug() or
+        scope.source_template_slug == MCPCustomScopes.core_variant_slug() or
         scope.name == MCPCustomScopes.account_default_name() or
         not is_nil(scope.user_id) or
         not is_nil(scope.organization_id)

--- a/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp_custom_scopes.ex
@@ -93,8 +93,8 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
   }
 
   # Global all-in-one package every account/org is cloned from. NPL load/spec
-  # tools are attached by MCP.Custom for all_in_one scopes and tobor clones
-  # (not a selectable group).
+  # tools are attached by MCP.Custom for all_in_one scopes, tobor clones, and
+  # core variants / core clones (not a selectable group).
   @default_package_slug "tobor"
   @account_default_name "Tobor Locker"
   @legacy_account_default_name "default-mcp"
@@ -123,6 +123,9 @@ defmodule NoizuPromptLingua.MCPCustomScopes do
 
   @doc "Slug of the global default package every account is offered."
   def default_package_slug, do: @default_package_slug
+
+  @doc "Slug of the global `core` core-variant template."
+  def core_variant_slug, do: @core_variant_slug
 
   # PRD-020 FR-1: built-in template slugs can never be claimed by new endpoints.
   @reserved_slugs [@default_package_slug, @core_variant_slug]

--- a/backend/test/noizu_prompt_lingua/mcp/custom_scope_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/custom_scope_test.exs
@@ -355,6 +355,96 @@ defmodule NoizuPromptLingua.MCP.CustomScopeTest do
     end
   end
 
+  # ── core endpoints carry the minimal NPL loader pair (root-plane, not a
+  #    selectable group) — restricted group surface stays restricted ──────────
+
+  describe "core variant NPL loaders" do
+    test "the core endpoint lists NPLLoad/NPLSpec" do
+      core = MCPCustomScopes.get_core_variant()
+      names = tool_specs(core.slug) |> Enum.map(& &1.definition.name)
+
+      assert "NPLLoad" in names
+      assert "NPLSpec" in names
+      # loaders ride along; the restricted group surface is unchanged
+      # (catalog-level names are dotted; Session_Manifest is underscore-native)
+      assert "Session.Create" in names
+      refute "Session.Archive" in names
+    end
+
+    test "clones of core keep the loaders (lineage, not kind)" do
+      _core = MCPCustomScopes.get_core_variant()
+
+      {:ok, clone} =
+        MCPCustomScopes.copy("core", %{"slug" => "core-npl-clone", "name" => "Clone"})
+
+      # copy/2 defaults kind to "custom" — the core lineage is what carries them
+      assert clone.kind == "custom"
+
+      names = tool_specs("core-npl-clone") |> Enum.map(& &1.definition.name)
+      assert "NPLLoad" in names
+      assert "NPLSpec" in names
+    end
+
+    test "tobor-lineage clones are unchanged: still list the loaders" do
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "tobor-npl-clone",
+          "name" => "Tobor Clone",
+          "source_template_slug" => MCPCustomScopes.default_package_slug(),
+          "config" => %{"groups" => %{"sessions" => %{}}}
+        })
+
+      names = tool_specs("tobor-npl-clone") |> Enum.map(& &1.definition.name)
+      assert "NPLLoad" in names
+      assert "NPLSpec" in names
+    end
+
+    test "plain custom scopes without core/tobor lineage do not list the loaders" do
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "npl-less",
+          "name" => "No Loaders",
+          "config" => %{"groups" => %{"sessions" => %{}}}
+        })
+
+      names = tool_specs("npl-less") |> Enum.map(& &1.definition.name)
+      refute "NPLLoad" in names
+      refute "NPLSpec" in names
+    end
+
+    test "NPLLoad dispatches on the core endpoint" do
+      _core = MCPCustomScopes.get_core_variant()
+
+      # success path returns a bare ToolResult (Dispatch convention)
+      result =
+        NoizuPromptLingua.MCP.Dispatch.call(
+          Custom,
+          "NPLLoad",
+          %{"expression" => "syntax"},
+          ctx(MCPCustomScopes.core_variant_slug())
+        )
+
+      assert %Noizu.MCP.Types.ToolResult{} = result
+      refute result.is_error
+
+      # and the same dispatch is refused on a scope without the loaders
+      {:ok, _} =
+        MCPCustomScopes.create(%{
+          "slug" => "npl-less-dispatch",
+          "name" => "No Loaders Dispatch",
+          "config" => %{"groups" => %{"sessions" => %{}}}
+        })
+
+      assert {:error, _} =
+               NoizuPromptLingua.MCP.Dispatch.call(
+                 Custom,
+                 "NPLLoad",
+                 %{"expression" => "syntax"},
+                 ctx("npl-less-dispatch")
+               )
+    end
+  end
+
   # ── alacarte WP2: core/full presets ──────────────────────────────────────────
 
   describe "core/full presets" do


### PR DESCRIPTION
Core-variant endpoints (`kind == "core_variant"`) and scopes cloned from the `core` template (`source_template_slug == "core"`) now receive the minimal NPL loader pair (`NPLLoad`, `NPLSpec`) through `MCP.Custom.catalog_specs/1` — the same root-plane attachment tobor/all_in_one uses. Listing and dispatch both resolve via `catalog_specs/1`, so one condition covers both. `heal_core_variant/1` and the restricted seed are untouched (loaders are outside the group universe); tobor/all_in_one behavior byte-identical; plain custom scopes without tobor/core lineage still get no loaders. Adds a public `MCPCustomScopes.core_variant_slug/0` accessor mirroring `default_package_slug/0`.

Test plan:
- `MIX_ENV=test mix test test/noizu_prompt_lingua/mcp/custom_scope_test.exs` — 24 passed (5 new: core lists loaders; core clone keeps them; tobor clone unchanged; plain scope excluded; NPLLoad dispatches on core, refused on lineage-less scope)
- `MIX_ENV=test mix test test/noizu_prompt_lingua/mcp/url_toolset_param_test.exs test/noizu_prompt_lingua/mcp/effective_toolset_test.exs` — 75 passed
- `MIX_ENV=test mix test test/noizu_prompt_lingua_web/controllers/custom_mcp_gateway_param_test.exs test/noizu_prompt_lingua/mcp/scope_packaging_test.exs` — 40 passed
- `mix compile` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)