### PR TITLE
feat(toolsets): built-in core profile

### DIFF
--- a/backend/lib/noizu_prompt_lingua/mcp/tool_sets.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/tool_sets.ex
@@ -90,9 +90,11 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
   @doc """
   Clone a profile slug or an existing set into a new, fully editable row.
 
-    * from a profile — `source: "clone"`, `source_profile` = the slug, and a
-      deep-copied allowlist config `%{"groups" => %{g => %{"enabled" => true}}}`
-      over the profile's expanded groups (FR-2A-7).
+    * from a profile — `source: "clone"`, `source_profile` = the slug, and the
+      profile's allowlist config (`Profiles.clone_config/1`) deep-copied over
+      its expanded groups (FR-2A-7) — group-grain for the capability profiles;
+      for `core`, per-tool `"enabled" => false` stamps outside its restricted
+      allowlist.
     * from a set — `source: "clone"` with the set's config deep-copied and
       provenance in `settings.cloned_from` (open question 4; `source_profile`
       stays nil).
@@ -109,10 +111,8 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
         {:error, :unknown_profile}
 
       profile ->
-        config = %{"groups" => Map.new(profile.groups, fn g -> {g, %{"enabled" => true}} end)}
-
         source
-        |> clone_attrs(attrs, config)
+        |> clone_attrs(attrs, Profiles.clone_config(source))
         |> Map.merge(%{
           "source" => "clone",
           "source_profile" => source,
@@ -316,7 +316,7 @@ defmodule NoizuPromptLingua.MCP.ToolSets do
       base: NoizuPromptLingua.MCP.UniverseToolset,
       title: Keyword.get(opts, :title),
       description: Keyword.get(opts, :description) || Map.get(settings, "instructions"),
-      immutable: false,
+      immutable: Keyword.get(opts, :immutable, false),
       include: universe.include,
       exclude: [],
       tools: override_map(config, universe.specs),

--- a/backend/lib/noizu_prompt_lingua/mcp/toolsets/profiles.ex
+++ b/backend/lib/noizu_prompt_lingua/mcp/toolsets/profiles.ex
@@ -1,6 +1,6 @@
 defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
   @moduledoc """
-  The 5 built-in capability profiles as pure DATA (PRD-N2 FR-2A-8, Decision 4).
+  The built-in capability profiles as pure DATA (PRD-N2 FR-2A-8, Decision 4).
 
   Profiles are VIRTUAL: never backed by `mcp_tool_sets` rows and never seeded —
   their slugs are reserved (see `NoizuPromptLingua.Schema.MCPToolSet`) so no set
@@ -10,6 +10,13 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
   below — membership is CODE, immutable, and a new domain group auto-joins the
   profiles listed in its annotation (a brand-new group id needs one
   `@profile_groups` entry).
+
+  `core` is the restricted starter surface: group-grain like the R1 four, but
+  the ONLY profile carrying a per-tool policy (`@profile_tool_policies`, a
+  mirror of the core-variant policy in `MCPCustomScopes`). Its slices and
+  clones keep just the essential Overview/Get/Create tools per group — every
+  other live catalog tool in its groups is stamped disabled (absent = enabled,
+  the preset-seeding rule).
 
   N2a ships profiles as DATA only. N2b (gated on lib PRD-3/PRD-4) adds
   `custom/1`, which turns a profile into an immutable
@@ -25,7 +32,7 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
   alias NoizuPromptLingua.MCP.ToolSets
   alias NoizuPromptLingua.MCPServers
 
-  @profile_slugs ~w(full agent-ops pm-dev content comms)
+  @profile_slugs ~w(full agent-ops pm-dev content comms core)
 
   @profile_meta %{
     "full" => %{
@@ -49,6 +56,11 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
     "comms" => %{
       label: "Communications",
       description: "Chat, notifications, pubsub, personas, memory and wiki tooling."
+    },
+    "core" => %{
+      label: "Core",
+      description:
+        "Restricted starter surface — organizations/projects Overview+Get, sessions Create+Overview. Clone to extend."
     }
   }
 
@@ -58,9 +70,9 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
   # or unknown profile slug FAILS COMPILATION (D4: compile-time checks where
   # config must not boot).
   @profile_groups %{
-    "organizations" => ["full", "agent-ops"],
-    "sessions" => ["full", "agent-ops", "pm-dev"],
-    "projects" => ["full", "agent-ops", "pm-dev"],
+    "organizations" => ["full", "agent-ops", "core"],
+    "sessions" => ["full", "agent-ops", "pm-dev", "core"],
+    "projects" => ["full", "agent-ops", "pm-dev", "core"],
     "notifications" => ["full", "agent-ops", "comms"],
     "memory" => ["full", "agent-ops", "comms"],
     "tickets" => ["full", "pm-dev"],
@@ -78,6 +90,22 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
     "chat" => ["full", "comms"],
     "pubsub" => ["full", "comms"],
     "personas" => ["full", "comms"]
+  }
+
+  # Per-group ENABLE allowlists for policy profiles. Group-grain profiles (the
+  # R1 four) resolve to EVERY catalog tool in their groups; a profile listed
+  # here keeps only the listed tools per group (canonical underscore names) —
+  # absent = enabled, so slices and clones stamp `enabled: false` on everything
+  # else (`clone_config/1` / `custom/1`). `core` mirrors the restricted
+  # core-variant policy in `MCPCustomScopes` (@core_variant_policy) with the
+  # W5 always-on Session_Manifest exemption folded into sessions, spelled out
+  # so the restricted surface is self-describing.
+  @profile_tool_policies %{
+    "core" => %{
+      "organizations" => ~w(Organization_Overview Organization_Get),
+      "projects" => ~w(Project_Overview Project_Get),
+      "sessions" => ~w(Session_Create Session_Overview Session_Manifest)
+    }
   }
 
   defp customizable_ids, do: MCPServers.customizable() |> Enum.map(& &1.id)
@@ -118,24 +146,48 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
     validate_registry!(@profile_groups, customizable_ids(), @profile_slugs)
   end
 
-  @doc "The 5 profile slugs, canonical order. Feeds the reserved-slug list in the MCPToolSet changeset."
+  @doc "The profile slugs, canonical order. Feeds the reserved-slug list in the MCPToolSet changeset."
   def slugs, do: @profile_slugs
 
   @doc """
-  Profile DATA for `slug`: `%{slug, label, description, groups}` with `groups`
-  the expanded MCP group-id list (`full` = `MCPServers.customizable()`). nil for
-  unknown slugs.
+  Profile DATA for `slug`: `%{slug, label, description, groups, tools}` with
+  `groups` the expanded MCP group-id list (`full` = `MCPServers.customizable()`)
+  and `tools` the per-group enabled allowlist when the profile carries one
+  (nil = group-grain: every catalog tool in `groups`). nil for unknown slugs.
   """
   def get(slug) when slug in @profile_slugs do
     %{slug: slug}
     |> Map.merge(Map.fetch!(@profile_meta, slug))
     |> Map.put(:groups, groups_for(slug))
+    |> Map.put(:tools, Map.get(@profile_tool_policies, slug))
   end
 
   def get(_), do: nil
 
-  @doc "All 5 profiles as DATA, canonical order."
+  @doc "All profiles as DATA, canonical order."
   def all, do: Enum.map(@profile_slugs, &get/1)
+
+  @doc """
+  The tool-set config a clone of `slug` starts from (FR-2A-7): every expanded
+  group `{"enabled" => true}`. For a policy profile (`core`) each policy group
+  also carries its allowlist as per-tool entries — essentials present with the
+  default (enabled) config, every other live catalog tool stamped
+  `{"enabled" => false}` (absent = enabled; canonical spellings fold their
+  dotted aliases). nil for unknown slugs.
+  """
+  def clone_config(slug) when slug in @profile_slugs do
+    profile = get(slug)
+
+    %{"groups" =>
+      Map.new(profile.groups, fn group_id ->
+        case Map.fetch(profile.tools || %{}, group_id) do
+          {:ok, essential} -> {group_id, allowlist_group(group_id, essential)}
+          :error -> {group_id, %{"enabled" => true}}
+        end
+      end)}
+  end
+
+  def clone_config(_), do: nil
 
   @doc """
   Expanded group ids for a profile slug: `full` = `MCPServers.customizable()`
@@ -151,6 +203,40 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
   end
 
   def groups_for(_), do: []
+
+  # Allowlist group config: walk the group's live catalog (Discovery excluded,
+  # canonical underscore spellings — the MCPCustomScopes seed vocabulary) and
+  # stamp `enabled: false` on every tool outside the essentials.
+  defp allowlist_group(group_id, essential) do
+    tools =
+      group_id
+      |> catalog_tool_names()
+      |> Map.new(fn name ->
+        if name in essential, do: {name, %{}}, else: {name, %{"enabled" => false}}
+      end)
+
+    %{"enabled" => true, "tools" => tools}
+  end
+
+  # Live catalog tool names for a group — canonical underscore, Discovery
+  # excluded (mirror of the core-variant seed walk in MCPCustomScopes).
+  defp catalog_tool_names(group_id) do
+    case MCPServers.server_module(group_id) do
+      module when is_atom(module) and not is_nil(module) ->
+        module.__mcp__(:tools)
+        |> Noizu.MCP.Server.Features.Tools.expand()
+        |> Enum.reject(&discovery_spec?/1)
+        |> Enum.map(&NoizuPromptLingua.MCP.ToolNames.canonical(&1.definition.name))
+        |> Enum.uniq()
+
+      _ ->
+        []
+    end
+  end
+
+  defp discovery_spec?(spec) do
+    ((spec.definition.meta && spec.definition.meta["category"]) || "Uncategorized") == "Discovery"
+  end
 
   @doc """
   Inverse of the annotation registry: group_id => [profile_slug], `full`
@@ -171,24 +257,40 @@ defmodule NoizuPromptLingua.MCP.Toolsets.Profiles do
   The profile as an IMMUTABLE, protocol-dispatchable `%Noizu.MCP.Toolset.Custom{}`
   (FR-2B-4): `slug: "profile:<slug>"`, base = the root aggregate
   (`UniverseToolset` — no single server module covers a profile's universe),
-  `include` = the expanded universe allowlist, `tools: %{}` (Decision 4:
-  slicing only — profiles carry NO override ops, so grant layers skip them
-  while the ACL layer still applies). Accepts the `get/1` DATA map or a slug.
+  `include` = the expanded universe allowlist. Group-grain profiles carry
+  `tools: %{}` (Decision 4: slicing only — profiles carry NO override ops, so
+  grant layers skip them while the ACL layer still applies); a policy profile
+  (`core`) assembles through `ToolSets.assemble_config_custom/2` so its
+  allowlist flattens into the static layer — non-essential group tools go
+  invisible + non-callable — while the immutability semantics stay intact.
+  Accepts the `get/1` DATA map or a slug.
   """
   def custom(slug) when slug in @profile_slugs do
     profile = get(slug)
 
-    %Custom{
-      slug: "profile:#{profile.slug}",
-      base: NoizuPromptLingua.MCP.UniverseToolset,
-      title: profile.label,
-      description: profile.description,
-      immutable: true,
-      include: ToolSets.universe_include(profile.groups),
-      exclude: [],
-      tools: %{},
-      metadata: %{profile: profile.slug}
-    }
+    case profile.tools do
+      nil ->
+        %Custom{
+          slug: "profile:#{profile.slug}",
+          base: NoizuPromptLingua.MCP.UniverseToolset,
+          title: profile.label,
+          description: profile.description,
+          immutable: true,
+          include: ToolSets.universe_include(profile.groups),
+          exclude: [],
+          tools: %{},
+          metadata: %{profile: profile.slug}
+        }
+
+      _policy ->
+        ToolSets.assemble_config_custom(clone_config(slug),
+          slug: "profile:#{profile.slug}",
+          title: profile.label,
+          description: profile.description,
+          immutable: true,
+          metadata: %{profile: profile.slug}
+        )
+    end
   end
 
   def custom(%{slug: slug}), do: custom(slug)

--- a/backend/lib/noizu_prompt_lingua/schema/mcp_tool_set.ex
+++ b/backend/lib/noizu_prompt_lingua/schema/mcp_tool_set.ex
@@ -11,7 +11,7 @@ defmodule NoizuPromptLingua.Schema.MCPToolSet do
     * group-set   — `group_id` set (an authz `groups` row id), `project_id` nil
 
   `(organization_id, slug)` is one org-wide namespace across all shapes (R4).
-  The 5 profile slugs (`Toolsets.Profiles.slugs/0`) plus `"root"` are reserved —
+  The profile slugs (`Toolsets.Profiles.slugs/0`) plus `"root"` are reserved —
   profiles are virtual and must never be shadowable by a row (FR-2A-9).
 
   `config` is validated STRUCTURALLY in N2a: unknown keys anywhere in the tree

--- a/backend/lib/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller.ex
+++ b/backend/lib/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller.ex
@@ -71,7 +71,7 @@ defmodule NoizuPromptLinguaWeb.ToolSetProfilesController do
   def show(conn, %{"org_id" => org_id, "slug" => slug}) do
     cond do
       profile = Profiles.get(slug) ->
-        profile_config = %{"groups" => Map.new(profile.groups, &{&1, %{"enabled" => true}})}
+        profile_config = Profiles.clone_config(slug)
 
         view =
           profile
@@ -482,7 +482,7 @@ defmodule NoizuPromptLinguaWeb.ToolSetProfilesController do
       description: profile.description,
       groups: profile.groups,
       group_count: length(profile.groups),
-      tool_count: profile.groups |> Enum.map(&Map.get(counts, &1, 0)) |> Enum.sum(),
+      tool_count: enabled_tool_count(profile, counts),
       cloneable: true,
       editable: false,
       is_profile: true,
@@ -490,21 +490,55 @@ defmodule NoizuPromptLinguaWeb.ToolSetProfilesController do
     }
   end
 
+  # Policy profiles (core) resolve to ONLY their allowlisted tools per group;
+  # group-grain profiles resolve to every catalog tool in their groups.
+  defp enabled_tool_count(%{tools: nil, groups: groups}, counts) do
+    groups |> Enum.map(&Map.get(counts, &1, 0)) |> Enum.sum()
+  end
+
+  defp enabled_tool_count(%{tools: policy}, _counts) when is_map(policy) do
+    policy |> Map.values() |> Enum.map(&length/1) |> Enum.sum()
+  end
+
   # Structural preview over the registry for a profile: what a clone would
   # start from. NOT an effective-catalog preview — that is N4b (D1).
   defp profile_preview(profile, counts) do
+    policy = Map.get(profile, :tools) || %{}
+
+    groups =
+      Map.new(profile.groups, fn group_id ->
+        case Map.fetch(policy, group_id) do
+          {:ok, essential} -> {group_id, allowlist_group_view(group_id, essential, counts)}
+          :error -> {group_id, full_group_view(group_id, counts)}
+        end
+      end)
+
     %{
-      groups:
-        Map.new(profile.groups, fn group_id ->
-          {group_id,
-           %{
-             enabled: true,
-             tool_count: Map.get(counts, group_id, 0),
-             overridden_tools: 0,
-             override_ops: 0
-           }}
-        end),
-      total_override_ops: 0
+      groups: groups,
+      total_override_ops: groups |> Map.values() |> Enum.map(& &1.override_ops) |> Enum.sum()
+    }
+  end
+
+  defp full_group_view(group_id, counts) do
+    %{
+      enabled: true,
+      tool_count: Map.get(counts, group_id, 0),
+      overridden_tools: 0,
+      override_ops: 0
+    }
+  end
+
+  # A policy group's clone starter: essentials enabled, the rest stamped
+  # `enabled: false` (⇒ :set_visible + :set_callable, 2 ops each).
+  defp allowlist_group_view(group_id, essential, counts) do
+    enabled = length(essential)
+    disabled = max(Map.get(counts, group_id, 0) - enabled, 0)
+
+    %{
+      enabled: true,
+      tool_count: enabled,
+      overridden_tools: disabled,
+      override_ops: disabled * 2
     }
   end
 

--- a/backend/test/noizu_prompt_lingua/mcp/tool_sets_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/tool_sets_test.exs
@@ -77,8 +77,8 @@ defmodule NoizuPromptLingua.MCP.ToolSetsTest do
       assert "can't be blank" in errors_on(changeset, :slug)
     end
 
-    test "rejects the 5 profile slugs and root as reserved", %{org_id: org_id} do
-      for slug <- ["full", "agent-ops", "pm-dev", "content", "comms", "root"] do
+    test "rejects the profile slugs and root as reserved", %{org_id: org_id} do
+      for slug <- ["full", "agent-ops", "pm-dev", "content", "comms", "core", "root"] do
         changeset = MCPToolSet.changeset(%MCPToolSet{}, base_attrs(org_id, slug: slug))
         refute changeset.valid?, "expected #{inspect(slug)} to be reserved"
         assert "is reserved" in errors_on(changeset, :slug)
@@ -470,6 +470,43 @@ defmodule NoizuPromptLingua.MCP.ToolSetsTest do
 
       {:ok, third} = ToolSets.clone("pm-dev", %{"organization_id" => org_id})
       assert third.slug == "pm-dev-copy-3"
+    end
+
+    test "from the core profile: restricted allowlist config, provenance, auto slug", %{
+      org_id: org_id
+    } do
+      {:ok, clone} = ToolSets.clone("core", %{"organization_id" => org_id})
+
+      assert clone.source == "clone"
+      assert clone.source_profile == "core"
+      assert clone.slug == "core-copy"
+
+      groups = clone.config["groups"]
+
+      assert MapSet.new(Map.keys(groups)) ==
+               MapSet.new(NoizuPromptLingua.MCP.Toolsets.Profiles.groups_for("core"))
+
+      # The restricted policy mirrors the core-variant seed: essentials keep
+      # the default (enabled) entry, every other live catalog tool in the
+      # group is stamped disabled.
+      policy = %{
+        "organizations" => ~w(Organization_Overview Organization_Get),
+        "projects" => ~w(Project_Overview Project_Get),
+        "sessions" => ~w(Session_Create Session_Overview Session_Manifest)
+      }
+
+      for {group_id, essential} <- policy do
+        group = groups[group_id]
+        assert group["enabled"] == true
+
+        for {name, cfg} <- group["tools"] do
+          if name in essential do
+            assert cfg == %{}, "expected #{name} enabled"
+          else
+            assert cfg == %{"enabled" => false}, "expected #{name} stamped disabled"
+          end
+        end
+      end
     end
 
     test "from a set: config deep-copied, provenance in settings.cloned_from, independent", %{

--- a/backend/test/noizu_prompt_lingua/mcp/toolset_provider_conformance_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/toolset_provider_conformance_test.exs
@@ -173,12 +173,19 @@ defmodule NoizuPromptLingua.MCP.ToolsetProviderConformanceTest do
   end
 
   describe "toolsets projections (PRD-5 §4.1 row 1)" do
-    test "get resolves the 5 virtual profiles as immutable records" do
+    test "get resolves the virtual profiles as immutable records" do
       for slug <- Profiles.slugs() do
         assert {:ok, %Custom{} = custom} = ToolsetProvider.get("toolsets", slug, [])
         assert custom.immutable == true
         assert custom.slug == "profile:#{slug}"
-        assert custom.tools == %{}
+
+        if slug == "core" do
+          # The policy profile carries its restricted allowlist as static ops.
+          refute custom.tools == %{}
+        else
+          # Group-grain profiles are slicing-only.
+          assert custom.tools == %{}
+        end
       end
     end
 

--- a/backend/test/noizu_prompt_lingua/mcp/toolsets/profiles_test.exs
+++ b/backend/test/noizu_prompt_lingua/mcp/toolsets/profiles_test.exs
@@ -1,9 +1,9 @@
 defmodule NoizuPromptLingua.MCP.Toolsets.ProfilesTest do
   @moduledoc """
-  N2a profiles-as-data matrix (PRD-N2 AC-2A-7): the 5 profile slugs, expanded
-  group lists vs. the MCPServers registry, annotation-registry inverse
-  consistency, and the compile-time registry validation (negative compile-check
-  via `Code.compile_string`).
+  N2a profiles-as-data matrix (PRD-N2 AC-2A-7): the built-in profile slugs,
+  expanded group lists vs. the MCPServers registry, annotation-registry inverse
+  consistency, the core restricted per-tool policy, and the compile-time
+  registry validation (negative compile-check via `Code.compile_string`).
 
   No DB — the registry is pure code (Decision 4).
   """
@@ -24,8 +24,8 @@ defmodule NoizuPromptLingua.MCP.Toolsets.ProfilesTest do
   }
 
   describe "slugs" do
-    test "the 5 canonical slugs in order" do
-      assert Profiles.slugs() == ["full", "agent-ops", "pm-dev", "content", "comms"]
+    test "the canonical slugs in order" do
+      assert Profiles.slugs() == ["full", "agent-ops", "pm-dev", "content", "comms", "core"]
     end
 
     test "get/1 returns DATA for each slug and nil for unknown" do
@@ -75,6 +75,86 @@ defmodule NoizuPromptLingua.MCP.Toolsets.ProfilesTest do
 
       for slug <- @r1 |> Map.keys() do
         refute "browser" in Profiles.groups_for(slug)
+      end
+    end
+  end
+
+  describe "core policy profile (restricted starter surface)" do
+    @core_policy %{
+      "organizations" => ~w(Organization_Overview Organization_Get),
+      "projects" => ~w(Project_Overview Project_Get),
+      "sessions" => ~w(Session_Create Session_Overview Session_Manifest)
+    }
+
+    test "core is a reserved slug expanding to exactly the three restricted groups" do
+      assert "core" in Profiles.slugs()
+      assert Enum.sort(Profiles.groups_for("core")) == ~w(organizations projects sessions)
+
+      # Member of `full`'s universe, and every group resolves in the registry
+      # (the shared slugs-loop assertion covers this too — kept local for the
+      # failure message).
+      for group_id <- Profiles.groups_for("core") do
+        assert group_id in @customizable_ids
+        assert "core" in Profiles.groups_for_tool(group_id)
+      end
+    end
+
+    test "core carries the 7-tool allowlist; every other profile is group-grain" do
+      assert Profiles.get("core").tools == @core_policy
+      assert @core_policy |> Map.values() |> Enum.map(&length/1) |> Enum.sum() == 7
+
+      for slug <- Profiles.slugs() -- ["core"] do
+        assert Profiles.get(slug).tools == nil, "unexpected per-tool policy on #{slug}"
+      end
+    end
+
+    test "core clone_config stamps disabled on non-essential catalog tools" do
+      config = Profiles.clone_config("core")
+
+      assert MapSet.new(Map.keys(config["groups"])) ==
+               MapSet.new(~w(organizations projects sessions))
+
+      for {group_id, essential} <- @core_policy do
+        group = config["groups"][group_id]
+        assert group["enabled"] == true
+        assert is_map(group["tools"]) and map_size(group["tools"]) > 0
+
+        for {name, cfg} <- group["tools"] do
+          if name in essential do
+            assert cfg == %{}, "expected #{name} enabled (default entry)"
+          else
+            assert cfg == %{"enabled" => false}, "expected #{name} stamped disabled"
+          end
+        end
+
+        for name <- essential do
+          assert Map.has_key?(group["tools"], name),
+                 "#{name} missing from #{group_id}'s live catalog walk"
+        end
+      end
+    end
+
+    test "group-grain clone_config stays group-grain (no per-tool stamps)" do
+      config = Profiles.clone_config("pm-dev")
+      assert MapSet.new(Map.keys(config["groups"])) == MapSet.new(Profiles.groups_for("pm-dev"))
+      assert Enum.all?(Map.values(config["groups"]), &(&1 == %{"enabled" => true}))
+    end
+
+    test "core custom/1 is immutable and carries the allowlist as static ops" do
+      custom = Profiles.custom("core")
+      assert custom.immutable
+      assert custom.slug == "profile:core"
+
+      essentials = List.flatten(Map.values(@core_policy))
+
+      refute custom.tools == %{}
+
+      for {name, ops} <- custom.tools do
+        canonical = NoizuPromptLingua.MCP.ToolNames.canonical(name)
+        refute canonical in essentials, "essential #{name} must not carry override ops"
+
+        assert Enum.sort(Enum.map(ops, & &1.op)) == [:set_callable, :set_visible]
+        assert Enum.all?(ops, &(&1.value == false))
       end
     end
   end

--- a/backend/test/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller_test.exs
+++ b/backend/test/noizu_prompt_lingua_web/controllers/tool_set_profiles_controller_test.exs
@@ -68,15 +68,15 @@ defmodule NoizuPromptLinguaWeb.ToolSetProfilesControllerTest do
   # ---- AC-N4-2: index composition ----
 
   describe "index" do
-    test "lists the 5 built-in profiles from DATA, read-only + cloneable", %{
+    test "lists the built-in profiles from DATA, read-only + cloneable", %{
       conn: conn,
       base: base
     } do
       %{"profiles" => profiles} = conn |> get(base) |> json_response(200)
 
-      assert length(profiles) == 5
+      assert length(profiles) == 6
       slugs = Enum.map(profiles, & &1["slug"])
-      assert slugs == ~w(full agent-ops pm-dev content comms)
+      assert slugs == ~w(full agent-ops pm-dev content comms core)
 
       full = Enum.find(profiles, &(&1["slug"] == "full"))
       assert full["cloneable"] == true
@@ -85,6 +85,11 @@ defmodule NoizuPromptLinguaWeb.ToolSetProfilesControllerTest do
       assert full["group_count"] == 21
       assert length(full["groups"]) == 21
       assert full["tool_count"] > 0
+
+      # The restricted policy profile: 3 groups, only its 7 essential tools.
+      core = Enum.find(profiles, &(&1["slug"] == "core"))
+      assert core["group_count"] == 3
+      assert core["tool_count"] == 7
     end
 
     test "lists org sets with shape and live member_count for group sets", %{
@@ -244,6 +249,18 @@ defmodule NoizuPromptLinguaWeb.ToolSetProfilesControllerTest do
       assert profile["is_profile"] == true
       assert profile["group_count"] == 21
       assert profile["preview"]["groups"]["tickets"]["overridden_tools"] == 0
+
+      # The policy profile previews its restricted clone starter: only the
+      # essentials enabled per group, the rest stamped disabled.
+      %{"profile" => core} = conn |> get("#{base}/core") |> json_response(200)
+
+      assert core["group_count"] == 3
+      assert core["tool_count"] == 7
+
+      orgs = core["preview"]["groups"]["organizations"]
+      assert orgs["tool_count"] == 2
+      assert orgs["overridden_tools"] > 0
+      assert orgs["override_ops"] == orgs["overridden_tools"] * 2
     end
 
     test "unknown slug -> 404", %{conn: conn, base: base} do


### PR DESCRIPTION
Adds a built-in `core` profile to the Tool Sets profiles: 3 groups (organizations, projects, sessions) carrying the restricted per-tool policy (Overview+Get / Create+Overview+Manifest), mirroring the core custom-endpoint variant.

- Slug reserved via `Profiles.slugs()`; virtual + read-only like the other profiles; cloneable.
- `Profiles.clone_config/1` stamps `enabled: false` on non-essential catalog tools (absent = enabled, preset-seeding rule) so clones and the serving slice match the restricted surface.
- `Profiles.custom/1` assembles the core slice through `ToolSets.assemble_config_custom/2` (new `:immutable` opt) — non-essential group tools go invisible + non-callable; immutability semantics unchanged.
- Admin badges/preview reflect the restricted counts (3 groups / 7 tools).

Tests: profiles, tool-sets (incl. core clone), custom-scope, provider conformance, controller suites green (190 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)