### PR TITLE
Merge develop into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ frontend/cypress/screenshots/
 # Canonical worktree placement
 .claude/worktrees/
 backend/_build
+
+# Local agent/release scratch
+.tmp/
+.coverage
+.sp_files.txt


### PR DESCRIPTION
Release merge of `develop` into `main` (regular merge commit, not squash).

Includes helm-tag reconcile from main plus:
- chore: ignore local release scratch and coverage files