### PR TITLE
fix(keyboard): normalize category-registry shape; no-store headers for /keyboard

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,17 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // /keyboard uses server actions; stale prerendered HTML (s-maxage=1y) from
+  // old tabs posts dead action IDs after redeploys ("Failed to find Server
+  // Action"). Serve it uncacheable.
+  async headers() {
+    return [
+      {
+        source: "/keyboard",
+        headers: [{ key: "Cache-Control", value: "no-store, must-revalidate" }],
+      },
+    ];
+  },
   // Pin tracing/turbopack to this package. Building from the monorepo
   // otherwise infers /Users/.../Noizu as the workspace root (multiple lockfiles).
   outputFileTracingRoot: frontendRoot,

--- a/frontend/src/lib/api/prompt-builder.ts
+++ b/frontend/src/lib/api/prompt-builder.ts
@@ -136,7 +136,8 @@ export async function fetchCategories(): Promise<CategoryDef[]> {
   const res = await fetch("/npl-keyboard/category-registry.json");
   if (!res.ok) return [];
   const data = await res.json();
-  return Array.isArray(data) ? data : (data.categories ?? []);
+  const raw = Array.isArray(data) ? data : (data.categories ?? []);
+  return Array.isArray(raw) ? raw : Object.values(raw);
 }
 
 export async function fetchUnicodeDb(): Promise<CatalogEntry[]> {


### PR DESCRIPTION
Two bugs on https://promptlingo.dev/keyboard:

1. **Live crash for every visitor** — `fetchCategories()` returned `data.categories` verbatim, but `/npl-keyboard/category-registry.json` stores `categories` as an **object** keyed by category id. The resulting non-array hit `.map()` in `/keyboard`'s `categoryNames` useMemo → `TypeError: u.map is not a function` → Next error boundary. Fix: normalize object-shaped `categories` to an array via `Object.values` (array and legacy top-level-array shapes still work).

2. **Stale-tab breakage after every redeploy** — `/keyboard` was served with the Next prerender default `s-maxage=31536000`. Old tabs held year-cacheable HTML and POSTed server actions with dead deployment IDs → "Failed to find Server Action" (observed in frontend container logs). Fix: `headers()` override serving `/keyboard` with `Cache-Control: no-store, must-revalidate`.

Verification: `npm run test:contracts` (100/100 pass, includes prompt-builder.test.ts), `npx tsc --noEmit` clean.

Co-Authored-By: Loom <loom@therobotlives.com>