### PR TITLE
Release: web keyboard crash fix + /keyboard no-store headers

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,17 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  // /keyboard uses server actions; stale prerendered HTML (s-maxage=1y) from
+  // old tabs posts dead action IDs after redeploys ("Failed to find Server
+  // Action"). Serve it uncacheable.
+  async headers() {
+    return [
+      {
+        source: "/keyboard",
+        headers: [{ key: "Cache-Control", value: "no-store, must-revalidate" }],
+      },
+    ];
+  },
   // Pin tracing/turbopack to this package. Building from the monorepo
   // otherwise infers /Users/.../Noizu as the workspace root (multiple lockfiles).
   outputFileTracingRoot: frontendRoot,

--- a/frontend/src/lib/api/prompt-builder.ts
+++ b/frontend/src/lib/api/prompt-builder.ts
@@ -136,7 +136,8 @@ export async function fetchCategories(): Promise<CategoryDef[]> {
   const res = await fetch("/npl-keyboard/category-registry.json");
   if (!res.ok) return [];
   const data = await res.json();
-  return Array.isArray(data) ? data : (data.categories ?? []);
+  const raw = Array.isArray(data) ? data : (data.categories ?? []);
+  return Array.isArray(raw) ? raw : Object.values(raw);
 }
 
 export async function fetchUnicodeDb(): Promise<CatalogEntry[]> {


### PR DESCRIPTION
Release merge of develop into main (regular merge commit per release policy). Carries PR #68: normalize category-registry object shape in fetchCategories (fixes TypeError crashing promptlingo.dev/keyboard for all visitors) + no-store cache headers for /keyboard (prevents stale server-action errors after redeploys).

Co-Authored-By: Loom <loom@therobotlives.com>