### PR TITLE
fix(keyboard): layer design-system CSS below utilities; re-assert Tailwind radius tokens

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,5 +1,6 @@
+@layer theme, base, components, design-system, utilities;
 @import "tailwindcss";
-@import "./design-system.generated.css";
+@import "./design-system.generated.css" layer(design-system);
 
 /* Scan styleguide package components for Tailwind utility classes */
 @source "../../node_modules/@noizu/styleguide/dist/engine-src";
@@ -59,6 +60,17 @@ html[data-design-theme="style-guide"] {
   --size-action: 40px;
   --size-icon-sm: 18px;
   --size-dot: 6px;
+}
+
+/* Re-assert Tailwind v4 default radius tokens: the generated design-system theme
+   hijacks this namespace with %-based values (blob bug on raw-Tailwind pages).
+   Unlayered + later = wins the custom-property cascade over layer(design-system). */
+html[data-design-theme="style-guide"] {
+  --radius-none: 0;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
 }
 
 /* Shared shell dimensions and state timing. */


### PR DESCRIPTION
## Summary
- The generated design-system CSS (`design-system.generated.css`) was imported **unlayered** after Tailwind v4. Its `html[data-design-theme="style-guide"]` block redefines the Tailwind radius token namespace with percentage values (`--radius-lg: 25%`, `--radius-xl: 50%`, `--radius-md: var(--space-1-mid)`), so any `rounded-*` utility resolved to those values — cards on `/keyboard` rendered as giant percentage-radius blobs. Its unlayered universal reset (`* { margin:0; padding:0 }`) also defeated all layered Tailwind spacing utilities (tabs overlapping headings, collapsed rhythm).
- Declare explicit layer order (`theme, base, components, design-system, utilities`) before the imports and pull the generated file into `layer(design-system)`, so Tailwind utilities win the cascade.
- Re-assert the Tailwind v4 default radius tokens (`--radius-none/sm/md/lg/xl`) on `html[data-design-theme="style-guide"]` in an unlayered, later rule — unlayered declarations win the custom-property cascade over layered ones, so raw-Tailwind pages get the intended rem-based radii even though the design-system layer still hijacks the names.

## Verification
- `npm run generate-css && npx next build --webpack` — build succeeds (turbopack build cannot follow the symlinked worktree `node_modules`; webpack fallback used, expected per repo gotcha).
- Compiled route CSS contains `@layer design-system` wrapping the generated tokens, and an unlayered rule setting `--radius-lg:.5rem` (`--radius-sm:.25rem`, `--radius-md:.375rem`, `--radius-xl:.75rem`, `--radius-none:0`).

Co-Authored-By: Loom <loom@therobotlives.com>